### PR TITLE
Fix VNC packet parsing

### DIFF
--- a/src/dissectors/ec_vnc.c
+++ b/src/dissectors/ec_vnc.c
@@ -31,6 +31,7 @@ struct vnc_status {
    u_char status;
    u_char challenge[16];
    u_char response[16];
+   u_char banner[16];
 };
 
 #define WAIT_AUTH       1
@@ -49,6 +50,18 @@ FUNC_DECODER(dissector_vnc);
 void vnc_init(void);
 
 /************************************************/
+
+static char itoa16[16] =  "0123456789abcdef";
+
+static inline void hex_encode(unsigned char *str, int len, unsigned char *out)
+{
+   int i;
+   for (i = 0; i < len; ++i) {
+      out[0] = itoa16[str[i]>>4];
+      out[1] = itoa16[str[i]&0xF];
+      out += 2;
+   }
+}
 
 /*
  * this function is the initializer.
@@ -70,7 +83,7 @@ FUNC_DECODER(dissector_vnc)
    void *ident = NULL;
    char tmp[MAX_ASCII_ADDR_LEN];
    struct vnc_status *conn_status;
-   
+
    /* Packets coming from the server */
    if (FROM_SERVER("vnc", PACKET)) {
 
@@ -79,99 +92,115 @@ FUNC_DECODER(dissector_vnc)
          return NULL;
 
       dissect_create_ident(&ident, PACKET, DISSECT_CODE(dissector_vnc));
-   
+
       /* if the session does not exist... */
       if (session_get(&s, ident, DISSECT_IDENT_LEN) == -ENOTFOUND) {
-        
+
          /* This is the first packet from the server (protocol version) */
          if (!strncmp(ptr, "RFB ", 4)) {
 
             DEBUG_MSG("\tdissector_vnc BANNER");
-    
-            /* Catch the banner that is like "RFB xxx.yyy" */   
+
+            /* Catch the banner that is like "RFB xxx.yyy" */
             PACKET->DISSECTOR.banner = strdup(ptr);
-    
             /* remove the \n */
             if ( (ptr = strchr(PACKET->DISSECTOR.banner, '\n')) != NULL )
                *ptr = '\0';
-       
+
             /* create the new session */
             dissect_create_session(&s, PACKET, DISSECT_CODE(dissector_vnc));
-       
+
             /* remember the state (used later) */
             SAFE_CALLOC(s->data, 1, sizeof(struct vnc_status));
-                  
+
             conn_status = (struct vnc_status *) s->data;
             conn_status->status = WAIT_AUTH;
+            strncpy(conn_status->banner, PACKET->DISSECTOR.banner, 16);
 
             /* save the session */
             session_put(s);
-    
          }
       } else { /* The session exists */
-      
+
          conn_status = (struct vnc_status *) s->data;
-         
+
          /* If we are waiting for auth scheme by the server */
          if (conn_status->status == WAIT_AUTH) {
-    
-            /* Authentication scheme requested by the server: 
+
+            /* Authentication scheme requested by the server:
              *  0 - Connection Failed
              *  1 - No Authentication
              *  2 - VNC Authentication
              */
-   
+
             DEBUG_MSG("\tDissector_vnc AUTH");
 
             /* No authentication required!!! */
             if (!memcmp(ptr, "\x00\x00\x00\x01", 4)) {
-               
-               /* 
-                * Free authentication will be notified on 
-                * next client's packet 
-                */
-               conn_status->status = NO_AUTH;   
-          
-            } else if (!memcmp(ptr, "\x00\x00\x00\x00", 4)) { /* Connection Failed */
 
-               /*...so destroy the session*/ 
-               dissect_wipe_session(PACKET, DISSECT_CODE(dissector_vnc));
-               SAFE_FREE(ident);
-               return NULL;
-         
+               /*
+                * Free authentication will be notified on
+                * next client's packet
+                */
+               if(!strstr(conn_status->banner, "008")) { /* TightVNC hack */
+                    conn_status->status = NO_AUTH;
+               }
+            } else if (!memcmp(ptr, "\x00\x00\x00\x00", 4)) { /* Connection Failed */
+               if(!strstr(conn_status->banner, "008")) { /* TightVNC hack */
+                  /*...so destroy the session*/
+                  dissect_wipe_session(PACKET, DISSECT_CODE(dissector_vnc));
+                  SAFE_FREE(ident);
+                  return NULL;
+               }
+
             } else if (!memcmp(ptr, "\x00\x00\x00\x02", 4)) { /* VNC Auth required */
-              
                /* Skip Authentication type code (if the challenge is in the same packet) */
                ptr+=4;
-          
+
                /* ...and waits for the challenge */
-               conn_status->status = WAIT_CHALLENGE;   
+               conn_status->status = WAIT_CHALLENGE;
             }
-         } 
+            else { /* search for challenge packet */
+               unsigned char buf[17];
+               if(PACKET->DATA.len >= 16) {
+                  memcpy(buf, ptr, 16);
+                  buf[16] = 0;
+                  if(!strstr(buf, "VNCAUTH_") && PACKET->DATA.len == 16) {
+                     /* Saves the server challenge (16byte) in the session data */
+                     conn_status->status = WAIT_RESPONSE;
+                     memcpy(conn_status->challenge, ptr, 16);
+                  }
+               }
+            }
+         }
 
-         /* We are waiting for the server challenge */    
+         /* We are waiting for the server challenge */
          if ((conn_status->status == WAIT_CHALLENGE) && (ptr < end)) {
-       
-            DEBUG_MSG("\tDissector_vnc CHALLENGE");
-
-            /* Saves the server challenge (16byte) in the session data */
-            conn_status->status = WAIT_RESPONSE;
-            memcpy(conn_status->challenge, ptr, 16);
-       
+            unsigned char buf[17];
+            if(PACKET->DATA.len >= 16) {
+               memcpy(buf, ptr, 16);
+               buf[16] = 0;
+               /* Saves the server challenge (16byte) in the session data */
+               if(!strstr(buf, "VNCAUTH_") && PACKET->DATA.len == 16) {
+                  DEBUG_MSG("\tDissector_vnc CHALLENGE");
+                  conn_status->status = WAIT_RESPONSE;
+                  memcpy(conn_status->challenge, ptr, 16);
+               }
+            }
          } else if (conn_status->status == WAIT_RESULT) { /* We are waiting for login result */
-       
+
             /* Login Result
              *  0 - Ok
              *  1 - Failed
-             *  2 - Too many attempts 
+             *  2 - Too many attempts
              */
             DEBUG_MSG("\tDissector_vnc RESULT");
 
-            if (!memcmp(ptr, "\x00\x00\x00\x00", 4)) 
+            if (!memcmp(ptr, "\x00\x00\x00\x00", 4))
                conn_status->status = LOGIN_OK;
-            else if (!memcmp(ptr, "\x00\x00\x00\x01", 4)) 
+            else if (!memcmp(ptr, "\x00\x00\x00\x01", 4))
                conn_status->status = LOGIN_FAILED;
-            else if (!memcmp(ptr, "\x00\x00\x00\x02", 4))          
+            else if (!memcmp(ptr, "\x00\x00\x00\x02", 4))
                conn_status->status = LOGIN_TOOMANY;
          }
       }
@@ -182,7 +211,7 @@ FUNC_DECODER(dissector_vnc)
       /* Only if we catched the connection from the beginning */
       if (session_get(&s, ident, DISSECT_IDENT_LEN) == ESUCCESS) {
 
-         /* We have to catch even ACKs to dump 
+         /* We have to catch even ACKs to dump
             LOGIN FAILURE information on a client's packet */
          conn_status = (struct vnc_status *) s->data;
 
@@ -198,57 +227,62 @@ FUNC_DECODER(dissector_vnc)
                                                                     ntohs(PACKET->L4.dst));
             dissect_wipe_session(PACKET, DISSECT_CODE(dissector_vnc));
          } else    /* If we have catched server result */
-            
+
             if (conn_status->status >= LOGIN_OK) {
                u_char *str_ptr, index;
-                   
+
                DEBUG_MSG("\tDissector_vnc DUMP ENCRYPTED");
 
                PACKET->DISSECTOR.user = strdup("VNC");
                SAFE_CALLOC(PACKET->DISSECTOR.pass, 256, sizeof(char));
-            
+
                /* Dump Challenge and Response */
                snprintf(PACKET->DISSECTOR.pass, 10, "Challenge:");
                str_ptr = PACKET->DISSECTOR.pass + strlen(PACKET->DISSECTOR.pass);
-            
+
                for (index = 0; index < 16; index++)
                   snprintf(str_ptr + (index * 2), 3, "%.2x", conn_status->challenge[index]);
-            
+
                strcat(str_ptr, " Response:");
                str_ptr = PACKET->DISSECTOR.pass + strlen(PACKET->DISSECTOR.pass);
-            
+
                for (index = 0; index < 16; index++)
                   snprintf(str_ptr + (index * 2), 3, "%.2x", conn_status->response[index]);
-       
+
                if (conn_status->status > LOGIN_OK) {
                   PACKET->DISSECTOR.failed = 1;
                   DISSECT_MSG("VNC : %s:%d -> %s (Login Failed)\n", ip_addr_ntoa(&PACKET->L3.dst, tmp),
-                                                                 ntohs(PACKET->L4.dst), 
+                                                                 ntohs(PACKET->L4.dst),
                                                                  PACKET->DISSECTOR.pass);
-
                } else {
                   DISSECT_MSG("VNC : %s:%d -> %s\n", ip_addr_ntoa(&PACKET->L3.dst, tmp),
-                                                  ntohs(PACKET->L4.dst), 
+                                                  ntohs(PACKET->L4.dst),
                                                   PACKET->DISSECTOR.pass);
                }
-            
+
                dissect_wipe_session(PACKET, DISSECT_CODE(dissector_vnc));
          } else { /* If we are waiting for client response (don't care ACKs) */
             if (conn_status->status == WAIT_RESPONSE && PACKET->DATA.len >= 16) {
-
+               unsigned char challenge[33];
+               unsigned char response[33];
+               hex_encode(conn_status->challenge, 16, challenge);
+               challenge[32] = 0;
+               hex_encode(ptr, 16, response);
+               response[32] = 0;
                DEBUG_MSG("\tDissector_vnc RESPONSE");
-
                /* Saves the client response (16byte) in the session data */
                conn_status->status = WAIT_RESULT;
                memcpy(conn_status->response, ptr, 16);
+               /* even possibly wrong passwords can be useful */
+               DISSECT_MSG("%s-%d:$vnc$*%s*%s\n", ip_addr_ntoa(&PACKET->L3.dst, tmp), ntohs(PACKET->L4.dst), challenge, response);
             }
          }
       }
-   }        
-   
+   }
+
    SAFE_FREE(ident);
    return NULL;
-}      
+}
 
 /* EOF */
 


### PR DESCRIPTION
VNC dissector was broken for http://openwall.info/wiki/_media/john/vnc-pcaps.zip and http://openwall.info/wiki/_media/john/RealVNC-RFB-3.3-client.zip

This patches fixes VNC packet parsing. There are some whitespace fixes as well.
