### PR TITLE
Fixed GTK MITM to use snprintf to avoid stack smashing. Modified DHCP an...

### DIFF
--- a/src/interfaces/gtk/ec_gtk_mitm.c
+++ b/src/interfaces/gtk/ec_gtk_mitm.c
@@ -177,12 +177,10 @@ void gtkui_icmp_redir(void)
    response = gtk_dialog_run(GTK_DIALOG(dialog));
    if(response == GTK_RESPONSE_OK) {
       gtk_widget_hide(dialog);
+      memset(params, '\0', PARAMS_LEN);
 
-      snprintf(params, 6, "icmp:");
-
-      strncat(params, gtk_entry_get_text(GTK_ENTRY(entry1)), ETH_ASCII_ADDR_LEN);
-      strncat(params, "/", 1);
-      strncat(params, gtk_entry_get_text(GTK_ENTRY(entry2)), IP6_ASCII_ADDR_LEN);
+      snprintf(params, PARAMS_LEN-1, "icmp:%s/%s",  gtk_entry_get_text(GTK_ENTRY(entry1)),
+                       gtk_entry_get_text(GTK_ENTRY(entry2)));
 
       gtkui_start_mitm();
    }
@@ -329,16 +327,12 @@ void gtkui_dhcp_spoofing(void)
    response = gtk_dialog_run(GTK_DIALOG(dialog));
    if(response == GTK_RESPONSE_OK) {
       gtk_widget_hide(dialog);
+      memset(params, '\0', PARAMS_LEN);
 
-      snprintf(params, 6, "dhcp:");
-      
+      snprintf(params, PARAMS_LEN-1, "dhcp:%s/%s/%s", gtk_entry_get_text(GTK_ENTRY(entry1)),
+                       gtk_entry_get_text(GTK_ENTRY(entry2)), gtk_entry_get_text(GTK_ENTRY(entry3)));
 
-      strncat(params, gtk_entry_get_text(GTK_ENTRY(entry1)), PARAMS_LEN);
-      strncat(params, "/", PARAMS_LEN);
-      strncat(params, gtk_entry_get_text(GTK_ENTRY(entry2)), PARAMS_LEN);
-      strncat(params, "/", PARAMS_LEN);
-      strncat(params, gtk_entry_get_text(GTK_ENTRY(entry3)), PARAMS_LEN);
-
+      DEBUG_MSG("ec_gtk_dhcp: DHCP MITM %s", params);
       gtkui_start_mitm();
    }
 

--- a/src/mitm/ec_dhcp_spoofing.c
+++ b/src/mitm/ec_dhcp_spoofing.c
@@ -93,10 +93,10 @@ static int dhcp_spoofing_start(char *args)
    for (p = strsep(&args, "/"); p != NULL; p = strsep(&args, "/")) {
       /* first parameter (the ip_pool) */
       if (i == 1) {
-         char tmp[strlen(p)+3];
+         char tmp[strlen(p)+4];
 
          /* add the / to be able to use the target parsing function */
-         snprintf(tmp, strlen(p)+3, "/%s/", p);
+         snprintf(tmp, strlen(p)+4, "/%s//", p);
 
          if (compile_target(tmp, &dhcp_ip_pool) != ESUCCESS)
             break;

--- a/src/mitm/ec_icmp_redirect.c
+++ b/src/mitm/ec_icmp_redirect.c
@@ -72,10 +72,10 @@ static int icmp_redirect_start(char *args)
    if (!strcmp(args, "")) {
       SEMIFATAL_ERROR("ICMP redirect needs a parameter.\n");
    } else {
-      char tmp[strlen(args)+2];
+      char tmp[strlen(args)+3];
 
       /* add the / to be able to use the target parsing function */
-      snprintf(tmp, strlen(args)+2, "%s/", args);
+      snprintf(tmp, strlen(args)+3, "%s//", args);
       
       if (compile_target(tmp, &redirected_gw) != ESUCCESS)
          SEMIFATAL_ERROR("Wrong target parameter");


### PR DESCRIPTION
...d ICMP GTK MITM to allow targets to use new target format (additional /). TODO: Need to change the targets in case IPv6 addresses are used.
