### PR TITLE
Add fields used by DocuWiki

### DIFF
--- a/share/etter.fields
+++ b/share/etter.fields
@@ -45,6 +45,7 @@ login_username
 login_email
 uin
 sign-in
+u
 
 
 
@@ -62,3 +63,4 @@ login_password
 passwort
 passwrd
 upasswd
+p


### PR DESCRIPTION
Add fields used by DocuWiki.

I found them while testing Ettercap on http://openwall.info/wiki/welcome?do=login
