### PR TITLE
Fix building with Clang.

### DIFF
--- a/src/dissectors/ec_mongodb.c
+++ b/src/dissectors/ec_mongodb.c
@@ -99,7 +99,7 @@ FUNC_DECODER(dissector_mongodb)
               if (session_get(&s, ident, DISSECT_IDENT_LEN) == ESUCCESS) {
                       conn_status = (struct mongodb_status *) s->data;
                       if (PACKET->DATA.len < 16)
-                              return;
+                              return NULL;
                       unsigned char *res = memmem(ptr, PACKET->DATA.len, "fails", 5);
                       unsigned char *gres = memmem(ptr, PACKET->DATA.len, "readOnly", 8);
                       if (conn_status->status == WAIT_RESULT && res) {
@@ -118,7 +118,7 @@ FUNC_DECODER(dissector_mongodb)
       if (session_get(&s, ident, DISSECT_IDENT_LEN) == ESUCCESS) {
          conn_status = (struct mongodb_status *) s->data;
          if (PACKET->DATA.len < 16)
-                 return;
+                 return NULL;
 
          unsigned char *noncep  = memmem(ptr, PACKET->DATA.len, "nonce", 5);
          unsigned char *keyp  = memmem(ptr, PACKET->DATA.len, "key\x00", 4);


### PR DESCRIPTION
- Return NULL for function with return type "void *".

GCC seems to be more permissive in this regard, but it is good to be more explicit anyway. Tested on Mac OS X 10.8.x with Xcode 4.5.2, Clang 4.1.
