### PR TITLE
Remove dead code from CVE-2012-0722 patch provided by Sajjad

### DIFF
--- a/include/ec_inet.h
+++ b/include/ec_inet.h
@@ -24,9 +24,6 @@
    #endif
 #endif
 
-#define	NS_IN6ADDRSZ 16
-#define 	NS_INT16SZ = 2
-
 #define	ETH_ADDR_LEN 6
 #define	TR_ADDR_LEN 6
 #define	FDDI_ADDR_LEN 6


### PR DESCRIPTION
That patch contains these lines:

 #define    NS_IN6ADDRSZ 16
 #define    NS_INT16SZ = 2

As noted by Adam D. Barratt adam@adam-barratt.org.uk, the "=" in the
second is bogus.  This bug did not break the build because these
definitions were shadowed anyway.
