### PR TITLE
Fix username detection in TN3270 dissector

### DIFF
--- a/src/dissectors/ec_TN3270.c
+++ b/src/dissectors/ec_TN3270.c
@@ -93,7 +93,7 @@ FUNC_DECODER(dissector_TN3270)
       /* find username */
       for (i = 0; i < PACKET->DATA.len; i++) {
          // Logons start with 125 193 215 17 64 90 ordinals so we check for those
-         if (ptr[i] == 125 && ptr[i+1] == 193 && ptr[i+2] == 215 && \
+         if (ptr[i] == 125 && ptr[i+1] == 193 && // (ptr[i+2] == 215 || ptr[i+2] == 213) &&
                  ptr[i+3] == 17 && ptr[i+4] == 64 && ptr[i+5] == 90) {
                  /* scan for spaces */
                  int j = i + 6;


### PR DESCRIPTION
Fix username detection in TN3270 dissector. I have relaxed the pattern matching a bit.
