### PR TITLE
Minor fix for finding libcurl/building sslstrip

### DIFF
--- a/CMakeFiles/lib_check.cmake
+++ b/CMakeFiles/lib_check.cmake
@@ -111,14 +111,15 @@ if(ENABLE_PLUGINS)
             set(EC_LIBS ${EC_LIBS} ${HAVE_DL})
         endif(HAVE_DL)
     endif(HAVE_DLOPEN)
-
-    find_library(FOUND_LIBCURL curl)
-    if (FOUND_LIBCURL)
-	set(HAVE_LIBCURL 1)
-        set(EC_LIBS ${EC_LIBS} ${FOUND_LIBCURL})
-    endif(FOUND_LIBCURL)
-	
 endif(ENABLE_PLUGINS)
+
+if(HAVE_PLUGINS)
+    # sslstrip has a requirement for libcurl >= 7.26.0
+    find_package(CURL 7.26.0)
+    if(CURL_FOUND)
+        include_directories(${CURL_INCLUDE_DIR})
+    endif(CURL_FOUND)
+endif(HAVE_PLUGINS)
 
 CHECK_FUNCTION_EXISTS(poll HAVE_POLL)
 CHECK_FUNCTION_EXISTS(strtok_r HAVE_STRTOK_R)

--- a/include/config.h.cmake
+++ b/include/config.h.cmake
@@ -38,7 +38,6 @@
 #cmakedefine HAVE_NCURSES
 #cmakedefine HAVE_GTK
 #cmakedefine HAVE_OPENSSL
-#cmakedefine HAVE_LIBCURL
 
 #cmakedefine HAVE_UTF8
 #cmakedefine HAVE_PLUGINS

--- a/plug-ins/CMakeLists.txt
+++ b/plug-ins/CMakeLists.txt
@@ -1,4 +1,3 @@
-
 add_library(arp_cop MODULE arp_cop/arp_cop.c)
 set_target_properties(arp_cop PROPERTIES PREFIX "ec_")
 
@@ -49,9 +48,18 @@ set_target_properties(link_type PROPERTIES PREFIX "ec_")
 add_library(nbns_spoof MODULE nbns_spoof/nbns_spoof.c)
 set_target_properties(nbns_spoof PROPERTIES PREFIX "ec_")
 
-add_library(sslstrip MODULE sslstrip/sslstrip.c)
-target_link_libraries(sslstrip ${FOUND_LIBCURL} ${HAVE_PCRE})
-set_target_properties(sslstrip PROPERTIES PREFIX "ec_")
+if(HAVE_PCRE)
+    if(CURL_FOUND)
+        add_library(sslstrip MODULE sslstrip/sslstrip.c)
+        target_link_libraries(sslstrip ${CURL_LIBRARY} ${HAVE_PCRE})
+        set_target_properties(sslstrip PROPERTIES PREFIX "ec_")
+        set(SSL_STRIP_PLUGIN sslstrip)
+    else(CURL_FOUND)
+        message(STATUS "Not building sslstrip plugin. Requires libcurl.")
+    endif(CURL_FOUND)
+else(HAVE_PCRE)
+    message(STATUS "Not building sslstrip plugin. Requires pcre.")
+endif(HAVE_PCRE)
 
 add_library(pptp_chapms1 MODULE pptp_chapms1/pptp_chapms1.c)
 set_target_properties(pptp_chapms1 PROPERTIES PREFIX "ec_")
@@ -111,7 +119,7 @@ gw_discover
 isolate
 link_type
 nbns_spoof
-sslstrip
+${SSL_STRIP_PLUGIN}
 pptp_chapms1
 pptp_clear
 pptp_pap
@@ -148,7 +156,7 @@ install(TARGETS
             isolate
             link_type
             nbns_spoof
-	    sslstrip
+            ${SSL_STRIP_PLUGIN}
             pptp_chapms1
             pptp_clear
             pptp_pap

--- a/plug-ins/sslstrip/sslstrip.c
+++ b/plug-ins/sslstrip/sslstrip.c
@@ -32,7 +32,6 @@
 
 #include <sys/wait.h>
 
-#ifdef HAVE_PCRE_H
 #include <pcre.h>
 
 #ifdef OS_LINUX
@@ -44,7 +43,6 @@
 #include <sys/poll.h>
 #endif
 
-#ifdef HAVE_LIBCURL
 #include <curl/curl.h>
 
 #if (LIBCURL_VERSION_MAJOR < 7) || (LIBCURL_VERSION_MINOR < 26)
@@ -1337,8 +1335,5 @@ void http_update_content_length(struct http_connection *connection) {
                 memcpy(buf+(content_length-buf)-1, c_length, strlen(c_length));
         }
 }
-
-#endif /* HAVE_LIBCURL */
-#endif /* HAVE_PCRE_H */
 
 // vim:ts=3:expandtab


### PR DESCRIPTION
OSX mountain lion has an old version of libcurl, and the build scripts didn't make it easy to point at a more recent build in a different directory on my system. CMake's find_package has several advantages over find_library/find_path. 

If @eaescob (or someone) wants to take a peek at this for me, that'd be great. I'm inclined to pursue some cleaning up of the cmake stuff a bit more, just to make things consistent. 
- Only look for CURL if we can build plugins (HAVE_PLUGINS).
- Use find_package to locate CURL headers _and_ libs. This makes it
  possible to specify alternate CURL installation root via
  CMAKE_PREFIX_PATH. (ex: -DCMAKE_PREFIX_PATH=/usr/local/opt/curl/)
- Have cmake only build sslstrip if requirements for CURL and PCRE are
  met.
