### PR TITLE
Text Interface Writing Uninitialized Characters

### DIFF
--- a/src/interfaces/text/ec_text_display.c
+++ b/src/interfaces/text/ec_text_display.c
@@ -90,6 +90,7 @@ static void display_headers(struct packet_object *po)
    char proto[5];
    
    memset(flags, 0, sizeof(flags));
+   memset(proto, 0, sizeof(proto));  
    
    fprintf(stdout, "\n\n");
    


### PR DESCRIPTION
When using the text interface the "proto" string was not being null terminated. This is because strncpy never encounters a null terminator in the source string. To fix this, I simply zeroed out the array upon entering the function to ensure that proto is always null terminated even if, for some reason, it never hits the tcp/udp cases in the switch.

Before:
![before](https://f.cloud.github.com/assets/787916/189492/a7e7364a-7e88-11e2-8df5-8b72da1a0cda.png)

After:
![after](https://f.cloud.github.com/assets/787916/189493/ac2e4a72-7e88-11e2-9a63-8591a968a7bd.png)
