### PR TITLE
Extra 0 make if statement always false.

### DIFF
--- a/src/dissectors/ec_gg.c
+++ b/src/dissectors/ec_gg.c
@@ -661,7 +661,7 @@ default:
 if ((version&0xf0000000)==0x40000000)
    strcat(str," + has audio");
 
-if ((version&0x0f000000)==0x040000000)
+if ((version&0x0f000000)== 0x04000000)
    strcat(str," + eraomnix");
 
 }


### PR DESCRIPTION
ec_gg.c line 661 can never evaluate to true since the mask and value do not line up. This is caused by an extra 0 on the 0x04000000.
