### PR TITLE
Fixed uninitialized value (pcap file size) due to fstat failure

### DIFF
--- a/src/ec_network.c
+++ b/src/ec_network.c
@@ -186,10 +186,18 @@ static int source_init(char *name, struct iface_env *source, bool primary, bool 
          return -ENOTHANDLED;
 
       struct stat st;
+      int stat_result;
+      FILE* pcap_file_h;
+
       pcap = pcap_open_offline(name, pcap_errbuf);
       ON_ERROR(pcap, NULL, "pcap_open_offline: %s", pcap_errbuf);
 
-      fstat(pcap_fileno(pcap), &st);
+      pcap_file_h = pcap_file(pcap);
+      ON_ERROR(pcap_file_h, 0, "pcap_fileno returned an invalid file handle");
+
+      stat_result = fstat(fileno(pcap_file_h), &st);
+      ON_ERROR(stat_result, -1, "fstat failed.");
+
       GBL_PCAP->dump_size = st.st_size;
    }
    source->dlt = pcap_datalink(pcap);


### PR DESCRIPTION
## Setup

OS: Ubuntu 12.10 32 bit
Ettercap Version: Github master (commit 7ab56a2196f032f67a6d95eaa1974f2af7893913)
## Symptoms:
1. Valgrind reports this error when running "ettercap -r <file> -T":
   <pre>
   ==21985== Thread 3:
   ==21985== Conditional jump or move depends on uninitialised value(s)
   ==21985==    at 0x805984A: ec_decode (ec_decode.c:228)
   ==21985==    by 0x48BF5CA: ??? (in /usr/lib/i386-linux-gnu/libpcap.so.1.3.0)
   ==21985==    by 0x48B03DE: pcap_loop (in /usr/lib/i386-linux-gnu/libpcap.so.1.3.0)
   ==21985==    by 0x80569E8: capture (ec_capture.c:125)
   ==21985==    by 0x488BD4B: start_thread (pthread_create.c:308)
   ==21985==    by 0x49FED3D: clone (clone.S:130)
   ==21985== 
   </pre>
2. Ettercap simply hangs after processing a file. I actually did not realize that was unexpected until I fixed the above.
## The Error

ec_decode.c:228 is this line:

<pre>
 if (GBL_OPTIONS->read && GBL_PCAP->dump_size == GBL_PCAP->dump_off)
</pre>

The complaint is that GBL_PCAP->dump_size is uninitialized (and thus incorrect).

GBL_PCAP->dump_size is supposed to be set at ec_network.c:193. However, the return value of pcap_fileno in ec_network.c:192 was returning an invalid handle which caused fstat to fail.
## The Fix:

Interestingly, pcap_fileno's man page indicates that pcap_activate needs to be called before pcap_fileno, but I didn't seem to have much luck. Instead, I switched from using pcap_fileno to pcap_file to get the FILE\* and then fileno in conjunction with fstat. Once I did that the dump_size was properly populated and ettercap properly closes after processing the file.
