### PR TITLE
Various Invalid Reads in SNMP

### DIFF
--- a/src/dissectors/ec_snmp.c
+++ b/src/dissectors/ec_snmp.c
@@ -71,6 +71,9 @@ FUNC_DECODER(dissector_snmp)
    /* reached the end */
    if (ptr >= end) return NULL;
       
+   // Check len + version    
+   if ((ptr + (*ptr) + 1) >= end) return NULL;
+   
    /* move to the len */
    ptr += *ptr;
 
@@ -94,6 +97,8 @@ FUNC_DECODER(dissector_snmp)
    
    if (n >= 128) {
       n &= ~128;
+
+      if ((ptr + n) > end) return NULL;
       ptr += n;
       
       switch(*ptr) {
@@ -119,7 +124,7 @@ FUNC_DECODER(dissector_snmp)
    ptr++;
 
    /* Avoid bof */
-   if (clen > MAX_COMMUNITY_LEN)
+   if (clen > MAX_COMMUNITY_LEN || ((ptr + clen) > end))
       return NULL;
          
    SAFE_CALLOC(PACKET->DISSECTOR.user, clen + 2, sizeof(char));


### PR DESCRIPTION
The SNMP dissector increments the data pointer based on packet data without bounds checking causing various invalid reads (and perhaps more) on malformed packets.

Example valgrind warning:

<pre>
==31053== Invalid read of size 1
==31053==    at 0x8081DB6: dissector_snmp (ec_snmp.c:87)
==31053==    by 0x80599F9: decode_data (ec_decode.c:298)
==31053==    by 0x808B1C8: decode_udp (ec_udp.c:129)
==31053==    by 0x808894C: decode_ip (ec_ip.c:224)
==31053==    by 0x8087D5E: decode_eth (ec_eth.c:81)
==31053==    by 0x805970F: ec_decode (ec_decode.c:186)
</pre>


This issue can be reproduced with https://www.wireshark.org/download/automated/captures/fuzz-2006-07-05-1209.pcap
