### PR TITLE
Invalid Reads in LDAP

### DIFF
--- a/src/dissectors/ec_ldap.c
+++ b/src/dissectors/ec_ldap.c
@@ -49,12 +49,9 @@ FUNC_DECODER(dissector_ldap)
    DECLARE_DISP_PTR_END(ptr, end);
    u_int16 type, user_len, pass_len;
    char tmp[MAX_ASCII_ADDR_LEN];
-   
-   /* unused variable */
-   (void)end;
 
-   /* Skip ACK packets */
-   if (PACKET->DATA.len == 0)
+   /* We need at least 15 bytes of data to be interested*/
+   if (PACKET->DATA.len < 15)
       return NULL;
     
    /* Only packets coming from the server */
@@ -69,7 +66,14 @@ FUNC_DECODER(dissector_ldap)
 
    /* Quite self-explaining :) */
    user_len = (u_int16)ptr[11];
+
+   if ((ptr + user_len + 12) > end)
+      return NULL;
+
    pass_len = (u_int16)ptr[13 + user_len];
+
+   if ((ptr + user_len + pass_len + 14) > end)
+      return NULL;
 
    if (user_len == 0) {
       PACKET->DISSECTOR.user = strdup("[Anonymous Bind]");


### PR DESCRIPTION
LDAP does a number of pointer manipulations that don't do any length checking. Here is a sample valgrind error:

<pre>
==6574== Invalid read of size 1
==6574==    at 0x807A147: dissector_ldap (ec_ldap.c:73)
==6574==    by 0x8059A74: decode_data (ec_decode.c:305)
==6574==    by 0x808A538: decode_tcp (ec_tcp.c:294)
==6574==    by 0x80889C4: decode_ip (ec_ip.c:224)
==6574==    by 0x8087DD6: decode_eth (ec_eth.c:81)
==6574==    by 0x805970F: ec_decode (ec_decode.c:186)
</pre>


I added in a few checks to ensure that this doesn't occur. I tested with http://www.pcapr.net/view/mu/2009/0/2/15/NSS-LDAP-login.cap.html to make sure the username/password still gets pulled out.

This issue can be reproduced with https://www.wireshark.org/download/automated/captures/fuzz-2006-07-05-6279.pcap
