### PR TITLE
Poll's return value was never getting checked.

### DIFF
--- a/src/ec_poll.c
+++ b/src/ec_poll.c
@@ -45,6 +45,7 @@ int ec_poll_buffer(char *buf);
 int ec_poll_in(int fd, u_int msec)
 {
 #if defined(HAVE_POLL) && !defined(OS_DARWIN)
+   int poll_result;
    struct pollfd poll_fd;
    
    /* set the correct fd */
@@ -52,10 +53,10 @@ int ec_poll_in(int fd, u_int msec)
    poll_fd.events = POLLIN;
          
    /* execute the syscall */
-   poll(&poll_fd, 1, msec);
-
+   poll_result = poll(&poll_fd, 1, msec);
+   
    /* the event has occurred, return 1 */
-   if (poll_fd.revents & POLLIN)
+   if (poll_result > 0 && poll_fd.revents & POLLIN)
       return 1;
   
    return 0;


### PR DESCRIPTION
Poll's return value was never being checked which results in some undefined behavior due to poll_fd not being set. The most popular error seemed to be EINTR. The fix is to simply check the return value and return 0 on failure.
