### PR TITLE
Invalid Read In DHCP

### DIFF
--- a/src/dissectors/ec_dhcp.c
+++ b/src/dissectors/ec_dhcp.c
@@ -267,7 +267,7 @@ u_int8 * get_dhcp_option(u_int8 opt, u_int8 *ptr, u_int8 *end)
        */
       ptr = ptr + 2 + (*(ptr + 1));
 
-   } while (*ptr != DHCP_OPT_END && ptr < end);
+   } while (ptr < end && *ptr != DHCP_OPT_END);
    
    return NULL;
 }


### PR DESCRIPTION
I came across this warning via valgrind:

<pre>
==6515== Invalid read of size 1
==6515==    at 0x807567E: get_dhcp_option (ec_dhcp.c:273)
==6515==    by 0x8075312: dissector_dhcp (ec_dhcp.c:208)
==6515==    by 0x80599F9: decode_data (ec_decode.c:298)
==6515==    by 0x808B288: decode_udp (ec_udp.c:129)
==6515==    by 0x8088A0C: decode_ip (ec_ip.c:224)
==6515==    by 0x8087E1E: decode_eth (ec_eth.c:81)
==6515==    by 0x805970F: ec_decode (ec_decode.c:186)
</pre>


Pretty simply, the data pointer gets moved and dereferenced without bounds checking. I just swapped the && clauses to ensure the loop terminates before the dereference occurs.

This can be reproduced using https://www.wireshark.org/download/automated/captures/fuzz-2006-07-09-348.pcap
