### PR TITLE
Del_decoder Overlapping Source and Destination

### DIFF
--- a/src/ec_decode.c
+++ b/src/ec_decode.c
@@ -452,8 +452,11 @@ void del_decoder(u_int8 level, u_int32 type)
 
    if(e = find_entry(level, type)) {
       DECODERS_LOCK;
-      /* Replace this entry with the last one */
-      memcpy(e, &protocols_table[protocols_num-1], sizeof(struct dec_entry));
+      if (e != &protocols_table[protocols_num-1])
+      {
+          /* Replace this entry with the last one */
+          memcpy(e, &protocols_table[protocols_num-1], sizeof(struct dec_entry));
+      }
       /* Resize the array */
       SAFE_REALLOC(protocols_table, --protocols_num*sizeof(struct dec_entry));
       /* And mark as unsorted */


### PR DESCRIPTION
ec_decode.c's del_decoder() function contains an overlapping memcpy when e == the last entry in the protocols table.

<pre>
==11458== Source and destination overlap in memcpy(0x536b194, 0x536b194, 12)
==11458==    at 0x402D50D: memcpy (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==11458==    by 0x8059E0B: del_decoder (ec_decode.c:458)
==11458==    by 0x805A59B: dissect_del (ec_dissect.c:210)
==11458==    by 0x805A6C6: dissect_modify (ec_dissect.c:246)
==11458==    by 0x8057E4B: set_dissector (ec_conf.c:436)
==11458==    by 0x8057B85: load_conf (ec_conf.c:333)
==11458==    by 0x8061D1B: main (ec_main.c:92)
</pre>


While this might not seem concerning it is actually undefined behavior. Valgrind's blurb on the error is quite good: http://valgrind.org/docs/manual/mc-manual.html#mc-manual.overlap

The fix I implemented was only to copy when e != the last protocol. Another solution would be to use memmove. This can be recreated with the default config file.
