### PR TITLE
Text UI Deadlock

### DIFF
--- a/src/ec_ui.c
+++ b/src/ec_ui.c
@@ -260,6 +260,7 @@ void ui_input(const char *title, char *input, size_t n, void (*callback)(void))
 int ui_msg_flush(int max)
 {
    int i = 0;
+   int old = 0;
    struct ui_message *msg;
   
 
@@ -269,6 +270,9 @@ int ui_msg_flush(int max)
      
    if (STAILQ_EMPTY(&messages_queue))
 	return 0; 
+
+   // don't allow the thread to cancel while holding the ui mutex
+   pthread_setcancelstate(PTHREAD_CANCEL_DISABLE, &old);
 
    /* the queue is updated by other threads */
    UI_MSG_LOCK;
@@ -290,7 +294,9 @@ int ui_msg_flush(int max)
    }
    
    UI_MSG_UNLOCK;
-   
+
+   pthread_setcancelstate(PTHREAD_CANCEL_ENABLE, &old);
+
    /* returns the number of displayed messages */
    return i;
    


### PR DESCRIPTION
<b>System</b>: 32 bit Ubuntu 12.10
<b>Ettercap Version</b>: Master (64df776f700d7a8dd0738cf3beb834262e4ed72f)
<b>Interface</b>: Text UI
<b>File</b>: I don't think it matters but I was testing with https://www.wireshark.org/download/automated/captures/fuzz-2006-06-26-2594.pcap
<b>Description</b>:
Every now and again Ettercap falls into a deadlock state. This occurs about once every five to six runs. Valgrind puts Ettercap into a deadlock state much more reliably (~50% of the time).
The dead lock occurs after the entire file has been processed and the system is trying to shutdown. After much debugging I discovered this occurs because a thread is exiting while still holding the UI_MSG_LOCK. The lock is grabbed via ui_msg_flush which can trigger fflush in ec_text::text_msg. fflush is an implicit cancellation point, so the thread hits it and exits while still holding the lock.
<b>Fix</b>:
To fix this I disabled cancellation while holding the UI_MSG_LOCK. I'm not certain this is the best solution, but it has allowed me to continue with other testing.
