### PR TITLE
Segmentation Fault in ec_http.c

### DIFF
--- a/src/dissectors/ec_http.c
+++ b/src/dissectors/ec_http.c
@@ -350,7 +350,7 @@ static int Parse_Basic_Auth(char *ptr, char *from_here, struct packet_object *po
 
    user = ec_strtok(to_decode, ":", &pass); 
 
-   if (pass != NULL) {
+   if (pass != NULL && user != NULL) {
       po->DISSECTOR.user = strdup(user);
       po->DISSECTOR.pass = strdup(pass);	
  


### PR DESCRIPTION
ec_http.c:Parse_Basic_Auth calls strdup on a pointer without checking if it is NULL. The pointer is the return value of ec_strtok(to_decode, ":", &pass) which is NULL when ':' is found at the end of the string.

This can be recreated with https://www.wireshark.org/download/automated/captures/fuzz-2007-02-17-28608.pcap
