### PR TITLE
Infinite loop in ec_tcp.c

### DIFF
--- a/src/protocols/ec_tcp.c
+++ b/src/protocols/ec_tcp.c
@@ -230,7 +230,8 @@ FUNC_DECODER(decode_tcp)
             case TCPOPT_TIMESTAMP:
                fingerprint_push(PACKET->PASSIVE.fingerprint, FINGER_TIMESTAMP, 1);
                opt_start++;
-               opt_start += (*opt_start - 1);
+               if ((*opt_start) > 0)
+                   opt_start += ((*opt_start) - 1);
                break;
             default:
                opt_start++;


### PR DESCRIPTION
An infinite loop can occur in ec_tcp.c when a malformed or crafted tcp packet contains a timestamp option field with a length of 0. This case had been considered for an unknown tcp option, but not for the timestamp case.

This can be recreated using https://www.wireshark.org/download/automated/captures/fuzz-2010-06-28-13441.pcap
