### PR TITLE
Added some length checks to BGP in order to avoid invalid reads.

### DIFF
--- a/src/dissectors/ec_bgp.c
+++ b/src/dissectors/ec_bgp.c
@@ -128,7 +128,7 @@ FUNC_DECODER(dissector_bgp)
    /* don't complain about unused var */
    (void)end;
    
-   /* skip packets that don't have neough data' */
+   /* skip packets that don't have enough data */
    if (PACKET->DATA.len < 30)
       return NULL;
 


### PR DESCRIPTION
Nothing too exciting here. BGP does various pointer manipulations without any type of length checks. I added a couple that should cover everything.

This can be recreated with https://www.wireshark.org/download/automated/captures/fuzz-2011-10-25-30900.pcap

<pre>
==2821== Invalid read of size 1
==2821==    at 0x807495B: dissector_bgp (in /usr/local/bin/ettercap)
==2821==    by 0x8059925: decode_data (in /usr/local/bin/ettercap)
==2821==    by 0x808AB58: decode_tcp (in /usr/local/bin/ettercap)
==2821==    by 0x8088FE4: decode_ip (in /usr/local/bin/ettercap)
==2821==    by 0x80883F6: decode_eth (in /usr/local/bin/ettercap)
==2821==    by 0x805963B: ec_decode (in /usr/local/bin/ettercap)
==2821==    by 0x48BE5CA: ??? (in /usr/lib/i386-linux-gnu/libpcap.so.1.3.0)
==2821==    by 0x48AF3DE: pcap_loop (in /usr/lib/i386-linux-gnu/libpcap.so.1.3.0)
==2821==    by 0x8056915: capture (in /usr/local/bin/ettercap)</code>
</pre>
