### PR TITLE
Added Support for IP Tunnels

### DIFF
--- a/include/ec_proto.h
+++ b/include/ec_proto.h
@@ -29,6 +29,8 @@ enum {
 /* network layer types */
 enum {
    NL_TYPE_ICMP  = 0x01,
+   NL_TYPE_IPIP  = 0x04,
+   NL_TYPE_IP6   = 0x29,
    NL_TYPE_ICMP6 = 0x3a,
    NL_TYPE_TCP   = 0x06,
    NL_TYPE_UDP   = 0x11,

--- a/src/protocols/ec_ip.c
+++ b/src/protocols/ec_ip.c
@@ -90,6 +90,7 @@ size_t ip_create_ident(void **i, struct packet_object *po);
 void __init ip_init(void)
 {
    add_decoder(NET_LAYER, LL_TYPE_IP, decode_ip);
+   add_decoder(PROTO_LAYER, NL_TYPE_IPIP, decode_ip);
    add_injector(CHAIN_LINKED, IP_MAGIC, inject_ip);
    add_injector(CHAIN_LINKED, STATELESS_IP_MAGIC, stateless_ip);
 }

--- a/src/protocols/ec_ip6.c
+++ b/src/protocols/ec_ip6.c
@@ -85,6 +85,7 @@ static void ip6_create_session(struct ec_session **s, struct packet_object *po);
 void __init ip6_init(void)
 {
    add_decoder(NET_LAYER, LL_TYPE_IP6, decode_ip6);
+   add_decoder(PROTO_LAYER, NL_TYPE_IP6, decode_ip6);
    add_decoder(NET6_LAYER, LO6_TYPE_HBH, decode_ip6_ext);
    add_decoder(NET6_LAYER, LO6_TYPE_RT, decode_ip6_ext);
    add_decoder(NET6_LAYER, LO6_TYPE_DST, decode_ip6_ext);


### PR DESCRIPTION
I noticed that data contained in an IP tunnel wasn't being processed. I added the linkages between the protocols to make this happen. I've tested:

IPv4 -> IPv4
IPv4 -> IPv6
IPv6 -> IPv4

Here are a couple of publicly available captures with IP tunnels:
http://packetlife.net/captures/IP_in_IP.cap
http://packetlife.net/captures/IPv6_in_IP.cap
