### PR TITLE
o5logon Heap Corruption

### DIFF
--- a/src/dissectors/ec_o5logon.c
+++ b/src/dissectors/ec_o5logon.c
@@ -97,8 +97,11 @@ FUNC_DECODER(dissector_o5logon)
               last--;
             }
             int length = *(last+1);
-            strncpy((char*)conn_status->user, (char*)last + 2, length);
-            conn_status->user[length] = 0;
+            if (length < sizeof(conn_status->user))
+            {
+               strncpy((char*)conn_status->user, (char*)last + 2, length);
+               conn_status->user[length] = 0;
+            }
 
             /* save the session */
             session_put(s);


### PR DESCRIPTION
<b>OS</b>: Ubunt 12.10 32 bit
<b>Ettercap Version</b>: Almost master (28bfb2dee328bbbc39fd69768a8f4af92cd9ed15)
<b>File: https://www.wireshark.org/download/automated/captures/fuzz-2009-06-26-23834.pcap</b>
<b>Description</b>:
The above capture causes heap corruption due to writing off of the end of an allocated structure.

<i>CLI Output</i>
**\* glibc detected **\* ettercap: malloc(): memory corruption: 0xb4c0ec70 ***

<i>Valgrind Output</i>

<pre>
==4454== Invalid write of size 1
==4454==    at 0x402C538: strncpy (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==4454==    by 0x807E59F: dissector_o5logon (ec_o5logon.c:100)
==4454==    by 0x8059CF0: decode_data (ec_decode.c:304)
==4454==    by 0x808BD5B: decode_tcp (ec_tcp.c:295)

... snip ...

valgrind: m_mallocfree.c:266 (mk_plain_bszB): Assertion 'bszB != 0' failed.
valgrind: This is probably caused by your program erroneously writing past the
end of a heap block and corrupting heap metadata.  If you fix any
invalid writes reported by Memcheck, this assertion failure will
probably go away.  Please try that before reporting this as a bug.
</pre>


<b> Fix </b>
Added a length check to make sure we don't overwrite the size of buffer. Retested with the captures listed here: https://github.com/Ettercap/ettercap/pull/19

Note that the original capture also has invalid reads in Napster that I (or someone) should get to at some point.
