### PR TITLE
Invalid IP Header Length

### DIFF
--- a/src/protocols/ec_ip.c
+++ b/src/protocols/ec_ip.c
@@ -109,6 +109,11 @@ FUNC_DECODER(decode_ip)
    ip = (struct ip_header *)DECODE_DATA;
   
    DECODED_LEN = (u_int32)(ip->ihl * 4);
+   if (DECODED_LEN < 20)
+   {
+       // invalid header length
+       return NULL;
+   }
 
    /* IP addresses */
    ip_addr_init(&PACKET->L3.src, AF_INET, (u_char *)&ip->saddr);


### PR DESCRIPTION
<b>Ettercap Version</b>: 1e0ca6b3df6eae81c779a17638a68a2b74bc546b
<b>File</b>: https://www.wireshark.org/download/automated/captures/fuzz-2009-06-26-29078.pcap
<b>Problem</b>: The above file causes a crash. The crash is caused by an infinite ip -> ip call stack eventually causing an overflow. This can occur when the header length in the ip packet is 0. If the header length is 0 then the data does not get incremented at all.
<b>Fix</b>: The minimum valid header length is 20. I added that check and the invalid packet that causes the crash gets ignored.
