### PR TITLE
Added UA parsing to ec_http.c

### DIFF
--- a/include/ec_profiles.h
+++ b/include/ec_profiles.h
@@ -11,6 +11,7 @@ struct dissector_info {
    char *pass;
    char *info;
    char *banner;
+   char *os;
    char failed;
    u_int8 advertised_proto;
    u_int16 advertised_port;
@@ -51,7 +52,9 @@ struct host_profile {
    struct ip_addr L3_addr;
 
    char hostname[MAX_HOSTNAME_LEN];
-   
+
+   char* os;
+
    /* the list of open ports */
    LIST_HEAD(, open_port) open_ports_head;
    

--- a/src/dissectors/ec_http.c
+++ b/src/dissectors/ec_http.c
@@ -102,6 +102,7 @@ static u_char Parse_Form(char *to_parse, char **ret, int mode);
 static int Parse_Passport_Auth(char *ptr, char *from_here, struct packet_object *po);
 static int Parse_NTLM_Auth(char *ptr, char *from_here, struct packet_object *po);
 static int Parse_Basic_Auth(char *ptr, char *from_here, struct packet_object *po);
+static int Parse_User_Agent(char *ptr, char *end, char *from_here, struct packet_object *po);
 static char *unicodeToString(char *p, size_t len);
 static void dumpRaw(char *str, unsigned char *buf, size_t len);
 int http_fields_init(void);
@@ -163,6 +164,8 @@ FUNC_DECODER(dissector_http)
          Parse_NTLM_Auth((char*)ptr, from_here + strlen(": NTLM "), PACKET));
       else if ((from_here = strstr((const char*)ptr, ": Basic ")) &&
          Parse_Basic_Auth((char*)ptr, from_here  + strlen(": Basic "), PACKET));
+      else if ((from_here = strstr((const char*)ptr, "User-Agent: ")) &&
+          Parse_User_Agent((char*)ptr, end, from_here + strlen("User-Agent: "), PACKET));
       else if (!strncmp((const char*)ptr, "GET ", 4))
          Parse_Method_Get((char*)ptr + strlen("GET "), PACKET);
       else if (!strncmp((const char*)ptr, "POST ", 5))
@@ -365,6 +368,60 @@ static int Parse_Basic_Auth(char *ptr, char *from_here, struct packet_object *po
 
    SAFE_FREE(to_decode);
    return 1;
+}
+
+static int Parse_User_Agent(char* ptr, char* end, char *from_here, struct packet_object *po)
+{
+    // find the end of the line
+    const char* line_end = (const char*)memchr(from_here, '\n', end - from_here);
+    if (line_end == NULL) {
+        return;
+    }
+
+    unsigned int line_length = line_end - from_here;
+    const char* comment_begin = (const char*)memchr(from_here, '(', line_length);
+    if (comment_begin == NULL && ((comment_begin + 1) < end)) {
+        // no comments found
+        return;
+    }
+    ++comment_begin;
+
+    const char* comment_end = (const char*)memchr(comment_begin, ')', line_end - comment_begin);
+    if (comment_begin == NULL) {
+        // couldn't find the close on the comment
+        return;
+    }
+
+    const char* os = NULL;
+    while (os == NULL && comment_begin != NULL) {
+        unsigned int comment_length = comment_end - comment_begin;
+        if ((comment_length > 10 && strncmp(comment_begin, "Windows NT", 10) == 0) ||
+            (comment_length > 9 && strncmp(comment_begin, "Intel Mac", 9) == 0) ||
+            (comment_length > 7 && strncmp(comment_begin, "PPC Mac", 7) == 0) ||
+            (comment_length > 10 && strncmp(comment_begin, "CPU iPhone", 10) == 0) ||
+            (comment_length > 8 && strncmp(comment_begin, "Android", 7) == 0) ||
+            (comment_length > 5 && strncmp(comment_begin, "CrOS", 4) == 0) || // Chrome OS
+            (comment_length > 5 && strncmp(comment_begin, "Linux", 5) == 0)) {
+            os = comment_begin;
+        }
+
+        if (os == NULL) {
+            comment_begin = memchr(comment_begin, ';', comment_end - comment_begin);
+            if (comment_begin != NULL && ((comment_begin + 2) < comment_end)) {
+                // skip the ; and the ' '
+                comment_begin += 2;
+            }
+        } else {
+            const char* the_end = memchr(comment_begin, ';', comment_end - comment_begin);
+            if (the_end != NULL) {
+                comment_end = the_end;
+            }
+
+            SAFE_CALLOC(po->DISSECTOR.os, 1, (comment_end - os) + 1);
+            memcpy(po->DISSECTOR.os, os, comment_end - os);
+            po->DISSECTOR.os[comment_end - os] = 0;
+        }
+    }
 }
 
 /* Parse NTLM challenge and response for both Proxy and WWW Auth */ 

--- a/src/ec_packet.c
+++ b/src/ec_packet.c
@@ -114,6 +114,7 @@ int packet_destroy_object(struct packet_object *po)
       SAFE_FREE(po->DISSECTOR.pass);
       SAFE_FREE(po->DISSECTOR.info);
       SAFE_FREE(po->DISSECTOR.banner);
+      SAFE_FREE(po->DISSECTOR.os);
    }
       
    /* 
@@ -187,6 +188,7 @@ struct packet_object * packet_dup(struct packet_object *po, u_char flag)
       dup_po->DISSECTOR.pass = NULL;
       dup_po->DISSECTOR.info = NULL;
       dup_po->DISSECTOR.banner = NULL;
+      dup_po->DISSECTOR.os = NULL;
    }
    
    /* 

--- a/src/interfaces/curses/ec_curses_view_profiles.c
+++ b/src/interfaces/curses/ec_curses_view_profiles.c
@@ -182,8 +182,10 @@ static void curses_profile_detail(void *profile)
       wdg_scroll_print(wdg_pro_detail, EC_COLOR, " TYPE         : REMOTE host\n\n");
    else if (h->type == FP_UNKNOWN)
       wdg_scroll_print(wdg_pro_detail, EC_COLOR, " TYPE         : unknown\n\n");
-      
-   
+
+   if (h->os)
+    wdg_scroll_print(wdg_pro_detail, EC_COLOR, " OBSERVED OS     : %s\n\n", h->os);
+
    wdg_scroll_print(wdg_pro_detail, EC_COLOR, " FINGERPRINT      : %s\n", h->fingerprint);
    if (fingerprint_search((const char*)h->fingerprint, os) == ESUCCESS)
       wdg_scroll_print(wdg_pro_detail, EC_COLOR, " OPERATING SYSTEM : %s \n\n", os);

--- a/src/interfaces/gtk/ec_gtk_view_profiles.c
+++ b/src/interfaces/gtk/ec_gtk_view_profiles.c
@@ -285,8 +285,13 @@ static void gtkui_profile_detail(void)
    else if (h->type == FP_UNKNOWN)
       snprintf(line, 200, " Type: \t\tunknown\n\n");
    gtkui_details_print(textbuf, line);
-      
-   
+
+   if (h->os)
+   {
+      snprintf(line, 200, " Observed OS:\t%s\n\n", h->os);
+      gtkui_details_print(textbuf, line);
+   }
+
    snprintf(line, 200, " Fingerprint: \t%s\n", h->fingerprint);
    gtkui_details_print(textbuf, line);
    if (fingerprint_search(h->fingerprint, os) == ESUCCESS)


### PR DESCRIPTION
There are multiple protocols in which the client advertises the OS they are running. Probably the most popular of these is HTTP via the User-Agent field. While the information in the user agent field isn't always a slam dunk it is typically accurate. As such, I've added parsing of the UA field and added the information to the profile. The current implementation hard codes the strings we are looking for, but this could be changed to a file.conf approach.

I've tested this on Ubuntu on various pcaps. Below are a couple of screenshots from wireshark sample http captures. 

![wireshark_http_cap](https://f.cloud.github.com/assets/787916/268712/c3cf9126-8f50-11e2-9d73-4cadaece8651.png)
![wireshark_gzip_cap](https://f.cloud.github.com/assets/787916/268714/cd032d3e-8f50-11e2-9923-ef7e154edd42.png)
