### PR TITLE
Fixed undefined behavior due to the lack of return

### DIFF
--- a/src/dissectors/ec_http.c
+++ b/src/dissectors/ec_http.c
@@ -585,7 +585,7 @@ static void Parse_Method_Get(char *ptr, struct packet_object *po)
    char *user = NULL;
    char *pass = NULL;
    
-   printf("HTTP --> dissector http (method GET)");
+   DEBUG_MSG("HTTP --> dissector http (method GET)");
 
    /* Isolate the parameters and copy them into another string */
    if (!(to_parse = strstr(ptr, "?")))


### PR DESCRIPTION
This patch addresses issue #125. I introduced the bug with the addition of UA parsing. The failure was no return value(s) on a function expecting a return value. This should have been flagged by -Wall but it currently isn't (for reasons that aren't all that clear to me right now - I'll look into that later.).

This bug causes undefined behavior which could explain why Mike sometimes had issues and sometimes not.
