### PR TITLE
Added ascii FQDN support to DHCP ACK

### DIFF
--- a/include/ec_proto.h
+++ b/include/ec_proto.h
@@ -113,6 +113,7 @@ enum {
    DHCP_OPT_SRV_ADDR    = 0x36,
    DHCP_OPT_RENEW_TIME  = 0x3a,
    DHCP_OPT_CLI_IDENT   = 0x3d,
+   DHCP_OPT_FQDN        = 0x51,
    DHCP_OPT_END         = 0xff,
    DHCP_OPT_MIN_LEN     = 0x12c,
 };


### PR DESCRIPTION
DHCP option 81 provides us with the client's fully qualified domain name (FQDN) which we can use to populate the client's hostname in the profile. The RFC can be found here: https://tools.ietf.org/html/rfc4702.

The domain name can be presented into two formats: ascii and canonical wire format. A single bit in option 81 indicates which format is being used. Technically speaking, the ascii format is deprecated, but I don't have a setup / couldn't find a capture that <i>didn't</i> use it. I assume I could pass the wire format data into resolv_cache_insert, but without test data I didn't want to go too crazy.

To test this, you can use a capture on wireshark's sample captures: http://wiki.wireshark.org/SampleCaptures?action=AttachFile&do=get&target=dhcp-and-dyndns.pcap.gz

And here is a before / after profile screenshot:
<i>Before</i>
![before](https://f.cloud.github.com/assets/787916/294399/755c07f8-93e8-11e2-8f6b-bbbde78a7752.png)

<i>After</i>
![after](https://f.cloud.github.com/assets/787916/294401/89936aa4-93e8-11e2-9f36-22994ccea63f.png)
