### PR TITLE
Fixed Two Parsing Errors

### DIFF
--- a/src/dissectors/ec_http.c
+++ b/src/dissectors/ec_http.c
@@ -380,14 +380,14 @@ static int Parse_User_Agent(char* ptr, char* end, char *from_here, struct packet
 
     unsigned int line_length = line_end - from_here;
     const char* comment_begin = (const char*)memchr(from_here, '(', line_length);
-    if (comment_begin == NULL && ((comment_begin + 1) < end)) {
+    if (comment_begin == NULL || ((comment_begin + 1) >= end)) {
         // no comments found
         return 0;
     }
     ++comment_begin;
 
     const char* comment_end = (const char*)memchr(comment_begin, ')', line_end - comment_begin);
-    if (comment_begin == NULL) {
+    if (comment_end == NULL) {
         // couldn't find the close on the comment
         return 0;
     }


### PR DESCRIPTION
Two parsing errors exist in ec_http.c. The first was using && where || should have been used (begin_comment was not found OR begin_comment + 1 >= end). The second was checking for comment_begin == NULL when we should check comment_end.

Not checking if comment_end is kinda a big deal. If the comment is malformed then an infinite loop can occur. This can be recreated with: https://www.wireshark.org/download/automated/captures/fuzz-2006-08-26-27284.pcap
