### PR TITLE
End loop if length check fails

### DIFF
--- a/src/dissectors/ec_http.c
+++ b/src/dissectors/ec_http.c
@@ -411,6 +411,10 @@ static int Parse_User_Agent(char* ptr, char* end, char *from_here, struct packet
                 // skip the ; and the ' '
                 comment_begin += 2;
             }
+            else
+            {
+            	comment_begin = NULL;
+            }
         } else {
             const char* the_end = memchr(comment_begin, ';', comment_end - comment_begin);
             if (the_end != NULL) {


### PR DESCRIPTION
An infinite loop occurs in this file: https://www.wireshark.org/download/automated/captures/fuzz-2009-06-27-18328.pcap

Specifically this http field causes the problem:
User-Agent: Mozilla/4.0 (compatible; MSIE 6.0; MS Web Services Client Protocol 2.0.50727.143;)

The ';' at the end causes the loop to recognize a length failure, but the loop continues since comment_begin isn't set to null.
