### PR TITLE
Invalid Read in DHCP

### DIFF
--- a/src/dissectors/ec_dhcp.c
+++ b/src/dissectors/ec_dhcp.c
@@ -152,8 +152,13 @@ FUNC_DECODER(dissector_dhcp)
             DEBUG_MSG("\tDissector_DHCP REQUEST");
       
             /* requested ip address */
-            if ((opt = get_dhcp_option(DHCP_OPT_RQ_ADDR, options, end)) != NULL)
+            if ((opt = get_dhcp_option(DHCP_OPT_RQ_ADDR, options, end)) != NULL) {
+               if ((opt + 5) >= end) {
+                   // not enough room for an ip address
+                   return NULL;
+               }
                ip_addr_init(&client, AF_INET, opt + 1);
+            }
             else {
                /* search if the client already has the ip address */
                if (dhcp->ciaddr != 0) {


### PR DESCRIPTION
DHCP can read past the end of the packet:

==28122== Thread 3:
==28122== Invalid read of size 2
==28122==    at 0x402D558: memcpy (in /usr/lib/valgrind/vgpreload_memcheck-x86-linux.so)
==28122==    by 0x805EDCA: ip_addr_init (ec_inet.c:74)
==28122==    by 0x80754C9: dissector_dhcp (ec_dhcp.c:156)
==28122==    by 0x8059AF8: decode_data (ec_decode.c:304)
==28122==    by 0x808C448: decode_udp (ec_udp.c:129)
==28122==    by 0x8089884: decode_ip (ec_ip.c:230)
==28122==    by 0x8088C66: decode_eth (ec_eth.c:81)
==28122==    by 0x8059793: ec_decode (ec_decode.c:186)

Example file: https://www.wireshark.org/download/automated/captures/fuzz-2012-11-26-27661.pcap

I simply added a check to ensure that we don't read too far. There are other place in DHCP where I believe this can occur, but I'd rather have concrete examples before addressing them. Probably a good place to start with unit tests.
