### PR TITLE
Fixed MPLS End of Stack Bit Checking

### DIFF
--- a/src/protocols/ec_mpls.c
+++ b/src/protocols/ec_mpls.c
@@ -66,8 +66,8 @@ FUNC_DECODER(decode_mpls)
    /* HOOK POINT : HOOK_PACKET_mpls */
    hook_point(HOOK_PACKET_MPLS, po);
 
-   /* check the stack bit (9th bit) */
-   if (mpls->shim & 0x00000100) {
+   /* check the end of stack bit */
+   if (mpls->shim & 0x00010000) {
       /* leave the control to the IP decoder */
       next_decoder = get_decoder(NET_LAYER, LL_TYPE_IP);
    } else {


### PR DESCRIPTION
<b>Description</b>: ec_mpls.c checks the end of stack bit in order to figure out if there is another MPLS label or if it can forward the data to IP. However, we are currently checking the wrong bit (it appears the mask is applied as if the data is in host order). This is most apparent when there is more than one label in the stack. 

<b>Recreate</b> Look at Wireshark's sample capture mpls-twolevel.cap (http://wiki.wireshark.org/SampleCaptures?action=AttachFile&do=get&target=mpls-twolevel.cap). If you filter mpls only data you can see that packets make it to IP but the data pointer is pointing to the second mpls label. 
