### PR TITLE
Fix Luajit on 64-bit OSX

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -173,6 +173,16 @@ add_dependencies(ettercap libnet)
 IF(ENABLE_LUA)
   add_subdirectory(lua)
   target_link_libraries(ettercap ec_lua)
+  if(OS_DARWIN AND (CMAKE_SIZEOF_VOID_P EQUAL 8))
+    # On 64-bit OSX platforms, luajit requires the following flags to be added.
+    # See: http://luajit.org/install.html
+    get_target_property(OLD_FLAGS ettercap LINK_FLAGS)
+    if(OLD_FLAGS STREQUAL "OLD_FLAGS-NOTFOUND")
+      set(OLD_FLAGS "")
+    endif()
+    set(NEW_FLAGS "${OLD_FLAGS} -pagezero_size 10000 -image_base 100000000")
+    SET_TARGET_PROPERTIES(ettercap PROPERTIES LINK_FLAGS "${NEW_FLAGS}")
+  endif()
 endif(ENABLE_LUA)
 
 target_link_libraries(ettercap ec_interfaces ${EC_LIBS})


### PR DESCRIPTION
- Luajit has specific linker requirements on 64-bit OSX. See
  http://luajit.org/install.html .. It doesn't work without this!
