### PR TITLE
Make PDF Doc generation optional (disabled by default)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ option(ENABLE_SSL "Enable SSL support" ON)
 option(ENABLE_PLUGINS "Enable plugins support" ON)
 option(ENABLE_IPV6 "Enable IPv6 support" OFF)
 option(ENABLE_LUA "Enable LUA support (EXPERIMENTAL)" OFF)
+option(ENABLE_PDF_DOCS "Enable PDF document generation" OFF)
 
 SET(VALID_BUILD_TYPES Debug Release)
 

--- a/README
+++ b/README
@@ -53,11 +53,13 @@ MANDATORY:
    - libpthread
    - zlib
    - CMake 2.8
-   - ghostscript
    - Curl    >= 7.26.0 to build SSLStrip plugin
    If you don't want to enable SSLStrip plugin you have to disable it. (more information about disabling a plugin in the README.GIT file)
 
 OPTIONAL:
+   To enable PDF documentation generation (enable via ENABLE_PDF_DOCS=On):
+      - ghostscript (ps2pdf13)
+      - groff
 
    To enable plugins:
       - libltdl (part of libtool)

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -1,10 +1,12 @@
 # Add man page custom target
-find_program(GROFF_EXECUTABLE NAMES groff)
-find_program(PS2PDF13_EXECUTABLE NAMES ps2pdf13)
+if(ENABLE_PDF_DOCS)
+  find_program(GROFF_EXECUTABLE NAMES groff)
+  find_program(PS2PDF13_EXECUTABLE NAMES ps2pdf13)
+  set(PDF_FILES)
+endif()
 
 set (MAN_NAMES ettercap.8 etterfilter.8 etterlog.8 etter.conf.5)
 set(MAN_FILES)
-set(PDF_FILES)
 
 if (ENABLE_PLUGINS)
         set(MAN_NAMES ${MAN_NAMES} ettercap_plugins.8)
@@ -16,27 +18,32 @@ endif(ENABLE_CURSES)
 
 foreach (m IN LISTS MAN_NAMES)
         set(mf ${CMAKE_BINARY_DIR}/man/${m})
-        set(ps ${CMAKE_BINARY_DIR}/man/${m}.ps)
-        set(pdf ${CMAKE_BINARY_DIR}/man/${m}.pdf)
-
-        add_custom_command(OUTPUT ${mf}.ps
-        COMMAND ${GROFF_EXECUTABLE} -mandoc -Tps ${mf} > ${ps}
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-        COMMENT "Building manpage ${mf}"
-        VERBATIM)
         list(APPEND MAN_FILES ${mf})
 
-        add_custom_command(OUTPUT ${pdf}
-        COMMAND ${PS2PDF13_EXECUTABLE} ${ps} ${pdf}
-        WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-	DEPENDS ${mf}.ps
-        COMMENT "Creating PDF for ${ps}"
-        VERBATIM)
-        list(APPEND PDF_FILES ${pdf})
+        if(ENABLE_PDF_DOCS)
+          set(ps ${CMAKE_BINARY_DIR}/man/${m}.ps)
+          set(pdf ${CMAKE_BINARY_DIR}/man/${m}.pdf)
+
+          add_custom_command(OUTPUT ${mf}.ps
+          COMMAND ${GROFF_EXECUTABLE} -mandoc -Tps ${mf} > ${ps}
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+          COMMENT "Building manpage ${mf}"
+          VERBATIM)
+
+          add_custom_command(OUTPUT ${pdf}
+          COMMAND ${PS2PDF13_EXECUTABLE} ${ps} ${pdf}
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
+          DEPENDS ${mf}.ps
+          COMMENT "Creating PDF for ${ps}"
+          VERBATIM)
+          list(APPEND PDF_FILES ${pdf})
+        endif()
 endforeach()
 
 add_custom_target(man ALL DEPENDS ${MAN_FILES})
-add_custom_target(pdf ALL DEPENDS ${PDF_FILES})
+if(ENABLE_PDF_DOCS)
+  add_custom_target(pdf ALL DEPENDS ${PDF_FILES})
+endif()
 
 install(FILES ${CMAKE_BINARY_DIR}/man/ettercap.8 ${CMAKE_BINARY_DIR}/man/etterfilter.8 ${CMAKE_BINARY_DIR}/man/etterlog.8 DESTINATION ${MAN_INSTALLDIR}/man8/)
 configure_file("ettercap.8.in" "ettercap.8")


### PR DESCRIPTION
- PDF documentation generation is now optional. Enable via
  ENABLE_PDF_DOCS=On

Fixes #165
