### PR TITLE
Fix for issue #271

### DIFF
--- a/src/interfaces/gtk/ec_gtk.c
+++ b/src/interfaces/gtk/ec_gtk.c
@@ -496,7 +496,8 @@ static void gtkui_progress(char *title, int value, int max)
     * when 100%, destroy it
     */
    if (value == max) {
-      gtk_widget_destroy(progress_dialog);
+      if (progress_dialog)
+         gtk_widget_destroy(progress_dialog);
       progress_dialog = NULL;
       progress_bar = NULL;
       gtkui_refresh_host_list();


### PR DESCRIPTION
When a target has been selected, the targets will be scanned separately. 
This will try to destroy the progress bar after the subnet scan but the progress bar has been destroyed already.

Just a quick check if the progress bar still exsits gets rid of the assertion.
