### PR TITLE
Fix socket

### DIFF
--- a/src/ec_send.c
+++ b/src/ec_send.c
@@ -302,6 +302,10 @@ int send_arp(u_char type, struct ip_addr *sip, u_int8 *smac, struct ip_addr *tip
    
    SEND_LOCK;
 
+   // FIXME
+   // why without clearing again the packet I get issue #245?
+   libnet_clear_packet(GBL_IFACE->lnet);
+
    /* ARP uses 00:00:00:00:00:00 broadcast */
    if (type == ARPOP_REQUEST && tmac == MEDIA_BROADCAST)
       tmac = ARP_BROADCAST;


### PR DESCRIPTION
addressing issue 245.

I don't honestly know why we need to call libnet_clear_packet twice, one while exiting the udp send and the other one while enterning into arp_send.

I tried to print "c" and it is wrong (some really high numbers) when changing between udp and arp.

Putting the line twice after udp_send DOESN'T work at all.

Something is definitively wrong with the thread implementation.
