### PR TITLE
Disable offload warning/error

### DIFF
--- a/src/os/ec_linux.c
+++ b/src/os/ec_linux.c
@@ -149,6 +149,8 @@ void disable_interface_offload(void)
 
 	switch(fork()) {
 		case 0:
+			/* if the command cannot disable some offloads don't show on console */
+			close(2);
 			execvp(param[0], param);
 			exit(EINVALID);
 		case -1:


### PR DESCRIPTION
Don't know if this has to be merged or not...

Maybe we need to disable the stderr of ethtool only if a special flag is provided during start of the program...

Which flag?
