### PR TITLE
Fix detection of system libnet.

### DIFF
--- a/cmake/Modules/FindLIBNET.cmake
+++ b/cmake/Modules/FindLIBNET.cmake
@@ -38,9 +38,9 @@ endif()
 function(_LIBNET_GET_VERSION _OUT_version _libnet_hdr)
     file(READ ${_libnet_hdr} _contents)
     if(_contents)
-      string(REGEX REPLACE ".*#define LIBNET_VERSION[ \t]+\"([0-9.]+)\".*" "\\1" ${_OUT_version} "${_contents}")
+      string(REGEX REPLACE ".*#define LIBNET_VERSION[ \t]+\"([0-9.rc-]+)\".*" "\\1" ${_OUT_version} "${_contents}")
         
-        if(NOT ${_OUT_version} MATCHES "[0-9.]+")
+        if(NOT ${_OUT_version} MATCHES "[0-9.rc-]+")
             message(FATAL_ERROR "Version parsing failed for LIBNET_VERSION!")
         endif()
 


### PR DESCRIPTION
The latest version of libnet from https://github.com/sam-github/libnet has `#define LIBNET_VERSION  "1.2-rc2"`. This causes the current version to not detect the presence of the system libnet because the regex used to extract the version number only includes numbers and periods.

This fixes the detection of 1.2-rc\* libnet versions. No problems exist when linking to the newer libnet library to the best of my knowledge.
