### PR TITLE
Fixed libnet pointer

### DIFF
--- a/include/ec_globals.h
+++ b/include/ec_globals.h
@@ -13,7 +13,7 @@
 #include <ec_interfaces.h>
 #include <config.h>
 #include <ec_encryption.h>
-
+#include <libnet.h>
 #include <regex.h>
 
 /* options form etter.conf */
@@ -117,8 +117,8 @@ struct pcap_env {
 
 /* lnet structure */
 struct lnet_env {
-   struct libnet_t *lnet_IP4;
-   struct libnet_t *lnet_IP6;
+   libnet_t *lnet_IP4;
+   libnet_t *lnet_IP6;
 };
 
 /* ip list per target */

--- a/include/ec_network.h
+++ b/include/ec_network.h
@@ -3,6 +3,7 @@
 
 #include <ec.h>
 #include <ec_inet.h>
+#include <libnet.h>
 
 /* per interface data */
 struct iface_env {
@@ -24,7 +25,7 @@ struct iface_env {
    u_int8 unoffensive:1;
 
    void* pcap;                 /* pcap_t pointer */
-   struct libnet_t* lnet;
+   libnet_t* lnet;
 };
 
 


### PR DESCRIPTION
This comes after checking the libnet pointer structure.

It is obviously wrong, I'll merge this if no complains in the next few days.

in all libnet examples the libnet is "libnet_t\* ptr", not "struct libnet_t*", I was misleading in this because of a struct error, caused by a non libnet.h inclusion (and not from a missing "struct" keyword)
