### PR TITLE
Fixed ethereal->wireshark references

### DIFF
--- a/man/ettercap.8.in
+++ b/man/ettercap.8.in
@@ -416,7 +416,7 @@ You will intercept and visualize all the traffic for 10.0.0.1.
 \fB\-o\fR, \fB\-\-only\-mitm\fR
 This options disables the sniffing thread and enables only the mitm attack.
 Useful if you want to use ettercap to perform mitm attacks and another sniffer
-(such as ethereal) to sniff the traffic. Keep in mind that the packets are not
+(such as wireshark) to sniff the traffic. Keep in mind that the packets are not
 forwarded by ettercap. The kernel will be responsible for the forwarding.
 Remember to activate the "ip forwarding" feature in your kernel.
 
@@ -452,7 +452,7 @@ OFF LINE sniffing
 With this option enabled, ettercap will sniff packets from a pcap compatible
 file instead of capturing from the wire.
 .br
-This is useful if you have a file dumped from tcpdump or ethereal and you want
+This is useful if you have a file dumped from tcpdump or wireshark and you want
 to make an analysis (search for passwords or passive fingerprint) on it.
 .br
 Obviously you cannot use "active" sniffing (arp poisoning or bridging) while
@@ -462,7 +462,7 @@ sniffing from a file.
 WRITE packet to a pcap file
 .br
 This is useful if you have to use "active" sniffing (arp poison) on a switched
-LAN but you want to analyze the packets with tcpdump or ethereal. You can use
+LAN but you want to analyze the packets with tcpdump or wireshark. You can use
 this option to dump the packets to a file and then load it into your favourite
 application.
 .Sp

--- a/src/ec_checksum.c
+++ b/src/ec_checksum.c
@@ -193,7 +193,7 @@ u_int32 CRC_checksum(u_char *buf, size_t len, u_int32 init)
     return crc;
 }
 
-/* stolen from ethereal source code (in_cksum.c) */
+/* stolen from wireshark source code (in_cksum.c) */
 
 /*
  * Given the network-byte-order value of the checksum field in a packet

--- a/src/protocols/ec_gre.c
+++ b/src/protocols/ec_gre.c
@@ -26,7 +26,7 @@
 /* globals */
 
 /* Flag mask - 
- * (taken from ethereal gre decoder 
+ * (taken from wireshark gre decoder
  * by Brad Robel-Forrest) 
  */
 #define GH_B_C       0x8000


### PR DESCRIPTION
Some bad references to the old wireshark name
