### PR TITLE
Flushing to file to force writing of header and before closing. This cau...

### DIFF
--- a/src/ec_network.c
+++ b/src/ec_network.c
@@ -128,6 +128,8 @@ static void pcap_winit(pcap_t *pcap)
    GBL_PCAP->dump = pdump;
 
    //save header to file
+   //XXX: Removing this will cause regression bug. 
+   //Still trying to figure out why.
    pcap_dump_flush(GBL_PCAP->dump);
 }
 


### PR DESCRIPTION
...ses enough latency to avoid the duplicate header entry. Fix for #297
