### PR TITLE
resolve ambiguous Gtk menu shortcut between Hosts and Help menu

### DIFF
--- a/src/interfaces/curses/ec_curses_help.c
+++ b/src/interfaces/curses/ec_curses_help.c
@@ -36,7 +36,7 @@ void help_etterlog(void);
 
 /* globals */
 
-struct wdg_menu menu_help[] = { {"Help",              0,       "",    NULL},
+struct wdg_menu menu_help[] = { {"?",                 0,       "",    NULL},
                                 {"ettercap"  ,        0,       "",    help_ettercap},
                                 {"curses gui"  ,      0,       "",    help_curses},
                                 {"plugins"  ,         0,       "",    help_plugins},

--- a/src/interfaces/gtk/ec_gtk.c
+++ b/src/interfaces/gtk/ec_gtk.c
@@ -610,8 +610,8 @@ static void gtkui_setup(void)
       { "/Options/Promisc mode", NULL, toggle_nopromisc,  0, "<ToggleItem>" },
       { "/Options/Set netmask", "n", gtkui_set_netmask,   0, "<Item>"}
 #ifndef OS_WINDOWS
-     ,{"/H_elp",          NULL,         NULL,             0, "<Branch>" },
-      {"/Help/Contents", " ",           gtkui_help,       0, "<StockItem>", GTK_STOCK_HELP }
+     ,{"/_?",          NULL,         NULL,             0, "<Branch>" },
+      {"/?/Contents", " ",           gtkui_help,       0, "<StockItem>", GTK_STOCK_HELP }
 #endif
    };
    gint nmenu_items = sizeof (file_menu) / sizeof (file_menu[0]);

--- a/src/interfaces/gtk/ec_gtk_menus.c
+++ b/src/interfaces/gtk/ec_gtk_menus.c
@@ -101,8 +101,8 @@ GtkItemFactoryEntry gmenu_plugins[] = {
 
 #ifndef OS_WINDOWS
 GtkItemFactoryEntry gmenu_help[] = {
-   {"/H_elp",                   NULL,         NULL,              0, "<Branch>" },
-   {"/Help/Contents", " ", gtkui_help, 0, "<StockItem>", GTK_STOCK_HELP }
+   {"/_?",                   NULL,         NULL,              0, "<Branch>" },
+   {"/?/Contents", " ", gtkui_help, 0, "<StockItem>", GTK_STOCK_HELP }
 };
 #endif
 


### PR DESCRIPTION
When using ettercaps Gtk UI and navigating through the menus using the keyboard shortcuts, there is ambiguous behaviour when pressing Alt+h to reach the hosts-menu because the help-menu uses the same keyboar shortcut.

This pull-requests resolves that by mapping the help-menu to Alt+e
