### PR TITLE
Fixed cmake flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,8 +107,8 @@ set(DESKTOP_DIR ${INSTALL_PREFIX}/share/applications/ CACHE PATH "Binary files i
 set(ICON_DIR ${INSTALL_PREFIX}/share/pixmaps CACHE PATH "Binary files installation directory")
 set(MAN_INSTALLDIR ${INSTALL_PREFIX}/share/man CACHE PATH "Path for manual pages") 
 
-set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -ggdb3 -DDEBUG -Wall -Wno-pointer-sign -pg" CACHE STRING "" FORCE)
-set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2 -w" CACHE STRING "" FORCE)
+set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0 -ggdb3 -DDEBUG -Wall -Wno-pointer-sign -pg -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security" CACHE STRING "" FORCE)
+set(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} -O2 -w -D_FORTIFY_SOURCE=2" CACHE STRING "" FORCE)
 
 if(OS_DARWIN)
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl" CACHE STRING "" FORCE)


### PR DESCRIPTION
(I'll stop bothering in the next few days, I promise :))

Seems to be debian is detecting an override of default C flags
http://qa.debian.org/bls/packages/e/ettercap.html

@justfalter what do you think about? this can be totally wrong, I'm not a cmake guy
