### PR TITLE
fix typo in warning message of dns_spoof and mdns_spoof plugin

### DIFF
--- a/plug-ins/dns_spoof/dns_spoof.c
+++ b/plug-ins/dns_spoof/dns_spoof.c
@@ -366,7 +366,7 @@ static void dns_spoof(struct packet_object *po)
 
          /* check if the family matches the record type */
          if (ntohs(reply->addr_type) != AF_INET) {
-            USER_MSG("mdns_spoof: can not spoof A record for %s "
+            USER_MSG("dns_spoof: can not spoof A record for %s "
                      "because the value is not a IPv4 address\n", name);
             return;
          }
@@ -421,7 +421,7 @@ static void dns_spoof(struct packet_object *po)
 
           /* check if the family matches the record type */
           if (ntohs(reply->addr_type) != AF_INET6) {
-             USER_MSG("mdns_spoof: can not spoof AAAA record for %s "
+             USER_MSG("dns_spoof: can not spoof AAAA record for %s "
                       "because the value is not a IPv6 address\n", name);
              return;
           }

--- a/plug-ins/mdns_spoof/mdns_spoof.c
+++ b/plug-ins/mdns_spoof/mdns_spoof.c
@@ -561,7 +561,7 @@ static int parse_line (const char *str, int line, int *type_p, char **ip_p, u_in
          send_mdns_reply(po->L4.src, sender, target, tmac, 
                          ntohs(mdns->id), answer, sizeof(answer), 2, 0, 0);
 
-         USER_MSG("dns_spoof: SRV [%s] spoofed to [%s:%d]\n", name, ip_addr_ntoa(reply, tmp), port);
+         USER_MSG("mdns_spoof: SRV [%s] spoofed to [%s:%d]\n", name, ip_addr_ntoa(reply, tmp), port);
       }
     }
 


### PR DESCRIPTION
Fixing typos in dns_spoof mdns_spoof plugin due to copy&paste.
