### PR TITLE
Attempting to solve issue #189

### DIFF
--- a/src/ec_sniff.c
+++ b/src/ec_sniff.c
@@ -256,26 +256,34 @@ int compile_display_filter(void)
   
 #ifdef WITH_IPV6 
    /* if not specified default to /// */
-   if (!GBL_OPTIONS->target1)
+   if (!GBL_OPTIONS->target1) {
       GBL_OPTIONS->target1 = strdup("///");
+      GBL_TARGET1->scan_all = 1;
+   }
    /* if /// was specified, select all */
    else if (!strncmp(GBL_OPTIONS->target1, "///", 3))
       GBL_TARGET1->scan_all = 1;
    
-   if (!GBL_OPTIONS->target2)
+   if (!GBL_OPTIONS->target2) {
       GBL_OPTIONS->target2 = strdup("///");
+      GBL_TARGET2->scan_all = 1;
+   }
    else if (!strncmp(GBL_OPTIONS->target2, "///", 3))
       GBL_TARGET2->scan_all = 1;
 #else
    /* if not specified default to // */
-   if (!GBL_OPTIONS->target1)
+   if (!GBL_OPTIONS->target1) {
       GBL_OPTIONS->target1 = strdup("//");
+      GBL_TARGET1->scan_all = 1;
+   } 
    /* if // was specified, select all */
    else if (!strncmp(GBL_OPTIONS->target1, "//", 2) && strlen(GBL_OPTIONS->target1) == 2)
       GBL_TARGET1->scan_all = 1;
   
-   if (!GBL_OPTIONS->target2)
+   if (!GBL_OPTIONS->target2) {
       GBL_OPTIONS->target2 = strdup("//");
+      GBL_TARGET2->scan_all = 1;
+   }
    else if (!strncmp(GBL_OPTIONS->target2, "//", 2) && strlen(GBL_OPTIONS->target2) == 2)
       GBL_TARGET2->scan_all = 1;
 #endif


### PR DESCRIPTION
When starting Ettercap with no target definition, scan_all was set to 0. This prevented hosts from being added to the hosts list.
