### PR TITLE
Ugly fixed the plugin path

### DIFF
--- a/src/ec_plugins.c
+++ b/src/ec_plugins.c
@@ -160,7 +160,7 @@ void plugin_load_all(void)
    if (n <= 0) {
       DEBUG_MSG("plugin_loadall: no plugin in %s searching locally...", where);
       /* change the path to the local one */
-      where = ".";
+      where = "./build/plug-ins";
       n = scandir(where, &namelist, plugin_filter, alphasort);
       DEBUG_MSG("plugin_loadall: %d found", n);
    }


### PR DESCRIPTION
In this way plugins are automatically loaded without make install stuff.

This is an extremely ugly solution, does somebody have any better idea?

maybe injecting the "build" directory with cmake?
put plugins out of build tree and doing something similar to what we do with share and other directories?
