### PR TITLE
Fix Scan crash

### DIFF
--- a/src/interfaces/gtk/ec_gtk.c
+++ b/src/interfaces/gtk/ec_gtk.c
@@ -328,7 +328,7 @@ static void gtkui_update(int target)
 {
     switch (target) {
         case UI_UPDATE_HOSTLIST:
-            gtkui_refresh_host_list();
+            gtk_idle_add(gtkui_refresh_host_list,NULL);
             break;
     }
 


### PR DESCRIPTION
This PR is intended to fix issue #419 .
The problem was that the update of the GTK interface have not been perfomed by the main thread which is responsible for the UI updates. Instead the scan thread has performed the update and caused race conditions.
