### PR TITLE
Fix unused param warinings

### DIFF
--- a/include/ec_inet.h
+++ b/include/ec_inet.h
@@ -93,7 +93,7 @@ EC_API_EXTERN int mac_addr_aton(char *str, u_char *mac);
 EC_API_EXTERN int ip_addr_is_local(struct ip_addr *sa, struct ip_addr *ifaddr);
 EC_API_EXTERN int ip_addr_is_global(struct ip_addr *ip);
 EC_API_EXTERN int ip_addr_is_multicast(struct ip_addr *ip);
-EC_API_EXTERN int ip_addr_is_broadcast(struct ip_addr *sa, struct ip_addr *ifaddr);
+EC_API_EXTERN int ip_addr_is_broadcast(struct ip_addr *sa);
 EC_API_EXTERN int ip_addr_is_ours(struct ip_addr *ip);
 EC_API_EXTERN int ip_addr_get_network(struct ip_addr*, struct ip_addr*, struct ip_addr*);
 EC_API_EXTERN int ip_addr_get_prefix(struct ip_addr* netmask);

--- a/include/ec_send.h
+++ b/include/ec_send.h
@@ -29,7 +29,7 @@ EC_API_EXTERN int send_L3_icmp_unreach(struct packet_object *po);
 #ifdef WITH_IPV6
 EC_API_EXTERN int send_icmp6_echo(struct ip_addr *sip, struct ip_addr *tip);
 EC_API_EXTERN int send_icmp6_nsol(struct ip_addr *sip, struct ip_addr *tip, struct ip_addr *tgt, u_int8 *macaddr);
-EC_API_EXTERN int send_icmp6_nadv(struct ip_addr *sip, struct ip_addr *tip, struct ip_addr *tgt, u_int8 *macaddr, int router);
+EC_API_EXTERN int send_icmp6_nadv(struct ip_addr *sip, struct ip_addr *tip, u_int8 *macaddr, int router);
 #endif
 
 EC_API_EXTERN void capture_only_incoming(pcap_t *p, libnet_t *l);

--- a/plug-ins/arp_cop/arp_cop.c
+++ b/plug-ins/arp_cop/arp_cop.c
@@ -67,6 +67,9 @@ int plugin_load(void *handle)
 
 static int arp_cop_init(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    USER_MSG("arp_cop: plugin running...\n");
 
    arp_init_list();
@@ -79,6 +82,9 @@ static int arp_cop_init(void *dummy)
 
 static int arp_cop_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    USER_MSG("arp_cop: plugin terminated...\n");
 
    /* We don't free the global list for further reuse */

--- a/plug-ins/autoadd/autoadd.c
+++ b/plug-ins/autoadd/autoadd.c
@@ -63,6 +63,9 @@ int plugin_load(void *handle)
 
 static int autoadd_init(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* 
     * we'll use arp request to detect active hosts.
     * if an host sends arp rq, it want to communicate,
@@ -75,6 +78,9 @@ static int autoadd_init(void *dummy)
 
 static int autoadd_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    hook_del(HOOK_PACKET_ARP_RQ, &parse_arp);
    return PLUGIN_FINISHED;
 }

--- a/plug-ins/chk_poison/chk_poison.c
+++ b/plug-ins/chk_poison/chk_poison.c
@@ -96,6 +96,9 @@ static int chk_poison_init(void *dummy)
    tm.tv_nsec = 0;
 #endif
      
+   /* variable not used */
+   (void) dummy;
+
    /* don't show packets while operating */
    GBL_OPTIONS->quiet = 1;
       
@@ -184,6 +187,9 @@ static int chk_poison_init(void *dummy)
 
 static int chk_poison_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    return PLUGIN_FINISHED;
 }
 

--- a/plug-ins/dns_spoof/dns_spoof.c
+++ b/plug-ins/dns_spoof/dns_spoof.c
@@ -130,6 +130,9 @@ int plugin_load(void *handle)
 
 static int dns_spoof_init(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* 
     * add the hook in the dissector.
     * this will pass only valid dns packets
@@ -142,6 +145,9 @@ static int dns_spoof_init(void *dummy)
 
 static int dns_spoof_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* remove the hook */
    hook_del(HOOK_PROTO_DNS, &dns_spoof);
 

--- a/plug-ins/dos_attack/dos_attack.c
+++ b/plug-ins/dos_attack/dos_attack.c
@@ -83,6 +83,9 @@ static int dos_attack_init(void *dummy)
    char unused_addr[MAX_ASCII_ADDR_LEN];
    struct port_list *p;
          
+   /* variable not used */
+   (void) dummy;
+
    /* It doesn't work if unoffensive */
    if (GBL_OPTIONS->unoffensive) {
       INSTANT_USER_MSG("dos_attack: plugin doesn't work in UNOFFENSIVE mode\n");
@@ -143,6 +146,9 @@ static int dos_attack_fini(void *dummy)
 {
    pthread_t pid;
 
+   /* variable not used */
+   (void) dummy;
+
    /* Remove the hooks */
    hook_del(HOOK_PACKET_ARP_RQ, &parse_arp);
    hook_del(HOOK_PACKET_TCP, &parse_tcp);
@@ -175,6 +181,10 @@ EC_THREAD_FUNC(syn_flooder)
    tm.tv_sec = 0;
    tm.tv_nsec = 1000*1000;
 #endif
+
+   /* variable not used */
+   (void) EC_THREAD_PARAM;
+
    /* init the thread and wait for start up */
    ec_thread_init();
  
@@ -220,7 +230,7 @@ static void parse_icmp6(struct packet_object *po)
    struct ip_addr ip;
    ip_addr_init(&ip, AF_INET6, po->L4.options);
    if(!ip_addr_cmp(&fake_host, &ip))
-      send_icmp6_nadv(&fake_host, &po->L3.src, &fake_host, GBL_IFACE->mac, 0);
+      send_icmp6_nadv(&fake_host, &po->L3.src, GBL_IFACE->mac, 0);
 }
 #endif
 

--- a/plug-ins/dummy/dummy.c
+++ b/plug-ins/dummy/dummy.c
@@ -87,6 +87,9 @@ static int dummy_init(void *dummy)
     * plugin type to PL_HOOK.
     */
    
+   /* variable not used - avoid extended warning */
+   (void) dummy;
+
    USER_MSG("DUMMY: plugin running...\n");
 
    /* return PLUGIN_FINISHED if the plugin has terminated
@@ -101,6 +104,9 @@ static int dummy_init(void *dummy)
 
 static int dummy_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* 
     * called to terminate a plugin.
     * usually to kill threads created in the 

--- a/plug-ins/find_conn/find_conn.c
+++ b/plug-ins/find_conn/find_conn.c
@@ -61,6 +61,9 @@ int plugin_load(void *handle)
 
 static int find_conn_init(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    USER_MSG("find_conn: plugin running...\n");
    
    hook_add(HOOK_PACKET_ARP_RQ, &parse_arp);
@@ -70,6 +73,9 @@ static int find_conn_init(void *dummy)
 
 static int find_conn_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    USER_MSG("find_conn: plugin terminated...\n");
 
    hook_del(HOOK_PACKET_ARP_RQ, &parse_arp);

--- a/plug-ins/find_ettercap/find_ettercap.c
+++ b/plug-ins/find_ettercap/find_ettercap.c
@@ -68,6 +68,9 @@ int plugin_load(void *handle)
 
 static int find_ettercap_init(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* add the hook in the dissector.  */
    hook_add(HOOK_PACKET_IP, &parse_ip);
    hook_add(HOOK_PACKET_ICMP, &parse_icmp);
@@ -79,6 +82,9 @@ static int find_ettercap_init(void *dummy)
 
 static int find_ettercap_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* remove the hook */
    hook_del(HOOK_PACKET_IP, &parse_ip);
    hook_del(HOOK_PACKET_ICMP, &parse_icmp);

--- a/plug-ins/find_ip/find_ip.c
+++ b/plug-ins/find_ip/find_ip.c
@@ -65,6 +65,9 @@ static int find_ip_init(void *dummy)
    char tmp[MAX_ASCII_ADDR_LEN];
    struct ip_addr *e;
    
+   /* variable not used */
+   (void) dummy;
+
    /* don't show packets while operating */
    GBL_OPTIONS->quiet = 1;
       
@@ -92,6 +95,9 @@ static int find_ip_init(void *dummy)
 
 static int find_ip_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    return PLUGIN_FINISHED;
 }
 

--- a/plug-ins/finger/finger.c
+++ b/plug-ins/finger/finger.c
@@ -77,6 +77,9 @@ int plugin_load(void *handle)
 
 static int finger_init(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* don't show packets while operating */
    GBL_OPTIONS->quiet = 1;
    
@@ -122,6 +125,9 @@ static int finger_init(void *dummy)
 
 static int finger_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    return PLUGIN_FINISHED;
 }
 

--- a/plug-ins/finger_submit/finger_submit.c
+++ b/plug-ins/finger_submit/finger_submit.c
@@ -68,6 +68,9 @@ static int finger_submit_init(void *dummy)
    char finger[FINGER_LEN + 1];
    char os[OS_LEN + 1];
    
+   /* variable not used */
+   (void) dummy;
+
    /* don't display messages while operating */
    GBL_OPTIONS->quiet = 1;
  
@@ -101,6 +104,9 @@ static int finger_submit_init(void *dummy)
 
 static int finger_submit_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    return PLUGIN_FINISHED;
 }
 

--- a/plug-ins/fraggle_attack/fraggle_attack.c
+++ b/plug-ins/fraggle_attack/fraggle_attack.c
@@ -42,6 +42,9 @@ static int fraggle_attack_init(void *dummy)
 {
    struct ip_list *i;
 
+   /* variable not used */
+   (void) dummy;
+
    DEBUG_MSG("fraggle_attack_init");
 
    if(GBL_OPTIONS->unoffensive) {
@@ -78,6 +81,9 @@ static int fraggle_attack_init(void *dummy)
 static int fraggle_attack_fini(void *dummy)
 {
    pthread_t pid;
+
+   /* variable not used */
+   (void) dummy;
 
    DEBUG_MSG("fraggle_attack_fini");
 

--- a/plug-ins/gre_relay/gre_relay.c
+++ b/plug-ins/gre_relay/gre_relay.c
@@ -90,6 +90,9 @@ static int gre_relay_init(void *dummy)
 {
    char tmp[MAX_ASCII_ADDR_LEN];
 
+   /* variable not used */
+   (void) dummy;
+
    /* It doesn't work if unoffensive */
    if (GBL_OPTIONS->unoffensive) {
       INSTANT_USER_MSG("gre_relay: plugin doesn't work in UNOFFENSIVE mode\n");
@@ -118,6 +121,9 @@ static int gre_relay_init(void *dummy)
 
 static int gre_relay_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    USER_MSG("gre_relay: plugin terminated...\n");
 
    hook_del(HOOK_PACKET_GRE, &parse_gre);

--- a/plug-ins/gw_discover/gw_discover.c
+++ b/plug-ins/gw_discover/gw_discover.c
@@ -73,6 +73,9 @@ int plugin_load(void *handle)
 
 static int gw_discover_init(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* don't show packets while operating */
    GBL_OPTIONS->quiet = 1;
    
@@ -90,6 +93,9 @@ static int gw_discover_init(void *dummy)
 
 static int gw_discover_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    return PLUGIN_FINISHED;
 }
 

--- a/plug-ins/isolate/isolate.c
+++ b/plug-ins/isolate/isolate.c
@@ -71,6 +71,10 @@ int plugin_load(void *handle)
 static int isolate_init(void *dummy) 
 {
    struct ip_list *t;
+
+   /* variable not used */
+   (void) dummy;
+
    /* sanity check */
    if (LIST_EMPTY(&GBL_TARGET1->ips) && LIST_EMPTY(&GBL_TARGET1->ip6)) {
       INSTANT_USER_MSG("isolate: please specify the TARGET host\n");
@@ -97,6 +101,9 @@ static int isolate_fini(void *dummy)
    pthread_t pid;
    struct hosts_list *h, *tmp;
   
+   /* variable not used */
+   (void) dummy;
+
    /* remove the hook */
    hook_del(HOOK_PACKET_ARP_RQ, &parse_arp);
    

--- a/plug-ins/link_type/link_type.c
+++ b/plug-ins/link_type/link_type.c
@@ -73,6 +73,9 @@ static int link_type_init(void *dummy)
    u_char counter = 0;
    struct hosts_list *h;
    
+   /* variable not used */
+   (void) dummy;
+
    /* don't show packets while operating */
    GBL_OPTIONS->quiet = 1;
 
@@ -146,6 +149,9 @@ static int link_type_init(void *dummy)
 
 static int link_type_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    return PLUGIN_FINISHED;
 }
 

--- a/plug-ins/mdns_spoof/mdns_spoof.c
+++ b/plug-ins/mdns_spoof/mdns_spoof.c
@@ -102,6 +102,9 @@ int plugin_load(void *handle)
 
 static int mdns_spoof_init(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* 
     * add the hook in the dissector.
     * this will pass only valid dns packets
@@ -114,6 +117,9 @@ static int mdns_spoof_init(void *dummy)
 
 static int mdns_spoof_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* remove the hook */
    hook_del(HOOK_PROTO_MDNS, &mdns_spoof);
 

--- a/plug-ins/nbns_spoof/nbns_spoof.c
+++ b/plug-ins/nbns_spoof/nbns_spoof.c
@@ -203,6 +203,9 @@ int plugin_load(void *handle)
 
 static int nbns_spoof_init(void *dummy)
 {
+   /* variable not used */
+   (void) dummy;
+
 	/*
 	 * add the hook in the dissector
 	 * this will pass only valid NBNS packets
@@ -215,6 +218,9 @@ static int nbns_spoof_init(void *dummy)
 
 static int nbns_spoof_fini(void *dummy)
 {
+   /* variable not used */
+   (void) dummy;
+
 	hook_del(HOOK_PROTO_NBNS, &nbns_spoof);
 	return PLUGIN_FINISHED;
 }

--- a/plug-ins/pptp_chapms1/pptp_chapms1.c
+++ b/plug-ins/pptp_chapms1/pptp_chapms1.c
@@ -79,6 +79,9 @@ int plugin_load(void *handle)
 
 static int pptp_chapms1_init(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* It doesn't work if unoffensive */
    if (GBL_OPTIONS->unoffensive) {
       INSTANT_USER_MSG("pptp_chapms1: plugin doesn't work in UNOFFENSIVE mode\n");
@@ -94,6 +97,9 @@ static int pptp_chapms1_init(void *dummy)
 
 static int pptp_chapms1_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    USER_MSG("pptp_chapms1: plugin terminated...\n");
 
    hook_del(HOOK_PACKET_LCP, &parse_ppp);

--- a/plug-ins/pptp_clear/pptp_clear.c
+++ b/plug-ins/pptp_clear/pptp_clear.c
@@ -84,6 +84,9 @@ int plugin_load(void *handle)
 
 static int pptp_clear_init(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* It doesn't work if unoffensive */
    if (GBL_OPTIONS->unoffensive) {
       INSTANT_USER_MSG("pptp_clear: plugin doesn't work in UNOFFENSIVE mode\n");
@@ -101,6 +104,9 @@ static int pptp_clear_init(void *dummy)
 
 static int pptp_clear_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    USER_MSG("pptp_clear: plugin terminated...\n");
 
    hook_del(HOOK_PACKET_LCP, &parse_lcp);

--- a/plug-ins/pptp_pap/pptp_pap.c
+++ b/plug-ins/pptp_pap/pptp_pap.c
@@ -76,6 +76,9 @@ int plugin_load(void *handle)
 
 static int pptp_pap_init(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* It doesn't work if unoffensive */
    if (GBL_OPTIONS->unoffensive) {
       INSTANT_USER_MSG("pptp_pap: plugin doesn't work in UNOFFENSIVE mode\n");
@@ -91,6 +94,9 @@ static int pptp_pap_init(void *dummy)
 
 static int pptp_pap_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    USER_MSG("pptp_pap: plugin terminated...\n");
 
    hook_del(HOOK_PACKET_LCP, &parse_ppp);

--- a/plug-ins/pptp_reneg/pptp_reneg.c
+++ b/plug-ins/pptp_reneg/pptp_reneg.c
@@ -83,6 +83,9 @@ int plugin_load(void *handle)
 
 static int pptp_reneg_init(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* It doesn't work if unoffensive */
    if (GBL_OPTIONS->unoffensive) {
       INSTANT_USER_MSG("pptp_reneg: plugin doesn't work in UNOFFENSIVE mode\n");
@@ -99,6 +102,9 @@ static int pptp_reneg_init(void *dummy)
 static int pptp_reneg_fini(void *dummy) 
 {
    struct call_list *p;
+
+   /* variable not used */
+   (void) dummy;
 
    USER_MSG("pptp_reneg: plugin terminated...\n");
 

--- a/plug-ins/rand_flood/rand_flood.c
+++ b/plug-ins/rand_flood/rand_flood.c
@@ -93,6 +93,9 @@ int plugin_load(void *handle)
 
 static int rand_flood_init(void *dummy) 
 {     
+   /* variable not used */
+   (void) dummy;
+
    /* It doesn't work if unoffensive */
    if (GBL_OPTIONS->unoffensive) {
       INSTANT_USER_MSG("rand_flood: plugin doesn't work in UNOFFENSIVE mode\n");
@@ -111,6 +114,9 @@ static int rand_flood_init(void *dummy)
 static int rand_flood_fini(void *dummy) 
 {
    pthread_t pid;
+
+   /* variable not used */
+   (void) dummy;
 
    pid = ec_thread_getpid("flooder");
 
@@ -137,6 +143,9 @@ EC_THREAD_FUNC(flooder)
    tm.tv_sec = GBL_CONF->port_steal_send_delay;
    tm.tv_nsec = 0;
 #endif
+
+   /* variable not used */
+   (void) EC_THREAD_PARAM;
 
    /* Get a "random" seed */ 
    gettimeofday(&seed, NULL);

--- a/plug-ins/remote_browser/remote_browser.c
+++ b/plug-ins/remote_browser/remote_browser.c
@@ -66,6 +66,9 @@ int plugin_load(void *handle)
 
 static int remote_browser_init(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* 
     * add the hook in the dissector.
     */
@@ -77,6 +80,9 @@ static int remote_browser_init(void *dummy)
 
 static int remote_browser_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* remove the hook */
    hook_del(HOOK_PROTO_HTTP, &remote_browser);
 

--- a/plug-ins/reply_arp/reply_arp.c
+++ b/plug-ins/reply_arp/reply_arp.c
@@ -61,6 +61,9 @@ int plugin_load(void *handle)
 
 static int reply_arp_init(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* It doesn't work if unoffensive */
    if (GBL_OPTIONS->unoffensive) {
       INSTANT_USER_MSG("reply_arp: plugin doesn't work in UNOFFENSIVE mode\n");
@@ -75,6 +78,9 @@ static int reply_arp_init(void *dummy)
 
 static int reply_arp_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    USER_MSG("reply_arp: plugin terminated...\n");
 
    hook_del(HOOK_PACKET_ARP_RQ, &parse_arp);

--- a/plug-ins/repoison_arp/repoison_arp.c
+++ b/plug-ins/repoison_arp/repoison_arp.c
@@ -65,6 +65,9 @@ int plugin_load(void *handle)
 
 static int repoison_arp_init(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* It doesn't work if unoffensive */
    if (GBL_OPTIONS->unoffensive) {
       INSTANT_USER_MSG("repoison_arp: plugin doesn't work in UNOFFENSIVE mode\n");
@@ -81,6 +84,9 @@ static int repoison_arp_init(void *dummy)
 
 static int repoison_arp_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    USER_MSG("repoison_arp: plugin terminated...\n");
 
    hook_del(HOOK_PACKET_ARP_RQ, &repoison_func);

--- a/plug-ins/scan_poisoner/scan_poisoner.c
+++ b/plug-ins/scan_poisoner/scan_poisoner.c
@@ -80,6 +80,9 @@ static int scan_poisoner_init(void *dummy)
    tm.tv_nsec = 0; 
 #endif
 
+   /* variable not used */
+   (void) dummy;
+
    /* don't show packets while operating */
    GBL_OPTIONS->quiet = 1;
       
@@ -145,6 +148,9 @@ static int scan_poisoner_init(void *dummy)
 
 static int scan_poisoner_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    return PLUGIN_FINISHED;
 }
 

--- a/plug-ins/search_promisc/search_promisc.c
+++ b/plug-ins/search_promisc/search_promisc.c
@@ -87,6 +87,10 @@ static int search_promisc_init(void *dummy)
    tm.tv_sec = GBL_CONF->arp_storm_delay;
    tm.tv_nsec = 0; 
 #endif
+
+   /* variable not used */
+   (void) dummy;
+
    /* don't show packets while operating */
    GBL_OPTIONS->quiet = 1;
       
@@ -161,6 +165,9 @@ static int search_promisc_init(void *dummy)
 
 static int search_promisc_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    return PLUGIN_FINISHED;
 }
 

--- a/plug-ins/smb_clear/smb_clear.c
+++ b/plug-ins/smb_clear/smb_clear.c
@@ -79,6 +79,9 @@ int plugin_load(void *handle)
 
 static int smb_clear_init(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* It doesn't work if unoffensive */
    if (GBL_OPTIONS->unoffensive) {
       INSTANT_USER_MSG("smb_clear: plugin doesn't work in UNOFFENSIVE mode\n");
@@ -94,6 +97,9 @@ static int smb_clear_init(void *dummy)
 
 static int smb_clear_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    USER_MSG("smb_clear: plugin terminated...\n");
 
    hook_del(HOOK_PROTO_SMB, &parse_smb);

--- a/plug-ins/smb_down/smb_down.c
+++ b/plug-ins/smb_down/smb_down.c
@@ -80,6 +80,9 @@ int plugin_load(void *handle)
 
 static int smb_down_init(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    /* It doesn't work if unoffensive */
    if (GBL_OPTIONS->unoffensive) {
       INSTANT_USER_MSG("smb_down: plugin doesn't work in UNOFFENSIVE mode\n");
@@ -95,6 +98,9 @@ static int smb_down_init(void *dummy)
 
 static int smb_down_fini(void *dummy) 
 {
+   /* variable not used */
+   (void) dummy;
+
    USER_MSG("smb_down: plugin terminated...\n");
 
    hook_del(HOOK_PROTO_SMB_CHL, &parse_smb);

--- a/plug-ins/smurf_attack/smurf_attack.c
+++ b/plug-ins/smurf_attack/smurf_attack.c
@@ -39,6 +39,9 @@ static int smurf_attack_init(void *dummy)
 {
    struct ip_list *i;
 
+   /* variable not used */
+   (void) dummy;
+
    DEBUG_MSG("smurf_attack_init");
 
    if(GBL_OPTIONS->unoffensive) {
@@ -75,6 +78,9 @@ static int smurf_attack_init(void *dummy)
 static int smurf_attack_fini(void *dummy)
 {
    pthread_t pid;
+
+   /* variable not used */
+   (void) dummy;
 
    DEBUG_MSG("smurf_attack_fini");
 

--- a/plug-ins/sslstrip/sslstrip.c
+++ b/plug-ins/sslstrip/sslstrip.c
@@ -216,6 +216,9 @@ static int sslstrip_init(void *dummy)
 	const char *error;
 	int erroroffset;
 
+   /* variable not used */
+   (void) dummy;
+
 	/*
 	 * Add IPTables redirect for port 80
          */
@@ -252,6 +255,9 @@ static int sslstrip_init(void *dummy)
 
 static int sslstrip_fini(void *dummy)
 {
+
+   /* variable not used */
+   (void) dummy;
 
 	DEBUG_MSG("SSLStrip: Removing redirect\n");
 	if (http_remove_redirect(bind_port) != ESUCCESS) {
@@ -577,6 +583,9 @@ static EC_THREAD_FUNC(http_accept_thread)
 	struct sockaddr_in client_sin;
 	int optval = 1;
 	socklen_t optlen = sizeof(optval);
+
+   /* variable not used */
+   (void) EC_THREAD_PARAM;
 
 	ec_thread_init();
 

--- a/plug-ins/stp_mangler/stp_mangler.c
+++ b/plug-ins/stp_mangler/stp_mangler.c
@@ -101,6 +101,9 @@ int plugin_load(void *handle)
 
 static int stp_mangler_init(void *dummy) 
 {     
+   /* variable not used */
+   (void) dummy;
+
    /* It doesn't work if unoffensive */
    if (GBL_OPTIONS->unoffensive) {
       INSTANT_USER_MSG("stp_mangler: plugin doesn't work in UNOFFENSIVE mode\n");
@@ -120,6 +123,9 @@ static int stp_mangler_fini(void *dummy)
 {
    pthread_t pid;
 
+   /* variable not used */
+   (void) dummy;
+
    pid = ec_thread_getpid("mangler");
 
    /* the thread is active or not ? */
@@ -138,6 +144,9 @@ EC_THREAD_FUNC(mangler)
    struct llc_header *hllc;
    struct stp_header *hstp;
    u_char MultiMAC[6]={0x01,0x80,0xc2,0x00,0x00,0x00};
+
+   /* variable not used */
+   (void) EC_THREAD_PARAM;
 
    /* Avoid crappy compiler alignment :( */    
    heth  = (struct eth_header *)fake_pck;

--- a/src/dissectors/ec_TN3270.c
+++ b/src/dissectors/ec_TN3270.c
@@ -83,6 +83,9 @@ FUNC_DECODER(dissector_TN3270)
 
    //suppress unused warning
    (void)end;
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
 
    if (FROM_CLIENT("TN3270", PACKET)) {
 

--- a/src/dissectors/ec_bgp.c
+++ b/src/dissectors/ec_bgp.c
@@ -126,7 +126,10 @@ FUNC_DECODER(dissector_bgp)
                           0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
 
    /* don't complain about unused var */
-   (void)end;
+   (void)end; 
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
    
    /* skip packets that don't have enough data */
    if (PACKET->DATA.len < 30)

--- a/src/dissectors/ec_cvs.c
+++ b/src/dissectors/ec_cvs.c
@@ -74,6 +74,10 @@ FUNC_DECODER(dissector_cvs)
 
    /* don't complain about unused var */
    (void)end;
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
 
    /* skip messages coming from the server */
    if (FROM_SERVER("cvs", PACKET))

--- a/src/dissectors/ec_dhcp.c
+++ b/src/dissectors/ec_dhcp.c
@@ -106,6 +106,11 @@ FUNC_DECODER(dissector_dhcp)
    struct dhcp_hdr *dhcp;
    u_int8 *options, *opt;
 
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    /* sanity check */
    if (PACKET->DATA.len < sizeof(struct dhcp_hdr))
       return NULL;

--- a/src/dissectors/ec_dns.c
+++ b/src/dissectors/ec_dns.c
@@ -105,6 +105,11 @@ FUNC_DECODER(dissector_dns)
    int16 class, type, a_len;
    int32 ttl;
 
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    DEBUG_MSG("DNS --> UDP 53  dissector_dns");
    
    dns = (struct dns_header *)po->DATA.data;

--- a/src/dissectors/ec_ftp.c
+++ b/src/dissectors/ec_ftp.c
@@ -49,6 +49,11 @@ FUNC_DECODER(dissector_ftp)
    void *ident = NULL;
    char tmp[MAX_ASCII_ADDR_LEN];
 
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    /* the connection is starting... create the session */
    CREATE_SESSION_ON_SYN_ACK("ftp", s, dissector_ftp);
    

--- a/src/dissectors/ec_gg.c
+++ b/src/dissectors/ec_gg.c
@@ -323,6 +323,9 @@ FUNC_DECODER(dissector_gg)
 
    /* don't complain about unused var */
    (void)end;
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
    
    /* skip empty packets (ACK packets) */
    if (PACKET->DATA.len == 0)

--- a/src/dissectors/ec_http.c
+++ b/src/dissectors/ec_http.c
@@ -99,10 +99,10 @@ static void Parse_Post_Payload(char *ptr, struct http_status *conn_status, struc
 static void Print_Pass(struct packet_object *po);
 static void Get_Banner(char *ptr, struct packet_object *po);
 static u_char Parse_Form(char *to_parse, char **ret, int mode);
-static int Parse_Passport_Auth(char *ptr, char *from_here, struct packet_object *po);
+static int Parse_Passport_Auth(char *from_here, struct packet_object *po);
 static int Parse_NTLM_Auth(char *ptr, char *from_here, struct packet_object *po);
 static int Parse_Basic_Auth(char *ptr, char *from_here, struct packet_object *po);
-static int Parse_User_Agent(char *ptr, char *end, char *from_here, struct packet_object *po);
+static int Parse_User_Agent(char *end, char *from_here, struct packet_object *po);
 static char *unicodeToString(char *p, size_t len);
 static void dumpRaw(char *str, unsigned char *buf, size_t len);
 int http_fields_init(void);
@@ -139,6 +139,9 @@ FUNC_DECODER(dissector_http)
 
    /* unused variable */
    (void)end;
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
 
    /* skip empty packets (ACK packets) */
    if (PACKET->DATA.len == 0)
@@ -159,13 +162,13 @@ FUNC_DECODER(dissector_http)
        * then password in the GET or POST.
        */
       if ((from_here = strstr((const char*)ptr, "Authorization: Passport")) && 
-         Parse_Passport_Auth((char*)ptr, from_here + strlen("Authorization: Passport"), PACKET));       
+         Parse_Passport_Auth(from_here + strlen("Authorization: Passport"), PACKET));       
       else if ((from_here = strstr((const char*)ptr, ": NTLM ")) && 
          Parse_NTLM_Auth((char*)ptr, from_here + strlen(": NTLM "), PACKET));
       else if ((from_here = strstr((const char*)ptr, ": Basic ")) &&
          Parse_Basic_Auth((char*)ptr, from_here  + strlen(": Basic "), PACKET));
       else if ((from_here = strstr((const char*)ptr, "User-Agent: ")) &&
-          Parse_User_Agent((char*)ptr, end, from_here + strlen("User-Agent: "), PACKET));
+          Parse_User_Agent(end, from_here + strlen("User-Agent: "), PACKET));
       else if (!strncmp((const char*)ptr, "GET ", 4))
          Parse_Method_Get((char*)ptr + strlen("GET "), PACKET);
       else if (!strncmp((const char*)ptr, "POST ", 5))
@@ -275,7 +278,7 @@ static void Get_Banner(char *ptr, struct packet_object *po)
 
 
 /* Parse Passport Authentication */ 
-static int Parse_Passport_Auth(char *ptr, char *from_here, struct packet_object *po)
+static int Parse_Passport_Auth(char *from_here, struct packet_object *po)
 {
    char *token, *to_decode, *tok;
 
@@ -370,7 +373,7 @@ static int Parse_Basic_Auth(char *ptr, char *from_here, struct packet_object *po
    return 1;
 }
 
-static int Parse_User_Agent(char* ptr, char* end, char *from_here, struct packet_object *po)
+static int Parse_User_Agent(char* end, char *from_here, struct packet_object *po)
 {
     // find the end of the line
     const char* line_end = (const char*)memchr(from_here, '\n', end - from_here);

--- a/src/dissectors/ec_icq.c
+++ b/src/dissectors/ec_icq.c
@@ -76,6 +76,9 @@ FUNC_DECODER(dissector_icq)
 
    /* don't complain about unused var */
    (void)end;
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
 
    /* parse only version 7/8 */
    if (ptr[0] != 0x2a || ptr[1] > 4) 

--- a/src/dissectors/ec_imap.c
+++ b/src/dissectors/ec_imap.c
@@ -62,6 +62,11 @@ FUNC_DECODER(dissector_imap)
    void *ident = NULL;
    char tmp[MAX_ASCII_ADDR_LEN];
    
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    /* the connection is starting... create the session */
    CREATE_SESSION_ON_SYN_ACK("imap", s, dissector_imap);
    /* create the session even if we are into an ssl tunnel */

--- a/src/dissectors/ec_irc.c
+++ b/src/dissectors/ec_irc.c
@@ -55,6 +55,9 @@ FUNC_DECODER(dissector_irc)
 
    /* unused variable */
    (void)end;
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
 
    /* skip messages coming from the server */
    if (FROM_SERVER("irc", PACKET) || FROM_SERVER("ircs", PACKET))

--- a/src/dissectors/ec_iscsi.c
+++ b/src/dissectors/ec_iscsi.c
@@ -109,6 +109,9 @@ FUNC_DECODER(dissector_iscsi)
 
    //suppress unused warning
    (void)end;
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
 
    /* Packets coming from the server */
    if (FROM_SERVER("iscsi", PACKET)) {

--- a/src/dissectors/ec_ldap.c
+++ b/src/dissectors/ec_ldap.c
@@ -50,6 +50,11 @@ FUNC_DECODER(dissector_ldap)
    u_int16 type, user_len, pass_len;
    char tmp[MAX_ASCII_ADDR_LEN];
 
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    /* We need at least 15 bytes of data to be interested*/
    if (PACKET->DATA.len < 15)
       return NULL;

--- a/src/dissectors/ec_mongodb.c
+++ b/src/dissectors/ec_mongodb.c
@@ -64,6 +64,9 @@ FUNC_DECODER(dissector_mongodb)
 
    //suppress unused warning
    (void)end;
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
 
    if (FROM_SERVER("mongodb", PACKET)) {
       if (PACKET->DATA.len < 13)

--- a/src/dissectors/ec_mountd.c
+++ b/src/dissectors/ec_mountd.c
@@ -59,6 +59,9 @@ FUNC_DECODER(dissector_mountd)
 
    /* don't complain about unused var */
    (void)end;
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
 
    /* skip packets which are not useful */
    if (PACKET->DATA.len < 24)

--- a/src/dissectors/ec_msn.c
+++ b/src/dissectors/ec_msn.c
@@ -53,6 +53,9 @@ FUNC_DECODER(dissector_msn)
 
    /* don't complain about unused var */
    (void)end;
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
    
    /* skip empty packets (ACK packets) */
    if (PACKET->DATA.len == 0)

--- a/src/dissectors/ec_mysql.c
+++ b/src/dissectors/ec_mysql.c
@@ -76,6 +76,11 @@ FUNC_DECODER(dissector_mysql)
    unsigned char output[41];
    int has_password = 0;
 
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    /* Skip ACK packets */
    if (PACKET->DATA.len == 0)
       return NULL;

--- a/src/dissectors/ec_nbns.c
+++ b/src/dissectors/ec_nbns.c
@@ -122,6 +122,11 @@ FUNC_DECODER(dissector_nbns)
 	char name[NBNS_NAME_LEN];
 	char ip[IP_ASCII_ADDR_LEN];
 
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
 	memset(name, 0, NBNS_NAME_LEN);
 
 	header = (struct nbns_header *)po->DATA.data;

--- a/src/dissectors/ec_nntp.c
+++ b/src/dissectors/ec_nntp.c
@@ -57,6 +57,11 @@ FUNC_DECODER(dissector_nntp)
    void *ident = NULL;
    char tmp[MAX_ASCII_ADDR_LEN];
    
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    /* the connection is starting... create the session */
    CREATE_SESSION_ON_SYN_ACK("nntp", s, dissector_nntp);
    CREATE_SESSION_ON_SYN_ACK("nntps", s, dissector_nntp);

--- a/src/dissectors/ec_o5logon.c
+++ b/src/dissectors/ec_o5logon.c
@@ -66,6 +66,9 @@ FUNC_DECODER(dissector_o5logon)
 
    //suppress unused warning
    (void)end;
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
 
    if (FROM_CLIENT("o5logon", PACKET)) {
 

--- a/src/dissectors/ec_ospf.c
+++ b/src/dissectors/ec_ospf.c
@@ -111,6 +111,7 @@ FUNC_DECODER(dissector_ospf)
    char pass[12];
 
    /* don't complain about unused var */
+   (void) DECODED_LEN;
    // (void)end;
 
    /* skip empty packets */

--- a/src/dissectors/ec_pop.c
+++ b/src/dissectors/ec_pop.c
@@ -61,6 +61,11 @@ FUNC_DECODER(dissector_pop)
    void *ident = NULL;
    char tmp[MAX_ASCII_ADDR_LEN];
    
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    /* the connection is starting... create the session */
    CREATE_SESSION_ON_SYN_ACK("pop3", s, dissector_pop);
    /* create the session even if we are into an ssl tunnel */

--- a/src/dissectors/ec_portmap.c
+++ b/src/dissectors/ec_portmap.c
@@ -84,6 +84,9 @@ FUNC_DECODER(dissector_portmap)
 
    /* don't complain about unused var */
    (void)end;
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
 
    /* skip packets which are not useful */
    if (PACKET->DATA.len < 24)  

--- a/src/dissectors/ec_postgresql.c
+++ b/src/dissectors/ec_postgresql.c
@@ -96,6 +96,11 @@ FUNC_DECODER(dissector_postgresql)
    char tmp[MAX_ASCII_ADDR_LEN];
    struct postgresql_status *conn_status;
 
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    if (FROM_CLIENT("postgresql", PACKET)) {
       if (PACKET->DATA.len < 4)
          return NULL;

--- a/src/dissectors/ec_radius.c
+++ b/src/dissectors/ec_radius.c
@@ -110,6 +110,11 @@ FUNC_DECODER(dissector_radius)
    char auth[0xff];
    size_t i;
    
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    DEBUG_MSG("RADIUS --> UDP dissector_radius");
 
    /* parse the packet as a radius header */

--- a/src/dissectors/ec_rcon.c
+++ b/src/dissectors/ec_rcon.c
@@ -46,6 +46,11 @@ FUNC_DECODER(dissector_rcon)
    DECLARE_DISP_PTR_END(ptr, end);
    char tmp[MAX_ASCII_ADDR_LEN];
 
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    /* skip messages coming from the server */
    if (FROM_SERVER("rcon", PACKET))
       return NULL;

--- a/src/dissectors/ec_rip.c
+++ b/src/dissectors/ec_rip.c
@@ -112,6 +112,9 @@ FUNC_DECODER(dissector_rip)
 
    /* don't complain about unused var */
    (void)end;
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
 
    /* skip empty packets */
    if (PACKET->DATA.len == 0)

--- a/src/dissectors/ec_rlogin.c
+++ b/src/dissectors/ec_rlogin.c
@@ -56,6 +56,11 @@ FUNC_DECODER(dissector_rlogin)
    void *ident = NULL;
    char tmp[MAX_ASCII_ADDR_LEN];
 
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    /* skip messages from the server */
    if (FROM_SERVER("rlogin", PACKET))
       return NULL;

--- a/src/dissectors/ec_smb.c
+++ b/src/dissectors/ec_smb.c
@@ -96,6 +96,11 @@ FUNC_DECODER(dissector_smb)
    NetBIOS_header *NetBIOS;
    char tmp[MAX_ASCII_ADDR_LEN];
 
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    ptr = PACKET->DATA.data;
 
    /* Catch netbios and smb headers */

--- a/src/dissectors/ec_smtp.c
+++ b/src/dissectors/ec_smtp.c
@@ -50,6 +50,11 @@ FUNC_DECODER(dissector_smtp)
    void *ident = NULL;
    char tmp[MAX_ASCII_ADDR_LEN];
    
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    /* the connection is starting... create the session */
    CREATE_SESSION_ON_SYN_ACK("smtp", s, dissector_smtp);
    CREATE_SESSION_ON_SYN_ACK("ssmtp", s, dissector_smtp);

--- a/src/dissectors/ec_snmp.c
+++ b/src/dissectors/ec_snmp.c
@@ -59,6 +59,11 @@ FUNC_DECODER(dissector_snmp)
    char tmp[MAX_ASCII_ADDR_LEN];
    u_int32 version, n;
 
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    /* skip empty packets (ACK packets) */
    if (PACKET->DATA.len == 0)
       return NULL;

--- a/src/dissectors/ec_socks.c
+++ b/src/dissectors/ec_socks.c
@@ -53,6 +53,9 @@ FUNC_DECODER(dissector_socks)
 
    /* don't complain about unused var */
    (void)end;
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
 
    /* Skip ACK packets */
    if (PACKET->DATA.len == 0)

--- a/src/dissectors/ec_ssh.c
+++ b/src/dissectors/ec_ssh.c
@@ -139,6 +139,11 @@ FUNC_DECODER(dissector_ssh)
    u_int32 ssh_len, ssh_mod;
    u_char ssh_packet_type, *ptr, *key_to_put;
 
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    /* skip empty packets (ACK packets) */
    if (PACKET->DATA.len == 0)
       return NULL;

--- a/src/dissectors/ec_telnet.c
+++ b/src/dissectors/ec_telnet.c
@@ -65,6 +65,11 @@ FUNC_DECODER(dissector_telnet)
    void *ident = NULL;
    char tmp[MAX_ASCII_ADDR_LEN];
 
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    /* the connection is starting... create the session */
    CREATE_SESSION_ON_SYN_ACK("telnet", s, dissector_telnet);
    CREATE_SESSION_ON_SYN_ACK("telnets", s, dissector_telnet);

--- a/src/dissectors/ec_vnc.c
+++ b/src/dissectors/ec_vnc.c
@@ -83,6 +83,10 @@ FUNC_DECODER(dissector_vnc)
    char tmp[MAX_ASCII_ADDR_LEN];
    struct vnc_status *conn_status;
 
+   /* don't complain about unused var */
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    /* Packets coming from the server */
    if (FROM_SERVER("vnc", PACKET)) {
 

--- a/src/dissectors/ec_vrrp.c
+++ b/src/dissectors/ec_vrrp.c
@@ -97,6 +97,9 @@ FUNC_DECODER(dissector_vrrp)
 
    /* don't complain about unused var */
    (void)end;
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
 
    /* skip empty packets */
    if (PACKET->DATA.len < sizeof(struct vrrp_hdr))

--- a/src/dissectors/ec_x11.c
+++ b/src/dissectors/ec_x11.c
@@ -67,6 +67,11 @@ FUNC_DECODER(dissector_x11)
    struct x11_request *x11;
    int i;
    
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    /* 
     * check if it is the first packet sent by the server i
     * after the session is created (cookie already sent)

--- a/src/dissectors/ec_ymsg.c
+++ b/src/dissectors/ec_ymsg.c
@@ -52,6 +52,11 @@ FUNC_DECODER(dissector_ymsg)
    u_char *q;
    u_int32 field_len;
    
+   /* don't complain about unused var */
+   (void) DECODE_DATA; 
+   (void) DECODE_DATALEN;
+   (void) DECODED_LEN;
+   
    /* Empty or not a yahoo messenger packet */
    if (PACKET->DATA.len == 0 || memcmp(ptr, "YMSG", 4))
       return NULL;

--- a/src/ec_conntrack.c
+++ b/src/ec_conntrack.c
@@ -377,6 +377,9 @@ EC_THREAD_FUNC(conntrack_timeouter)
    struct conn_tail *tmp = NULL;
    size_t sec;
    
+   /* variable not used */
+   (void) EC_THREAD_PARAM;
+
    /* initialize the thread */
    ec_thread_init();
    

--- a/src/ec_dispatcher.c
+++ b/src/ec_dispatcher.c
@@ -61,6 +61,9 @@ EC_THREAD_FUNC(top_half)
    struct po_queue_entry *e;
    u_int pck_len;
  
+   /* variable not used */
+   (void) EC_THREAD_PARAM;
+
 #if !defined(OS_WINDOWS) 
    struct timespec tm;   
    tm.tv_sec = 0;

--- a/src/ec_encryption.c
+++ b/src/ec_encryption.c
@@ -519,7 +519,10 @@ int wpa_decrypt_broadcast_key(struct eapol_key_header *eapol_key, struct rsn_ie_
    u_int16 key_len = 0;
    //static AIRPDCAP_KEY_ITEM dummy_key; /* needed in case AirPDcapRsnaMng() wants the key structure */
 
-char tmp[512];
+   char tmp[512];
+
+   /* variable not used */
+   (void) rsn_ie;
 
    /* Preparation for decrypting the group key - determine group key data length */
    /* depending on whether it's a TKIP or AES encryption key */

--- a/src/ec_filter.c
+++ b/src/ec_filter.c
@@ -45,7 +45,7 @@ static pthread_mutex_t filters_mutex;
 /* protos */
 
 static void reconstruct_strings(struct filter_env *fenv, struct filter_header *fh);
-static int compile_regex(struct filter_env *fenv, struct filter_header *fh);
+static int compile_regex(struct filter_env *fenv);
    
 static int filter_engine(struct filter_op *fop, struct packet_object *po);
 static int execute_test(struct filter_op *fop, struct packet_object *po);
@@ -1065,7 +1065,7 @@ int filter_load_file(const char *filename, struct filter_list **list, uint8_t en
    FILTERS_UNLOCK;
 
    /* compile the regex to speed up the matching */
-   if (compile_regex(fenv, &fh) != ESUCCESS)
+   if (compile_regex(fenv) != ESUCCESS)
       return -EFATAL;
    
    USER_MSG("Content filters loaded from %s...\n", filename);
@@ -1181,7 +1181,7 @@ static void reconstruct_strings(struct filter_env *fenv, struct filter_header *f
 /*
  * compile the regex of a filter_op
  */
-static int compile_regex(struct filter_env *fenv, struct filter_header *fh)
+static int compile_regex(struct filter_env *fenv)
 {
    size_t i = 0;
    struct filter_op *fop = fenv->chain;

--- a/src/ec_format.c
+++ b/src/ec_format.c
@@ -335,6 +335,10 @@ int bin_format(const u_char *buf, size_t len, u_char *dst)
 
 int zero_format(const u_char *buf, size_t len, u_char *dst)
 {
+   /* variable not used */
+   (void) buf;
+   (void) len;
+
    strncpy((char*)dst, "", 1);
    return 0;
 }

--- a/src/ec_inet.c
+++ b/src/ec_inet.c
@@ -433,7 +433,7 @@ int ip_addr_is_multicast(struct ip_addr *ip)
  * returns  ESUCCESS if the ip is broadcast
  * returns -ENOTFOUND if not
  */
-int ip_addr_is_broadcast(struct ip_addr *sa, struct ip_addr *ifaddr)
+int ip_addr_is_broadcast(struct ip_addr *sa)
 {
 	struct ip_addr *nw;
 	struct ip_addr *nm;

--- a/src/ec_plugins.c
+++ b/src/ec_plugins.c
@@ -59,7 +59,7 @@ static SLIST_HEAD(, plugin_entry) plugin_head;
 /* protos... */
 
 void plugin_unload_all(void);
-static void plugin_print(char active, struct plugin_ops *ops);
+static void plugin_print(struct plugin_ops *ops);
 #if defined(OS_BSD) || defined (OS_DARWIN)
 int plugin_filter(struct dirent *d);
 #else
@@ -395,7 +395,7 @@ void plugin_list(void)
 /*
  * callback function for displaying the plugin list 
  */
-static void plugin_print(char active, struct plugin_ops *ops)
+static void plugin_print(struct plugin_ops *ops)
 {
    fprintf(stdout, " %15s %4s  %s\n", ops->name, ops->version, ops->info);  
 }

--- a/src/ec_scan.c
+++ b/src/ec_scan.c
@@ -147,6 +147,9 @@ static EC_THREAD_FUNC(scan_thread)
    int nhosts = 0;
    int threadize = 1;
 
+   /* variable not used */
+   (void) EC_THREAD_PARAM;
+
    DEBUG_MSG("scan_thread");
 
    ts.tv_sec = 1;
@@ -324,6 +327,9 @@ static void scan_decode(u_char *param, const struct pcap_pkthdr *pkthdr, const u
    bpf_u_int32 len;
    u_char *data;
    bpf_u_int32 datalen;
+
+   /* variable not used */
+   (void) param;
 
    CANCELLATION_POINT();
 

--- a/src/ec_send.c
+++ b/src/ec_send.c
@@ -731,7 +731,7 @@ int send_icmp6_nsol(struct ip_addr *sip, struct ip_addr *tip, struct ip_addr *re
    return c;
 }
 
-int send_icmp6_nadv(struct ip_addr *sip, struct ip_addr *tip, struct ip_addr *tgt, u_int8 *macaddr, int router)
+int send_icmp6_nadv(struct ip_addr *sip, struct ip_addr *tip, u_int8 *macaddr, int router)
 {
    libnet_ptag_t t;
    int c, h = 0;

--- a/src/ec_signals.c
+++ b/src/ec_signals.c
@@ -232,6 +232,8 @@ static void signal_TERM(int sig)
  */
 static void signal_CHLD(int sig)
 {
+   /* variable not used */
+   (void) sig;
 #ifndef OS_WINDOWS
    int stat;
    

--- a/src/ec_sniff.c
+++ b/src/ec_sniff.c
@@ -170,7 +170,7 @@ static void set_interesting_flag(struct packet_object *po)
    if ( value && (
         (GBL_TARGET2->all_mac || !memcmp(GBL_TARGET2->mac, po->L2.dst, MEDIA_ADDR_LEN) || !memcmp(GBL_IFACE->mac, po->L2.dst, MEDIA_ADDR_LEN)) &&
         (GBL_TARGET2->all_ip || cmp_ip_list(&po->L3.dst, GBL_TARGET2) || 
-            (GBL_OPTIONS->broadcast && ip_addr_is_broadcast(&po->L3.dst, &GBL_IFACE->ip) == ESUCCESS) ||
+            (GBL_OPTIONS->broadcast && ip_addr_is_broadcast(&po->L3.dst) == ESUCCESS) ||
             (GBL_OPTIONS->remote && ip_addr_is_local(&po->L3.dst, NULL) != ESUCCESS) ) &&
         (GBL_TARGET2->all_port || BIT_TEST(GBL_TARGET2->ports, ntohs(po->L4.dst))) ) )
       good = 1;   
@@ -193,7 +193,7 @@ static void set_interesting_flag(struct packet_object *po)
    /* if broadcast then T2 -> broadcast */
    if ( (GBL_TARGET1->all_mac  || !memcmp(GBL_TARGET1->mac, po->L2.dst, MEDIA_ADDR_LEN) || !memcmp(GBL_IFACE->mac, po->L2.dst, MEDIA_ADDR_LEN)) &&
         (GBL_TARGET1->all_ip   || cmp_ip_list(&po->L3.dst, GBL_TARGET1) || 
-            (GBL_OPTIONS->broadcast && ip_addr_is_broadcast(&po->L3.dst, &GBL_IFACE->ip) == ESUCCESS) ||
+            (GBL_OPTIONS->broadcast && ip_addr_is_broadcast(&po->L3.dst) == ESUCCESS) ||
             (GBL_OPTIONS->remote && ip_addr_is_local(&po->L3.dst, NULL) != ESUCCESS) ) &&
         (GBL_TARGET1->all_port || BIT_TEST(GBL_TARGET1->ports, ntohs(po->L4.dst))) )
       value = 1;

--- a/src/ec_sslwrap.c
+++ b/src/ec_sslwrap.c
@@ -245,6 +245,9 @@ EC_THREAD_FUNC(sslw_start)
    u_int len = sizeof(struct sockaddr_in), i;
    struct sockaddr_in client_sin;
 
+   /* variable not used */
+   (void) EC_THREAD_PARAM;
+
    ec_thread_init();
 
    /* disabled if not aggressive */

--- a/src/interfaces/curses/ec_curses_filters.c
+++ b/src/interfaces/curses/ec_curses_filters.c
@@ -51,6 +51,9 @@ static int n_filters = 0;
 
 static int add_filter_to_list(struct filter_list *f, void *data)
 {
+   /* variable not used */
+   (void) data;
+
    SAFE_REALLOC(wdg_filters_elements, (n_filters + 1) * sizeof(struct wdg_list));
    SAFE_CALLOC(wdg_filters_elements[n_filters].desc, MAX_DESC_LEN + 1, sizeof(char));
    snprintf(wdg_filters_elements[n_filters].desc, MAX_DESC_LEN, "[%c] %s", f->enabled?'X':' ', f->name);

--- a/src/interfaces/curses/ec_curses_hosts.c
+++ b/src/interfaces/curses/ec_curses_hosts.c
@@ -245,6 +245,9 @@ void curses_hosts_update()
 
 static void curses_hosts_help(void *dummy)
 {
+   /* variable not used */
+   (void) dummy;
+
    char help[] = "HELP: shortcut list:\n\n"
                  "  d - to delete an host from the list\n"
                  "  1 - to add the host to TARGET1\n"

--- a/src/interfaces/curses/ec_curses_plugins.c
+++ b/src/interfaces/curses/ec_curses_plugins.c
@@ -153,6 +153,9 @@ static void curses_plug_destroy(void)
 
 static void curses_plugin_help(void *dummy)
 {
+   /* variable not used */
+   (void) dummy;
+
    char help[] = "HELP: shortcut list:\n\n"
                  "  ENTER - activate/deactivate a plugin";
 

--- a/src/interfaces/curses/ec_curses_targets.c
+++ b/src/interfaces/curses/ec_curses_targets.c
@@ -390,6 +390,9 @@ static void curses_delete_target2(void *host)
  */
 static void curses_add_target1(void *entry)
 {
+   /* variable not used */
+   (void) entry;
+
    DEBUG_MSG("curses_add_target1");
 
    curses_input("IP address :", thost, MAX_ASCII_ADDR_LEN, add_target1);
@@ -397,6 +400,9 @@ static void curses_add_target1(void *entry)
 
 static void curses_add_target2(void *entry)
 {
+   /* variable not used */
+   (void) entry;
+
    DEBUG_MSG("curses_add_target2");
 
    curses_input("IP address :", thost, MAX_ASCII_ADDR_LEN, add_target2);

--- a/src/interfaces/curses/ec_curses_view_connections.c
+++ b/src/interfaces/curses/ec_curses_view_connections.c
@@ -124,6 +124,9 @@ static void curses_kill_connections(void)
 
 static void curses_connection_help(void *dummy)
 {
+   /* variable not used */
+   (void) dummy;
+
    char help[] = "HELP: shortcut list:\n\n"
                  "  ENTER - open the data panel in real time\n"
                  "    d   - show details of the current connection\n"
@@ -530,6 +533,9 @@ static void curses_connection_kill(void *conn)
  */
 static void curses_connection_purge(void *conn)
 {
+   /* variable not used */
+   (void) conn;
+
    DEBUG_MSG("curses_connection_purge");
    
    conntrack_purge();

--- a/src/interfaces/curses/ec_curses_view_profiles.c
+++ b/src/interfaces/curses/ec_curses_view_profiles.c
@@ -104,6 +104,9 @@ static void curses_kill_profiles(void)
 
 static void curses_profiles_help(void *dummy)
 {
+   /* variable not used */
+   (void) dummy;
+
    char help[] = "HELP: shortcut list:\n\n"
                  "  ENTER - show the infos about the host\n"
                  "    l   - remove the remote hosts from the list\n"
@@ -219,6 +222,9 @@ static void curses_profile_detail(void *profile)
 
 static void curses_profiles_local(void *dummy)
 {
+   /* variable not used */
+   (void) dummy;
+
    profile_purge_remote();
    wdg_dynlist_reset(wdg_profiles);
    wdg_dynlist_refresh(wdg_profiles);
@@ -226,6 +232,9 @@ static void curses_profiles_local(void *dummy)
 
 static void curses_profiles_remote(void *dummy)
 {
+   /* variable not used */
+   (void) dummy;
+
    profile_purge_local();
    wdg_dynlist_reset(wdg_profiles);
    wdg_dynlist_refresh(wdg_profiles);
@@ -233,12 +242,18 @@ static void curses_profiles_remote(void *dummy)
 
 static void curses_profiles_convert(void *dummy)
 {
+   /* variable not used */
+   (void) dummy;
+
    profile_convert_to_hostlist();
    curses_message("The hosts list was populated with local profiles");
 }
 
 static void curses_profiles_dump(void *dummy)
 {
+   /* variable not used */
+   (void) dummy;
+
    DEBUG_MSG("curses_profiles_dump");
 
    /* make sure to free if already set */

--- a/src/interfaces/curses/widgets/wdg_dynlist.c
+++ b/src/interfaces/curses/widgets/wdg_dynlist.c
@@ -552,6 +552,9 @@ static void wdg_dynlist_mouse(struct wdg_object *wo, int key, struct wdg_mouse_e
    size_t y = wdg_get_begin_y(wo) + 2;
    size_t line, i = 0;
    void *next;
+
+   /* variable currently not used */
+   (void) key;
    
    /* calculate which line was selected */
    line = mouse->y - y;

--- a/src/interfaces/curses/widgets/wdg_file.c
+++ b/src/interfaces/curses/widgets/wdg_file.c
@@ -374,6 +374,9 @@ static int wdg_file_driver(struct wdg_object *wo, int key, struct wdg_mouse_even
    WDG_WO_EXT(struct wdg_file_handle, ww);
    int c;
    struct stat buf;
+
+   /* variable currently not used */
+   (void) mouse;
    
    c = menu_driver(ww->m, wdg_file_virtualize(key) );
    

--- a/src/interfaces/curses/widgets/wdg_input.c
+++ b/src/interfaces/curses/widgets/wdg_input.c
@@ -387,6 +387,9 @@ static int wdg_input_driver(struct wdg_object *wo, int key, struct wdg_mouse_eve
 {
    WDG_WO_EXT(struct wdg_input_handle, ww);
    int c, v;
+
+   /* variable currently not used */
+   (void) mouse;
    
    WDG_DEBUG_MSG("keypress driver: %d", key);
    

--- a/src/interfaces/curses/widgets/wdg_list.c
+++ b/src/interfaces/curses/widgets/wdg_list.c
@@ -381,6 +381,9 @@ static int wdg_list_driver(struct wdg_object *wo, int key, struct wdg_mouse_even
 {
    WDG_WO_EXT(struct wdg_list_handle, ww);
    int c;
+
+   /* variable currently not used */
+   (void) mouse;
    
    c = menu_driver(ww->menu, wdg_list_virtualize(key) );
    

--- a/src/interfaces/curses/widgets/wdg_menu.c
+++ b/src/interfaces/curses/widgets/wdg_menu.c
@@ -468,6 +468,9 @@ static int wdg_menu_driver(struct wdg_object *wo, int key, struct wdg_mouse_even
    WDG_WO_EXT(struct wdg_menu_handle, ww);
    int c;
    struct wdg_key_callback *kcall;
+
+   /* variable currently not used */
+   (void) mouse;
    
    c = menu_driver(ww->focus_unit->m, wdg_menu_virtualize(key) );
    

--- a/src/interfaces/daemon/ec_daemon.c
+++ b/src/interfaces/daemon/ec_daemon.c
@@ -102,6 +102,9 @@ static void daemon_cleanup(void)
 
 static int daemon_progress(char *title, int value, int max)
 {
+   /* variable not used */
+   (void) title;
+
    if (value == max)
       return UI_PROGRESS_FINISHED;
    else

--- a/src/interfaces/gtk/ec_gtk.c
+++ b/src/interfaces/gtk/ec_gtk.c
@@ -90,6 +90,9 @@ static void gtkui_page_defocus_tabs(void);
 */
 static gboolean gtkui_cleanup_shim(gpointer data)
 {
+   /* variable not used */
+   (void) data;
+
    gtkui_cleanup();
    return FALSE;
 }
@@ -357,6 +360,9 @@ static void gtkui_msg(const char *msg)
 /* flush pending messages */
 gboolean gtkui_flush_msg(gpointer data)
 {
+   /* variable not used */
+   (void) data;
+
    ui_msg_flush(MSG_ALL);
 
    return(TRUE);
@@ -508,7 +514,11 @@ static void gtkui_progress(char *title, int value, int max)
 
 }
 
-static gboolean gtkui_progress_cancel(GtkWidget *window, gpointer data) {
+static gboolean gtkui_progress_cancel(GtkWidget *window, gpointer data) 
+{
+   /* variable not used */
+   (void) window;
+
    progress_canceled = TRUE;
 
    /* the progress dialog must be manually destroyed if the cancel button is used */
@@ -1160,6 +1170,9 @@ void gtkui_details_print(GtkTextBuffer *textbuf, char *data)
 void gtkui_dialog_enter(GtkWidget *widget, gpointer data) {
    GtkWidget *dialog;
 
+   /* variable not used */
+   (void) data;
+
    dialog = g_object_get_data(G_OBJECT(widget), "dialog");
    gtk_dialog_response(GTK_DIALOG (dialog), GTK_RESPONSE_OK);
 }
@@ -1270,6 +1283,10 @@ void gtkui_page_close(GtkWidget *widget, gpointer data) {
    gint num = 0;
    void (*callback)(void);
 
+   /* variable not used */
+   (void) widget;
+   (void) data;
+
    DEBUG_MSG("gtkui_page_close");
 
    num = gtk_notebook_page_num(GTK_NOTEBOOK(notebook), GTK_WIDGET (data));
@@ -1296,6 +1313,9 @@ void gtkui_page_close_current(void) {
 
 /* show the context menu when the notebook tabs recieve a mouse right-click */
 gboolean gtkui_context_menu(GtkWidget *widget, GdkEventButton *event, gpointer data) {
+   /* variable not used */
+   (void) widget;
+
     if(event->button == 3)
         gtk_menu_popup(GTK_MENU(data), NULL, NULL, NULL, NULL, 3, event->time);
     return(FALSE);
@@ -1351,6 +1371,9 @@ void gtkui_filename_browse(GtkWidget *widget, gpointer data)
    gint response = 0;
    const char *filename = NULL;
    
+   /* variable not used */
+   (void) widget;
+
    dialog = gtk_file_selection_new ("Select a file...");
    
    response = gtk_dialog_run (GTK_DIALOG (dialog));

--- a/src/interfaces/gtk/ec_gtk_help.c
+++ b/src/interfaces/gtk/ec_gtk_help.c
@@ -158,6 +158,9 @@ void gtkui_help_selected(GtkTreeSelection *treeselection, gpointer data) {
    GtkTreeModel *model;
    gchar *file;
 
+   /* variable not used */
+   (void) data;
+
    if (gtk_tree_selection_get_selected (GTK_TREE_SELECTION (treeselection), &model, &iter)) {
       gtk_tree_model_get (model, &iter, 1, &file, -1);
       if(!file) return;

--- a/src/interfaces/gtk/ec_gtk_hosts.c
+++ b/src/interfaces/gtk/ec_gtk_hosts.c
@@ -324,6 +324,9 @@ void gtkui_button_callback(GtkWidget *widget, gpointer data)
    char tmp[MAX_ASCII_ADDR_LEN];
    struct hosts_list *hl = NULL;
 
+   /* variable not used */
+   (void) widget;
+
    model = GTK_TREE_MODEL (liststore);
 
    if(gtk_tree_selection_count_selected_rows(selection) > 0) {

--- a/src/interfaces/gtk/ec_gtk_targets.c
+++ b/src/interfaces/gtk/ec_gtk_targets.c
@@ -374,6 +374,9 @@ void gtkui_create_targets_array(void)
  */
 static void gtkui_add_target1(void *entry)
 {
+   /* variable not used */
+   (void) entry;
+
    DEBUG_MSG("gtk_add_target1");
 
    gtkui_input("IP address :", thost, MAX_ASCII_ADDR_LEN, add_target1);
@@ -381,6 +384,9 @@ static void gtkui_add_target1(void *entry)
 
 static void gtkui_add_target2(void *entry)
 {
+   /* variable not used */
+   (void) entry;
+
    DEBUG_MSG("gtk_add_target2");
 
    gtkui_input("IP address :", thost, MAX_ASCII_ADDR_LEN, add_target2);
@@ -445,6 +451,9 @@ static void gtkui_delete_targets(GtkWidget *widget, gpointer data) {
    GtkTreeIter iter;
    GtkTreeModel *model;
    struct ip_list *il = NULL;
+
+   /* variable not used */
+   (void) widget;
 
    switch((int)data) {
       case 1:

--- a/src/interfaces/gtk/ec_gtk_view.c
+++ b/src/interfaces/gtk/ec_gtk_view.c
@@ -241,6 +241,9 @@ static gboolean refresh_stats(gpointer data)
 {
    char line[50];
 
+   /* variable not used */
+   (void) data;
+
    /* if not focused don't refresh it */
    /* this also removes the idle call, but should 
       only occur if the window isn't visible */

--- a/src/interfaces/gtk/ec_gtk_view_connections.c
+++ b/src/interfaces/gtk/ec_gtk_view_connections.c
@@ -283,6 +283,9 @@ static gboolean refresh_connections(gpointer data)
    unsigned int tx = 0, rx = 0;
    struct row_pairs *row = NULL, *nextrow = NULL, top, bottom;
 
+   /* variable not used */
+   (void) data;
+
    /* init strings */
    memset(&flags, 0, sizeof(flags));
    memset(&status, 0, sizeof(status));
@@ -1077,6 +1080,9 @@ static void gtkui_connection_purge(void *conn)
 {
    struct row_pairs *row, *nextrow, *list = connections;
 
+   /* variable not used */
+   (void) conn;
+
    DEBUG_MSG("gtkui_connection_purge");
 
    connections = NULL;
@@ -1097,6 +1103,9 @@ static void gtkui_connection_kill(void *conn)
    GtkTreeIter iter;
    GtkTreeModel *model;
    struct conn_tail *c = NULL;
+
+   /* variable not used */
+   (void) conn;
 
    DEBUG_MSG("gtkui_connection_kill");
 

--- a/src/interfaces/gtk/ec_gtk_view_profiles.c
+++ b/src/interfaces/gtk/ec_gtk_view_profiles.c
@@ -181,6 +181,9 @@ static gboolean refresh_profiles(gpointer data)
    char tmp[MAX_ASCII_ADDR_LEN];
    int found = 0;
 
+   /* variable not used */
+   (void) data;
+
    if(!ls_profiles) {
       ls_profiles = gtk_list_store_new (4, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_STRING, G_TYPE_POINTER);
    }
@@ -348,6 +351,9 @@ static void gtkui_profiles_convert(void)
 
 static void gtkui_profiles_dump(void *dummy)
 {
+   /* variable not used */
+   (void) dummy;
+
    DEBUG_MSG("gtkui_profiles_dump");
 
    /* make sure to free if already set */

--- a/src/interfaces/text/ec_text.c
+++ b/src/interfaces/text/ec_text.c
@@ -216,6 +216,9 @@ static int text_progress(char *title, int value, int max)
 {
    float percent;
    int i;
+   
+   /* variable not used */
+   (void) title;
   
    /* calculate the percent */
    percent = (float)(value)*100/(max);

--- a/src/mitm/ec_arp_poisoning.c
+++ b/src/mitm/ec_arp_poisoning.c
@@ -248,7 +248,10 @@ EC_THREAD_FUNC(arp_poisoner)
    tm.tv_nsec = GBL_CONF->arp_storm_delay * 1000;
    tm.tv_sec = 0;
 #endif
-   
+
+   /* variable not used */
+   (void) EC_THREAD_PARAM;
+
    /* init the thread and wait for start up */
    ec_thread_init();
   

--- a/src/mitm/ec_ip6nd_poison.c
+++ b/src/mitm/ec_ip6nd_poison.c
@@ -135,6 +135,9 @@ EC_THREAD_FUNC(nadv_poisoner)
    tm.tv_sec = 0;
 #endif
 
+   /* variable not used */
+   (void) EC_THREAD_PARAM;
+
    ec_thread_init();
    DEBUG_MSG("nadv_poisoner");
 
@@ -150,9 +153,9 @@ EC_THREAD_FUNC(nadv_poisoner)
             if(!ip_addr_cmp(&t1->ip, &t2->ip))
                continue;
 
-            send_icmp6_nadv(&t1->ip, &t2->ip, &t1->ip, GBL_IFACE->mac, flags);
+            send_icmp6_nadv(&t1->ip, &t2->ip, GBL_IFACE->mac, flags);
             if(!(flags & ND_ONEWAY))
-               send_icmp6_nadv(&t2->ip, &t1->ip, &t2->ip, GBL_IFACE->mac, flags & ND_ROUTER);
+               send_icmp6_nadv(&t2->ip, &t1->ip, GBL_IFACE->mac, flags & ND_ROUTER);
 
 #if !defined(OS_WINDOWS)
             nanosleep(&tm, NULL);
@@ -382,9 +385,9 @@ static void nadv_antidote(void)
             if(!ip_addr_cmp(&h1->ip, &h2->ip))
                continue;
 
-            send_icmp6_nadv(&h1->ip, &h2->ip, &h1->ip, h1->mac, flags);
+            send_icmp6_nadv(&h1->ip, &h2->ip, h1->mac, flags);
             if(!(flags & ND_ONEWAY))
-               send_icmp6_nadv(&h2->ip, &h1->ip, &h2->ip, h2->mac, flags & ND_ROUTER);
+               send_icmp6_nadv(&h2->ip, &h1->ip, h2->mac, flags & ND_ROUTER);
 
             usleep(GBL_CONF->ndp_poison_send_delay);
          }

--- a/src/mitm/ec_port_stealing.c
+++ b/src/mitm/ec_port_stealing.c
@@ -275,6 +275,9 @@ EC_THREAD_FUNC(port_stealer)
    struct steal_list *s;
    struct eth_header *heth;
    
+   /* variable not used */
+   (void) EC_THREAD_PARAM;
+
    /* init the thread and wait for start up */
    ec_thread_init();
   

--- a/src/protocols/ec_arp.c
+++ b/src/protocols/ec_arp.c
@@ -65,6 +65,9 @@ FUNC_DECODER(decode_arp)
 {
    struct arp_header *arp;
 
+   /* don't complain about unused var */
+   (void) DECODE_DATALEN;
+   
    arp = (struct arp_header *)DECODE_DATA;
 
    /*

--- a/src/protocols/ec_wifi_eapol.c
+++ b/src/protocols/ec_wifi_eapol.c
@@ -64,6 +64,9 @@ FUNC_DECODER(decode_eapol)
    struct wpa_sa sa;
    char tmp[512];
 
+   /* don't complain about unused var */
+   (void) DECODE_DATALEN;
+   
    /* analyze these only if we have a wpa key */
    if (GBL_WIFI->wifi_schema != WIFI_WPA)
       return NULL;

--- a/utils/etterfilter/ef_ec_compat.c
+++ b/utils/etterfilter/ef_ec_compat.c
@@ -43,7 +43,10 @@ int send_L3_icmp_unreach(struct packet_object *po);
  
 /* the void implemetation */
 
-void debug_msg(const char *message, ...) { }
+void debug_msg(const char *message, ...) 
+{
+   (void) message;
+}
 
 
 /* fake the UI implementation */
@@ -81,11 +84,21 @@ void ui_cleanup(void)
 /* remove ec_send.c dependency */
 int send_tcp(struct ip_addr *sip, struct ip_addr *tip, u_int16 sport, u_int16 dport, u_int32 seq, u_int32 ack, u_int8 flags) 
 { 
+   (void) sip;
+   (void) tip;
+   (void) sport;
+   (void) dport;
+   (void) seq;
+   (void) ack;
+   (void) flags;
+
    return 0;
 }
 
 int send_L3_icmp_unreach(struct packet_object *po)
 {
+   (void) po;
+
    return 0;
 }
 

--- a/utils/etterlog/el_ec_compat.c
+++ b/utils/etterlog/el_ec_compat.c
@@ -44,7 +44,10 @@ void close_socket(int s);
  
 /* the void implemetation */
 
-void debug_msg(const char *message, ...) { }
+void debug_msg(const char *message, ...) 
+{
+   (void) message;
+}
 
 /* fake the UI implementation */
 void ui_msg(const char *fmt, ...) 
@@ -83,14 +86,36 @@ void ui_cleanup(void) { }
 /* for ec_passive is_open_port */
 void * get_decoder(u_int8 level, u_int32 type)
 {
+   (void) level;
+   (void) type;
+
    return NULL;
 }
 
 /* fake socket connections */
-void open_socket(char *host, u_int16 port) { }
-void socket_send(int s, u_char *payload, size_t size) { }
-void socket_recv(int s, u_char *payload, size_t size) { }
-void close_socket(int s) { }
+void open_socket(char *host, u_int16 port) 
+{
+   (void) host;
+   (void) port;
+}
+
+void socket_send(int s, u_char *payload, size_t size) 
+{
+   (void) s;
+   (void) payload;
+   (void) size;
+}
+
+void socket_recv(int s, u_char *payload, size_t size) 
+{
+   (void) s;
+   (void) payload;
+   (void) size;
+}
+void close_socket(int s) 
+{
+   (void) s;
+}
 
 /* EOF */
 


### PR DESCRIPTION
I checked the top warning messages and found it worth fixing some after -Wextra Cflag has been introduced.
The biggest point have now been the -Wunused-parameter warnings:

```
$ make 2> ../compile-warnings.txt >/dev/null
$ grep '\-W' ../compile-warnings.txt | perl -pe 's/^.+-W([^\]]+).*$/$1/' | sort | uniq -c | sort -nr
    268 unused-parameter
     74 missing-field-initializers
     27 format
     10 redundant-decls
      8 implicit-function-declaration
      5 sign-compare
      4 unused-function
      3 pointer-to-int-cast
      1 unused-but-set-variable
      1 empty-body
$ 
```

So this PR intends to fix this type of warnings.
In the curses widgets I left the parameter of the function without any obvious dependency but because I could think of a potential future use, I left it and just voided it as the most of the changes.
