### PR TITLE
delay gtk progress dialog based on time

### DIFF
--- a/src/interfaces/gtk/ec_gtk.h
+++ b/src/interfaces/gtk/ec_gtk.h
@@ -20,6 +20,7 @@ struct gtk_conf_entry {
 extern GtkWidget *window;  /* main window */
 extern GtkWidget *notebook;
 extern GtkWidget *main_menu;
+extern GTimer *progress_timer;
 
 extern void gtkui_message(const char *msg);
 extern void gtkui_input(const char *title, char *input, size_t n, void (*callback)(void));


### PR DESCRIPTION
If a scan is perfomed the progress dialog will appear after 750ms displaying the current status.
This prevents the flickering of the progress dialog being rendered and destroyed subsequently because the scan action was too fast on a faster system.
It also prevents the progress bar not being shown on slower systems scanning a subnet even smaller than 2048 hosts though taking a resonalble time being worth the progress dialog to be rendered.
