### PR TITLE
Fix 64bit specific warnings 

### DIFF
--- a/src/interfaces/gtk/ec_gtk_hosts.c
+++ b/src/interfaces/gtk/ec_gtk_hosts.c
@@ -173,6 +173,9 @@ void gtkui_host_list(void)
    GtkWidget *scrolled, *treeview, *vbox, *hbox, *button;
    GtkCellRenderer   *renderer;
    GtkTreeViewColumn *column;
+   gint host_delete = HOST_DELETE;
+   gint host_target1 = HOST_TARGET1;
+   gint host_target2 = HOST_TARGET2;
 
    DEBUG_MSG("gtk_host_list");
 
@@ -230,17 +233,17 @@ void gtkui_host_list(void)
 
    button = gtk_button_new_with_mnemonic("_Delete Host");
    gtk_box_pack_start(GTK_BOX (hbox), button, TRUE, TRUE, 0);
-   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_button_callback), (gpointer)HOST_DELETE);
+   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_button_callback), (gpointer)&host_delete);
    gtk_widget_show(button);
 
    button = gtk_button_new_with_mnemonic("Add to Target _1");
    gtk_box_pack_start(GTK_BOX (hbox), button, TRUE, TRUE, 0);
-   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_button_callback), (gpointer)HOST_TARGET1);
+   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_button_callback), (gpointer)&host_target1);
    gtk_widget_show(button);
 
    button = gtk_button_new_with_mnemonic("Add to Target _2");
    gtk_box_pack_start(GTK_BOX (hbox), button, TRUE, TRUE, 0);
-   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_button_callback), (gpointer)HOST_TARGET2);
+   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_button_callback), (gpointer)&host_target2);
    gtk_widget_show(button);
 
    gtk_widget_show(hosts_window);
@@ -324,9 +327,13 @@ void gtkui_button_callback(GtkWidget *widget, gpointer data)
    GtkTreeModel *model;
    char tmp[MAX_ASCII_ADDR_LEN];
    struct hosts_list *hl = NULL;
+   gint *type = data;
 
    /* variable not used */
    (void) widget;
+
+   if (type == NULL)
+       return;
 
    model = GTK_TREE_MODEL (liststore);
 
@@ -336,7 +343,7 @@ void gtkui_button_callback(GtkWidget *widget, gpointer data)
          gtk_tree_model_get_iter(model, &iter, list->data);
          gtk_tree_model_get(model, &iter, 3, &hl, -1);
 
-         switch((int)data) {
+         switch(*type) {
             case HOST_DELETE:
                DEBUG_MSG("gtkui_button_callback: delete host");
                gtk_list_store_remove(GTK_LIST_STORE (liststore), &iter);

--- a/src/interfaces/gtk/ec_gtk_targets.c
+++ b/src/interfaces/gtk/ec_gtk_targets.c
@@ -198,6 +198,8 @@ void gtkui_current_targets(void)
    GtkWidget *scrolled, *treeview, *vbox, *hbox, *button;
    GtkCellRenderer   *renderer;
    GtkTreeViewColumn *column;
+   gint delete_targets1 = 1;
+   gint delete_targets2 = 2;
 
    DEBUG_MSG("gtk_current_targets");
 
@@ -267,13 +269,13 @@ void gtkui_current_targets(void)
    gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 0);
 
    button = gtk_button_new_with_mnemonic("Delete");
-   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_delete_targets), (gpointer)1);
+   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_delete_targets), (gpointer)&delete_targets1);
    gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 0);
    button = gtk_button_new_with_mnemonic("Add");
    g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_add_target1), NULL);
    gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 0);
    button = gtk_button_new_with_mnemonic("Delete");
-   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_delete_targets), (gpointer)2);
+   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_delete_targets), (gpointer)&delete_targets2);
    gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 0);
    button = gtk_button_new_with_mnemonic("Add");
    g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_add_target2), NULL);
@@ -451,11 +453,15 @@ static void gtkui_delete_targets(GtkWidget *widget, gpointer data) {
    GtkTreeIter iter;
    GtkTreeModel *model;
    struct ip_list *il = NULL;
+   gint *type = data;
 
    /* variable not used */
    (void) widget;
 
-   switch((int)data) {
+   if (type == NULL)
+       return;
+
+   switch(*type) {
       case 1:
          DEBUG_MSG("gtkui_delete_target: list 1");
          model = GTK_TREE_MODEL (liststore1);

--- a/src/interfaces/gtk/ec_gtk_view_connections.c
+++ b/src/interfaces/gtk/ec_gtk_view_connections.c
@@ -612,6 +612,7 @@ static void gtkui_connection_data_split(void)
    GtkTextIter iter;
    char tmp[MAX_ASCII_ADDR_LEN];
    char title[MAX_ASCII_ADDR_LEN+6];
+   gint scroll_split = 1;
 
    DEBUG_MSG("gtk_connection_data_split");
 
@@ -745,7 +746,7 @@ static void gtkui_connection_data_split(void)
       gtkui_page_present(data_window);
 
    /* after widgets are drawn, scroll to bottom */
-   g_timeout_add(500, gtkui_connections_scroll, (gpointer)1);
+   g_timeout_add(500, gtkui_connections_scroll, (gpointer)&scroll_split);
 
    /* print the old data */
    connbuf_print(&curr_conn->data, split_print);
@@ -919,6 +920,7 @@ static void gtkui_connection_data_join(void)
    char src[MAX_ASCII_ADDR_LEN];
    char dst[MAX_ASCII_ADDR_LEN];
    char title[TITLE_LEN];
+   gint scroll_join = 2;
 
    DEBUG_MSG("gtk_connection_data_join");
 
@@ -999,7 +1001,7 @@ static void gtkui_connection_data_join(void)
       gtkui_page_present(data_window);
 
    /* after widgets are drawn, scroll to bottom */
-   g_timeout_add(500, gtkui_connections_scroll, (gpointer)2);
+   g_timeout_add(500, gtkui_connections_scroll, (gpointer)&scroll_join);
 
    /* print the old data */
    connbuf_print(&curr_conn->data, join_print);
@@ -1010,7 +1012,12 @@ static void gtkui_connection_data_join(void)
 
 static gboolean gtkui_connections_scroll(gpointer data)
 {
-   if((int)data == 1 && textview1 && endmark1 && textview2 && endmark2) {
+   gint *type = data;
+
+   if (type == NULL)
+       return FALSE;
+
+   if(*type == 1 && textview1 && endmark1 && textview2 && endmark2) {
       /* scroll split data views to bottom */
       gtk_text_view_scroll_to_mark(GTK_TEXT_VIEW (textview1), endmark1, 0, FALSE, 0, 0);
       gtk_text_view_scroll_to_mark(GTK_TEXT_VIEW (textview2), endmark2, 0, FALSE, 0, 0); 


### PR DESCRIPTION
This pull should be discussed in a dedicated pull as it addresses a new standard header file inclusion and I can only test for Linux 32/64 bit.

I'm not sure how the availability of this header file is on other platforms. I tried to handle it by defining the used macros if the header file is not found on a system.

To successfully build it cmake have to freshly run the configure phase.
So 

```
make clean-all
cmake ../
make
```

should do it. However the warninigs addressed in this pull only appear on 64-bit systems. 
