### PR TITLE
define stack vars as static to be still set in callback func

### DIFF
--- a/src/interfaces/gtk/ec_gtk_hosts.c
+++ b/src/interfaces/gtk/ec_gtk_hosts.c
@@ -173,9 +173,9 @@ void gtkui_host_list(void)
    GtkWidget *scrolled, *treeview, *vbox, *hbox, *button;
    GtkCellRenderer   *renderer;
    GtkTreeViewColumn *column;
-   gint host_delete = HOST_DELETE;
-   gint host_target1 = HOST_TARGET1;
-   gint host_target2 = HOST_TARGET2;
+   static gint host_delete = HOST_DELETE;
+   static gint host_target1 = HOST_TARGET1;
+   static gint host_target2 = HOST_TARGET2;
 
    DEBUG_MSG("gtk_host_list");
 
@@ -233,17 +233,17 @@ void gtkui_host_list(void)
 
    button = gtk_button_new_with_mnemonic("_Delete Host");
    gtk_box_pack_start(GTK_BOX (hbox), button, TRUE, TRUE, 0);
-   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_button_callback), (gpointer)&host_delete);
+   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_button_callback), &host_delete);
    gtk_widget_show(button);
 
    button = gtk_button_new_with_mnemonic("Add to Target _1");
    gtk_box_pack_start(GTK_BOX (hbox), button, TRUE, TRUE, 0);
-   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_button_callback), (gpointer)&host_target1);
+   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_button_callback), &host_target1);
    gtk_widget_show(button);
 
    button = gtk_button_new_with_mnemonic("Add to Target _2");
    gtk_box_pack_start(GTK_BOX (hbox), button, TRUE, TRUE, 0);
-   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_button_callback), (gpointer)&host_target2);
+   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_button_callback), &host_target2);
    gtk_widget_show(button);
 
    gtk_widget_show(hosts_window);

--- a/src/interfaces/gtk/ec_gtk_targets.c
+++ b/src/interfaces/gtk/ec_gtk_targets.c
@@ -198,8 +198,8 @@ void gtkui_current_targets(void)
    GtkWidget *scrolled, *treeview, *vbox, *hbox, *button;
    GtkCellRenderer   *renderer;
    GtkTreeViewColumn *column;
-   gint delete_targets1 = 1;
-   gint delete_targets2 = 2;
+   static gint delete_targets1 = 1;
+   static gint delete_targets2 = 2;
 
    DEBUG_MSG("gtk_current_targets");
 
@@ -269,13 +269,13 @@ void gtkui_current_targets(void)
    gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 0);
 
    button = gtk_button_new_with_mnemonic("Delete");
-   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_delete_targets), (gpointer)&delete_targets1);
+   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_delete_targets), &delete_targets1);
    gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 0);
    button = gtk_button_new_with_mnemonic("Add");
    g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_add_target1), NULL);
    gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 0);
    button = gtk_button_new_with_mnemonic("Delete");
-   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_delete_targets), (gpointer)&delete_targets2);
+   g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_delete_targets), &delete_targets2);
    gtk_box_pack_start(GTK_BOX(hbox), button, TRUE, TRUE, 0);
    button = gtk_button_new_with_mnemonic("Add");
    g_signal_connect(G_OBJECT (button), "clicked", G_CALLBACK (gtkui_add_target2), NULL);

--- a/src/interfaces/gtk/ec_gtk_view_connections.c
+++ b/src/interfaces/gtk/ec_gtk_view_connections.c
@@ -612,7 +612,7 @@ static void gtkui_connection_data_split(void)
    GtkTextIter iter;
    char tmp[MAX_ASCII_ADDR_LEN];
    char title[MAX_ASCII_ADDR_LEN+6];
-   gint scroll_split = 1;
+   static gint scroll_split = 1;
 
    DEBUG_MSG("gtk_connection_data_split");
 
@@ -746,7 +746,7 @@ static void gtkui_connection_data_split(void)
       gtkui_page_present(data_window);
 
    /* after widgets are drawn, scroll to bottom */
-   g_timeout_add(500, gtkui_connections_scroll, (gpointer)&scroll_split);
+   g_timeout_add(500, gtkui_connections_scroll, &scroll_split);
 
    /* print the old data */
    connbuf_print(&curr_conn->data, split_print);
@@ -920,7 +920,7 @@ static void gtkui_connection_data_join(void)
    char src[MAX_ASCII_ADDR_LEN];
    char dst[MAX_ASCII_ADDR_LEN];
    char title[TITLE_LEN];
-   gint scroll_join = 2;
+   static gint scroll_join = 2;
 
    DEBUG_MSG("gtk_connection_data_join");
 
@@ -1001,7 +1001,7 @@ static void gtkui_connection_data_join(void)
       gtkui_page_present(data_window);
 
    /* after widgets are drawn, scroll to bottom */
-   g_timeout_add(500, gtkui_connections_scroll, (gpointer)&scroll_join);
+   g_timeout_add(500, gtkui_connections_scroll, &scroll_join);
 
    /* print the old data */
    connbuf_print(&curr_conn->data, join_print);


### PR DESCRIPTION
Just encountered an issue with one of my latest pulls.
In Gtk, if you try to select one host to any target, ist just gets deleted from the host list.

This is due to the variable which is copied by reference to the callback function not declared as static. In the scope of the callback function, the pointer value isn't set.
