### PR TITLE
Bug #436: Include guards became unique.

### DIFF
--- a/include/ec.h
+++ b/include/ec.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_H
-#define EC_H
+#ifndef ETTERCAP_H
+#define ETTERCAP_H
 
 #include <config.h>
 

--- a/include/ec_capture.h
+++ b/include/ec_capture.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_CAPTURE_H
-#define EC_CAPTURE_H
+#ifndef ETTERCAP_CAPTURE_H
+#define ETTERCAP_CAPTURE_H
 
 #include <ec.h>
 #include <ec_threads.h>

--- a/include/ec_checksum.h
+++ b/include/ec_checksum.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_CHECKSUM_H
-#define EC_CHECKSUM_H
+#ifndef ETTERCAP_CHECKSUM_H
+#define ETTERCAP_CHECKSUM_H
 
 #include <ec_packet.h>
 

--- a/include/ec_conf.h
+++ b/include/ec_conf.h
@@ -1,8 +1,5 @@
-
-
-#ifndef EC_CONF_H
-#define EC_CONF_H
-
+#ifndef ETTERCAP_CONF_H
+#define ETTERCAP_CONF_H
 
 struct conf_entry {
    char *name;

--- a/include/ec_connbuf.h
+++ b/include/ec_connbuf.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_CONNBUF_H
-#define EC_CONNBUF_H
+#ifndef ETTERCAP_CONNBUF_H
+#define ETTERCAP_CONNBUF_H
 
 #include <ec_inet.h>
 #include <ec_threads.h>

--- a/include/ec_conntrack.h
+++ b/include/ec_conntrack.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_CONNTRACK_H
-#define EC_CONNTRACK_H
+#ifndef ETTERCAP_CONNTRACK_H
+#define ETTERCAP_CONNTRACK_H
 
 #include <ec_profiles.h>
 #include <ec_connbuf.h>

--- a/include/ec_debug.h
+++ b/include/ec_debug.h
@@ -1,7 +1,5 @@
-
-
-#if defined (DEBUG) && !defined(EC_DEBUG_H)
-#define EC_DEBUG_H
+#if defined(DEBUG) && !defined(ETTERCAP_DEBUG_H)
+#define ETTERCAP_DEBUG_H
 
 EC_API_EXTERN void debug_init(void);
 EC_API_EXTERN void debug_msg(const char *message, ...);

--- a/include/ec_decode.h
+++ b/include/ec_decode.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_DECODE_H
-#define EC_DECODE_H
+#ifndef ETTERCAP_DECODE_H
+#define ETTERCAP_DECODE_H
 
 #include <ec_proto.h>
 #include <ec_packet.h>

--- a/include/ec_dispatcher.h
+++ b/include/ec_dispatcher.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_DISPATCHER_H
-#define EC_DISPATCHER_H
+#ifndef ETTERCAP_DISPATCHER_H
+#define ETTERCAP_DISPATCHER_H
 
 #include <ec_threads.h>
 #include <ec_packet.h>

--- a/include/ec_dissect.h
+++ b/include/ec_dissect.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_DISSECT_H
-#define EC_DISSECT_H
+#ifndef ETTERCAP_DISSECT_H
+#define ETTERCAP_DISSECT_H
 
 #include <ec_packet.h>
 #include <ec_session.h>

--- a/include/ec_encryption.h
+++ b/include/ec_encryption.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_ENCRYPTION_H
-#define EC_ENCRYPTION_H
+#ifndef ETTERCAP_ENCRYPTION_H
+#define ETTERCAP_ENCRYPTION_H
 
 #include <ec_inet.h>
 

--- a/include/ec_error.h
+++ b/include/ec_error.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_ERROR_H
-#define EC_ERROR_H
+#ifndef ETTERCAP_ERROR_H
+#define ETTERCAP_ERROR_H
 
 #include <errno.h>
 

--- a/include/ec_file.h
+++ b/include/ec_file.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_FILE_H
-#define EC_FILE_H
+#ifndef ETTERCAP_FILE_H
+#define ETTERCAP_FILE_H
 
 EC_API_EXTERN FILE * open_data(char *dir, char *file, char *mode);
 EC_API_EXTERN char * get_full_path(const char *dir, const char *file);

--- a/include/ec_filter.h
+++ b/include/ec_filter.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_FILTER_H
-#define EC_FILTER_H
+#ifndef ETTERCAP_FILTER_H
+#define ETTERCAP_FILTER_H
 
 #include <ec_packet.h>
 

--- a/include/ec_fingerprint.h
+++ b/include/ec_fingerprint.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_FINGERPRINT_H
-#define EC_FINGERPRINT_H
+#ifndef ETTERCAP_FINGERPRINT_H
+#define ETTERCAP_FINGERPRINT_H
 
 EC_API_EXTERN int fingerprint_init(void);
 EC_API_EXTERN int fingerprint_search(const char *f, char *dst);

--- a/include/ec_format.h
+++ b/include/ec_format.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_FORMAT_H
-#define EC_FORMAT_H
+#ifndef ETTERCAP_FORMAT_H
+#define ETTERCAP_FORMAT_H
 
 EC_API_EXTERN int hex_len(int len);
 EC_API_EXTERN int hex_format(const u_char *buf, size_t len, u_char *dst);

--- a/include/ec_globals.h
+++ b/include/ec_globals.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_GLOBALS_H
-#define EC_GLOBALS_H
+#ifndef ETTERCAP_GLOBALS_H
+#define ETTERCAP_GLOBALS_H
 
 #include <ec_sniff.h>
 #include <ec_inet.h>

--- a/include/ec_hash.h
+++ b/include/ec_hash.h
@@ -1,5 +1,3 @@
-
-
 #ifndef __FNV_H__
 #define __FNV_H__
 

--- a/include/ec_hook.h
+++ b/include/ec_hook.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_HOOK_H
-#define EC_HOOK_H
+#ifndef ETTERCAP_HOOK_H
+#define ETTERCAP_HOOK_H
 
 #include <ec_packet.h>
 

--- a/include/ec_http.h
+++ b/include/ec_http.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_HTTP_H
-#define EC_HTTP_H
+#ifndef ETTERCAP_HTTP_H
+#define ETTERCAP_HTTP_H
 
 EC_API_EXTERN int http_fields_init(void);
 

--- a/include/ec_inet.h
+++ b/include/ec_inet.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_INET_H
-#define EC_INET_H
+#ifndef ETTERCAP_INET_H
+#define ETTERCAP_INET_H
 
 #include <ec_queue.h>
 

--- a/include/ec_inject.h
+++ b/include/ec_inject.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_INJECT_H
-#define EC_INJECT_H
+#ifndef ETTERCAP_INJECT_H
+#define ETTERCAP_INJECT_H
 
 #include <ec_packet.h>
 #include <ec_conntrack.h>

--- a/include/ec_interfaces.h
+++ b/include/ec_interfaces.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_INTERFACES_H
-#define EC_INTERFACES_H
+#ifndef ETTERCAP_INTERFACES_H
+#define ETTERCAP_INTERFACES_H
 
 /* colors for curses interface */
 struct curses_color {

--- a/include/ec_log.h
+++ b/include/ec_log.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_LOG_H
-#define EC_LOG_H
+#ifndef ETTERCAP_LOG_H
+#define ETTERCAP_LOG_H
 
 #include <ec_inet.h>
 #include <ec_packet.h>

--- a/include/ec_lua.h
+++ b/include/ec_lua.h
@@ -1,5 +1,5 @@
-#ifndef EC_LUA_H
-#define EC_LUA_H
+#ifndef ETTERCAP_LUA_H
+#define ETTERCAP_LUA_H
 #include <ec_packet.h>
 #define ETTERCAP_LUA_MODULE "ettercap"
 #define ETTERCAP_C_API_LUA_MODULE "ettercap_c"

--- a/include/ec_manuf.h
+++ b/include/ec_manuf.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_MANUF_H
-#define EC_MANUF_H
+#ifndef ETTERCAP_MANUF_H
+#define ETTERCAP_MANUF_H
 
 EC_API_EXTERN int manuf_init(void);
 EC_API_EXTERN char * manuf_search(const char *m);

--- a/include/ec_mitm.h
+++ b/include/ec_mitm.h
@@ -1,8 +1,5 @@
-
-
-#ifndef EC_MITM_H
-#define EC_MITM_H
-
+#ifndef ETTERCAP_MITM_H
+#define ETTERCAP_MITM_H
 
 struct mitm_method {
    char *name;

--- a/include/ec_network.h
+++ b/include/ec_network.h
@@ -1,5 +1,5 @@
-#ifndef EC_INIT_H
-#define EC_INIT_H
+#ifndef ETTERCAP_INIT_H
+#define ETTERCAP_INIT_H
 
 #include <ec.h>
 #include <ec_inet.h>

--- a/include/ec_os_mingw.h
+++ b/include/ec_os_mingw.h
@@ -1,5 +1,5 @@
-#ifndef EC_OS_MINGW_H
-#define EC_OS_MINGW_H
+#ifndef ETTERCAP_OS_MINGW_H
+#define ETTERCAP_OS_MINGW_H
 
 /* This file is *not* MingW specific, but Ettercap requires gcc.
  * So that leaves other Win32 compilers out.

--- a/include/ec_packet.h
+++ b/include/ec_packet.h
@@ -1,7 +1,5 @@
-
-
-#if !defined(EC_PACKET_H)
-#define EC_PACKET_H
+#ifndef ETTERCAP_PACKET_H
+#define ETTERCAP_PACKET_H
 
 #include <ec_proto.h>
 #include <ec_profiles.h>

--- a/include/ec_parser.h
+++ b/include/ec_parser.h
@@ -1,8 +1,5 @@
-
-
-#ifndef EC_PARSER_H
-#define EC_PARSER_H
-
+#ifndef ETTERCAP_PARSER_H
+#define ETTERCAP_PARSER_H
 
 EC_API_EXTERN void parse_options(int argc, char **argv);
 

--- a/include/ec_passive.h
+++ b/include/ec_passive.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_PASSIVE_H
-#define EC_PASSIVE_H
+#ifndef ETTERCAP_PASSIVE_H
+#define ETTERCAP_PASSIVE_H
 
 EC_API_EXTERN int is_open_port(u_int8 proto, u_int16 port, u_int8 flags);
 EC_API_EXTERN void print_host(struct host_profile *h); 

--- a/include/ec_plugins.h
+++ b/include/ec_plugins.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_PLUGINS_H
-#define EC_PLUGINS_H
+#ifndef ETTERCAP_PLUGINS_H
+#define ETTERCAP_PLUGINS_H
 
 #include <ec_stdint.h>
 #include <ec_version.h>

--- a/include/ec_poll.h
+++ b/include/ec_poll.h
@@ -1,8 +1,5 @@
-
-
-#ifndef EC_POLL_H
-#define EC_POLL_H
-
+#ifndef ETTERCAP_POLL_H
+#define ETTERCAP_POLL_H
 
 EC_API_EXTERN int ec_poll_in(int fd, u_int msec);
 EC_API_EXTERN int ec_poll_out(int fd, u_int msec);

--- a/include/ec_profiles.h
+++ b/include/ec_profiles.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_PROFILES_H
-#define EC_PROFILES_H
+#ifndef ETTERCAP_PROFILES_H
+#define ETTERCAP_PROFILES_H
 
 #include <ec_fingerprint.h>
 #include <ec_resolv.h>

--- a/include/ec_proto.h
+++ b/include/ec_proto.h
@@ -1,6 +1,5 @@
-
-#ifndef EC_PROTO_H
-#define EC_PROTO_H
+#ifndef ETTERCAP_PROTO_H
+#define ETTERCAP_PROTO_H
 
 #include <ec_inet.h>
 

--- a/include/ec_queue.h
+++ b/include/ec_queue.h
@@ -40,8 +40,8 @@
  *      @(#)queue.h     8.5 (Berkeley) 8/20/94
  */
 
-#ifndef EC_QUEUE_H
-#define EC_QUEUE_H
+#ifndef ETTERCAP_QUEUE_H
+#define ETTERCAP_QUEUE_H
 
 /* to avoid conflict with system includes */
 #define _SYS_QUEUE_H_

--- a/include/ec_resolv.h
+++ b/include/ec_resolv.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_RESOLV_H
-#define EC_RESOLV_H
+#ifndef ETTERCAP_RESOLV_H
+#define ETTERCAP_RESOLV_H
 
 #include <ec_inet.h>
 

--- a/include/ec_scan.h
+++ b/include/ec_scan.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_SCAN_H
-#define EC_SCAN_H
+#ifndef ETTERCAP_SCAN_H
+#define ETTERCAP_SCAN_H
 
 EC_API_EXTERN void build_hosts_list(void);
 EC_API_EXTERN void del_hosts_list(void);

--- a/include/ec_send.h
+++ b/include/ec_send.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_SEND_H
-#define EC_SEND_H
+#ifndef ETTERCAP_SEND_H
+#define ETTERCAP_SEND_H
 
 #include <ec_packet.h>
 #include <ec_network.h>

--- a/include/ec_services.h
+++ b/include/ec_services.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_SERVICES_H
-#define EC_SERVICES_H
+#ifndef ETTERCAP_SERVICES_H
+#define ETTERCAP_SERVICES_H
 
 EC_API_EXTERN int services_init(void);
 EC_API_EXTERN char * service_search(u_int32 serv, u_int8 proto);

--- a/include/ec_session.h
+++ b/include/ec_session.h
@@ -1,8 +1,5 @@
-
-
-#ifndef EC_SESSION_H
-#define EC_SESSION_H
-
+#ifndef ETTERCAP_SESSION_H
+#define ETTERCAP_SESSION_H
 
 struct ec_session {
    void *ident;

--- a/include/ec_session_tcp.h
+++ b/include/ec_session_tcp.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_SESSION_TCP_H
-#define EC_SESSION_TCP_H
+#ifndef ETTERCAP_SESSION_TCP_H
+#define ETTERCAP_SESSION_TCP_H
 
 /* Session data structure */
 struct tcp_half_status {

--- a/include/ec_set.h
+++ b/include/ec_set.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_SET_H
-#define EC_SET_H
+#ifndef ETTERCAP_SET_H
+#define ETTERCAP_SET_H
 
 EC_API_EXTERN void set_mitm(char *mitm);
 EC_API_EXTERN void set_onlymitm(void);

--- a/include/ec_signals.h
+++ b/include/ec_signals.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_SIGNAL_H
-#define EC_SIGNAL_H
+#ifndef ETTERCAP_SIGNAL_H
+#define ETTERCAP_SIGNAL_H
 
 EC_API_EXTERN void signal_handler(void);
 

--- a/include/ec_sniff.h
+++ b/include/ec_sniff.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_SNIFF_H
-#define EC_SNIFF_H
+#ifndef ETTERCAP_SNIFF_H
+#define ETTERCAP_SNIFF_H
 
 #include <ec_packet.h>
 

--- a/include/ec_sniff_bridge.h
+++ b/include/ec_sniff_bridge.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_SNIFF_BRIDGE_H
-#define EC_SNIFF_BRIDGE_H
+#ifndef ETTERCAP_SNIFF_BRIDGE_H
+#define ETTERCAP_SNIFF_BRIDGE_H
 
 #include <ec_packet.h>
 

--- a/include/ec_sniff_unified.h
+++ b/include/ec_sniff_unified.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_SNIFF_UNIFIED_H
-#define EC_SNIFF_UNIFIED_H
+#ifndef ETTERCAP_SNIFF_UNIFIED_H
+#define ETTERCAP_SNIFF_UNIFIED_H
 
 /* exported functions */
 

--- a/include/ec_socket.h
+++ b/include/ec_socket.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_SOCKET_H
-#define EC_SOCKET_H
+#ifndef ETTERCAP_SOCKET_H
+#define ETTERCAP_SOCKET_H
 
 /* The never ending errno problems... */
 #if defined(OS_WINDOWS) && !defined(OS_CYGWIN)

--- a/include/ec_sslwrap.h
+++ b/include/ec_sslwrap.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_SSLWRAP_H
-#define EC_SSLWRAP_H
+#ifndef ETTERCAP_SSLWRAP_H
+#define ETTERCAP_SSLWRAP_H
 
 #include <ec_decode.h>
 #include <ec_threads.h>

--- a/include/ec_stats.h
+++ b/include/ec_stats.h
@@ -1,5 +1,5 @@
-#ifndef EC_STATS_H
-#define EC_STATS_H
+#ifndef ETTERCAP_STATS_H
+#define ETTERCAP_STATS_H
 
 #include <pcap.h>
 

--- a/include/ec_stdint.h
+++ b/include/ec_stdint.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_STDINT_H
-#define EC_STDINT_H
+#ifndef ETTERCAP_STDINT_H
+#define ETTERCAP_STDINT_H
 
 #include <limits.h>
 

--- a/include/ec_streambuf.h
+++ b/include/ec_streambuf.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_STREAMBUF_H
-#define EC_STREAMBUF_H
+#ifndef ETTERCAP_STREAMBUF_H
+#define ETTERCAP_STREAMBUF_H
 
 #include <ec_threads.h>
 

--- a/include/ec_strings.h
+++ b/include/ec_strings.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_STRINGS_H
-#define EC_STRINGS_H
+#ifndef ETTERCAP_STRINGS_H
+#define ETTERCAP_STRINGS_H
 
 #ifdef HAVE_CTYPE_H
    #include <ctype.h>

--- a/include/ec_threads.h
+++ b/include/ec_threads.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_THREADS_H
-#define EC_THREADS_H
+#ifndef ETTERCAP_THREADS_H
+#define ETTERCAP_THREADS_H
 
 #include <ec_stdint.h>
 #include <pthread.h>

--- a/include/ec_ui.h
+++ b/include/ec_ui.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_UI_H
-#define EC_UI_H
+#ifndef ETTERCAP_UI_H
+#define ETTERCAP_UI_H
 
 #include <stdarg.h>
 

--- a/include/ec_update.h
+++ b/include/ec_update.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_UPDATE_H
-#define EC_UPDATE_H
+#ifndef ETTERCAP_UPDATE_H
+#define ETTERCAP_UPDATE_H
 
 EC_API_EXTERN void global_update(void);
 

--- a/include/ec_utils.h
+++ b/include/ec_utils.h
@@ -1,5 +1,5 @@
-#ifndef EC_UTILS_H_
-#define EC_UTILS_H_
+#ifndef ETTERCAP_UTILS_H
+#define ETTERCAP_UTILS_H
 
 EC_API_EXTERN int expand_token(char *s, u_int max, void (*func)(void *t, u_int n), void *t );
 EC_API_EXTERN int set_regex(char *regex);

--- a/include/ec_version.h
+++ b/include/ec_version.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_VERS_H
-#define EC_VERS_H
+#ifndef ETTERCAP_VERS_H
+#define ETTERCAP_VERS_H
 
 #define EC_VERSION            "0.8.0"
 #define EC_VERSION_MAJOR      0

--- a/include/ef.h
+++ b/include/ef.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EF_H
-#define EF_H
+#ifndef ETTERFILTER_H
+#define ETTERFILTER_H
 
 #include <config.h>
 

--- a/include/ef_functions.h
+++ b/include/ef_functions.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EF_FUNCTIONS_H
-#define EF_FUNCTIONS_H
+#ifndef ETTERFILTER_FUNCTIONS_H
+#define ETTERFILTER_FUNCTIONS_H
 
 #include <ec_filter.h>
 

--- a/include/el.h
+++ b/include/el.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EL_H
-#define EL_H
+#ifndef ETTERLOG_H
+#define ETTERLOG_H
 
 #include <config.h>
 

--- a/include/el_functions.h
+++ b/include/el_functions.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EL_FUNCTIONS_H
-#define EL_FUNCTIONS_H
+#ifndef ETTERLOG_FUNCTIONS_H
+#define ETTERLOG_FUNCTIONS_H
 
 #include <ec_log.h>
 #include <ec_profiles.h>

--- a/src/interfaces/curses/ec_curses.h
+++ b/src/interfaces/curses/ec_curses.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_CURSES_H
-#define EC_CURSES_H
+#ifndef ETTERCAP_CURSES_H
+#define ETTERCAP_CURSES_H
 
 #include <wdg.h>
 

--- a/src/interfaces/gtk/ec_gtk.h
+++ b/src/interfaces/gtk/ec_gtk.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_GTK_H
-#define EC_GTK_H
+#ifndef ETTERCAP_GTK_H
+#define ETTERCAP_GTK_H
 #define G_DISABLE_CONST_RETURNS
 #include <gtk/gtk.h>
 

--- a/src/interfaces/text/ec_text.h
+++ b/src/interfaces/text/ec_text.h
@@ -1,7 +1,5 @@
-
-
-#ifndef EC_TEXT_H
-#define EC_TEXT_H
+#ifndef ETTERCAP_TEXT_H
+#define ETTERCAP_TEXT_H
 
 extern void set_text_interface(void);
 extern int text_plugin(char *plugin);


### PR DESCRIPTION
Include guards prevent the multiple inclusion of header files only correctly
if the chosen identifiers are different from others with such a functionality.
The probability for name clashes is reduced by the addition of the project name
as a prefix.

Signed-off-by: Markus Elfring elfring@users.sourceforge.net
