### PR TITLE
Fixed atexit message

### DIFF
--- a/include/ec_utils.h
+++ b/include/ec_utils.h
@@ -6,5 +6,6 @@ EC_API_EXTERN int set_regex(char *regex);
 EC_API_EXTERN char **parse_iflist(char *list);
 EC_API_EXTERN void drop_privs(void);
 EC_API_EXTERN void regain_privs(void);
+EC_API_EXTERN void regain_privs_atexit(void);
 
 #endif

--- a/src/ec_utils.c
+++ b/src/ec_utils.c
@@ -152,6 +152,15 @@ char **parse_iflist(char *list)
 }
 
 /*
+ * regain root privs inside an atexit call
+ */
+void regain_privs_atexit(void)
+{
+   DEBUG_MSG("ATEXIT: regain_privs");
+   regain_privs();
+}
+
+/*
  * regain root privs
  */
 void regain_privs(void)

--- a/src/os/ec_bsd.c
+++ b/src/os/ec_bsd.c
@@ -54,7 +54,7 @@ void disable_ip_forward(void)
    DEBUG_MSG("disable_ip_forward | net.inet.ip.forwarding = %d  old_value = %d\n", val, saved_status);
   
    atexit(restore_ip_forward);
-   atexit(regain_privs);
+   atexit(regain_privs_atexit);
 }
 
 

--- a/src/os/ec_cygwin.c
+++ b/src/os/ec_cygwin.c
@@ -90,7 +90,7 @@ void disable_ip_forward(void)
    }
 
    atexit(restore_ip_forward);
-   atexit(regain_privs);
+   atexit(regain_privs_atexit);
 }
 
 static void restore_ip_forward(void)

--- a/src/os/ec_darwin.c
+++ b/src/os/ec_darwin.c
@@ -52,7 +52,7 @@ void disable_ip_forward(void)
    DEBUG_MSG("disable_ip_forward | net.inet.ip.forwarding = %d  old_value = %d\n", val, saved_status);
                                        
    atexit(restore_ip_forward);
-   atexit(regain_privs);
+   atexit(regain_privs_atexit);
 }
 
 

--- a/src/os/ec_linux.c
+++ b/src/os/ec_linux.c
@@ -50,7 +50,7 @@ void disable_ip_forward(void)
    fclose(fd);
    
    atexit(restore_ip_forward);
-   atexit(regain_privs);
+   atexit(regain_privs_atexit);
 }
 
 static void restore_ip_forward(void)

--- a/src/os/ec_solaris.c
+++ b/src/os/ec_solaris.c
@@ -83,7 +83,7 @@ void disable_ip_forward(void)
    DEBUG_MSG("Inet_DisableForwarding -- NEW value = 0");
 
    atexit(restore_ip_forward);
-   atexit(regain_privs);
+   atexit(regain_privs_atexit);
 }
 
 static void restore_ip_forward(void)


### PR DESCRIPTION
in this way when we call regain_privs from atexit we get the debug message, and we don't when we call it from ssl\* stuff
