### PR TITLE
check on every plugin

### DIFF
--- a/include/ec_plugins.h
+++ b/include/ec_plugins.h
@@ -21,6 +21,7 @@ struct plugin_ops
 struct plugin_list
 {
    char *name;
+   bool exists;
    LIST_ENTRY(plugin_list) next;
 };
 

--- a/src/ec_set.c
+++ b/src/ec_set.c
@@ -83,6 +83,7 @@ void set_plugin(char *name)
 
     SAFE_CALLOC(plugin, 1, sizeof(struct plugin_list));
     plugin->name = strdup(name);
+    plugin->exists = true;
     LIST_INSERT_HEAD(&GBL_OPTIONS->plugins, plugin, next);
 
 }

--- a/src/interfaces/daemon/ec_daemon.c
+++ b/src/interfaces/daemon/ec_daemon.c
@@ -151,7 +151,9 @@ void daemon_interface(void)
    LIST_FOREACH_SAFE(plugin, &GBL_OPTIONS->plugins, next, tmp) {
       /* check if the plugin exists */
       if (search_plugin(plugin->name) != ESUCCESS)
-         FATAL_ERROR("%s plugin can not be found !", plugin->name);
+         plugin->exists = false;
+         USER_MSG("Sorry, plugin '%s' can not be found - skipping!\n\n", 
+               plugin->name);
    }
    
    /* build the list of active hosts */
@@ -165,9 +167,9 @@ void daemon_interface(void)
    
    /* if we have to activate a plugin */
    LIST_FOREACH_SAFE(plugin, &GBL_OPTIONS->plugins, next, tmp) {
-      if (plugin_init(plugin->name) != PLUGIN_RUNNING)
-         /* end the interface */
-         return;
+      if (plugin->exists && plugin_init(plugin->name) != PLUGIN_RUNNING)
+         /* skip plugin */
+         USER_MSG("Plugin '%s' can not be started - skipping!\n\n", plugin->name);
    }
 
    /* discard the messages */

--- a/src/interfaces/text/ec_text.c
+++ b/src/interfaces/text/ec_text.c
@@ -276,8 +276,9 @@ void text_interface(void)
    LIST_FOREACH_SAFE(plugin, &GBL_OPTIONS->plugins, next, tmp) {
       /* check if the specified plugin exists */
       if (search_plugin(plugin->name) != ESUCCESS) {
-         tcsetattr(0, TCSANOW, &old_tc);
-         FATAL_ERROR("%s plugin can not be found !", plugin->name);
+         plugin->exists = false;
+         USER_MSG("Sorry, plugin '%s' can not be found - skipping!\n\n", 
+               plugin->name);
       }
 
    }
@@ -308,9 +309,10 @@ void text_interface(void)
        * its execution
        */
       LIST_FOREACH_SAFE(plugin, &GBL_OPTIONS->plugins, next, tmp) {
-          if (text_plugin(plugin->name) != PLUGIN_RUNNING)
-             /* end the interface */
-             return;
+          if (plugin->exists && text_plugin(plugin->name) != PLUGIN_RUNNING)
+             /* skip plugin */
+             USER_MSG("Plugin '%s' can not be started - skipping!\n\n", 
+                   plugin->name);
       }
    }
 


### PR DESCRIPTION
This pull is the result of the suggestion in pull #476 not to stop the user interface (text and daemon) if one plugin was not found due to typo or something else.
