### PR TITLE
ARP poison only IPv4 addresses if ANY is targeted

### DIFF
--- a/src/mitm/ec_arp_poisoning.c
+++ b/src/mitm/ec_arp_poisoning.c
@@ -411,8 +411,10 @@ static int create_silent_list(void)
       memcpy(&g->mac, MEDIA_BROADCAST, MEDIA_ADDR_LEN);
    }
 
-   if (i == j) {
-      USER_MSG("\nERROR: Cannot poison theese targets...\n");
+   if (i == j || 
+       ntohs(i->ip.addr_type) != AF_INET || 
+       ntohs(j->ip.addr_type) != AF_INET) {
+      USER_MSG("\nERROR: Cannot ARP poison theese targets...\n");
       SAFE_FREE(h);
       SAFE_FREE(g);
       return -EFATAL;
@@ -467,6 +469,9 @@ static int create_list(void)
       
       /* add them */ 
       LIST_FOREACH(h, &GBL_HOSTLIST, next) {
+         /* only IPv4 */
+         if (ntohs(h->ip.addr_type) != AF_INET)
+            continue;
            
          /* create the element and insert it in the list */
          SAFE_CALLOC(g, 1, sizeof(struct hosts_list));
@@ -506,6 +511,9 @@ static int create_list(void)
       
       /* add them */ 
       LIST_FOREACH(h, &GBL_HOSTLIST, next) {
+         /* only IPv4 */
+         if (ntohs(h->ip.addr_type) != AF_INET)
+            continue;
            
          /* create the element and insert it in the list */
          SAFE_CALLOC(g, 1, sizeof(struct hosts_list));


### PR DESCRIPTION
It's like having a déjà vu.
While trying to reproduce #485, I've encountered a strange thing which we had already some time ago.
I thought that we fixed it but I propably mess this with something else.

We saw that ettercap had some "foreign" addresses in the host list, which shouldn't be there because they we outside the subnet and not existing within the broadcast domain. And I've now been able to reproduce it.

I saw two hosts who didn't belong to my RFC1918 local IPv4 subnet:

```
1)  32.1.77.208 00:24:2B:69:C2:9B
....
15) 254.128.0.0 00:24:2B:69:C2:9B
```

FIrst I was wondering about the MAC address, but after a bit I figured that it's my own.
In the debug log I found the correspoinding debug output:

```
[capture[wlan0]]        get_response from 254.128.0.0
[capture[wlan0]]        get_response from 32.1.77.208
```

I've been able to catch the traffic and actually saw the packets, then I understood where theses addresses are coming from:

`254.128.0.0` is the same as `0xfe 80 00 00`(Link-Local IPv6 prefix) and `32.1.77.208` is the same as `0x20 01 4d d0` (my parent global unicast IPv6 prefix).

I found the root cause for this in the ARP poisoner, populating the ARP poison lists when ANY is targeted.
