### PR TITLE
handle different AF_INET6 values on different OSes

### DIFF
--- a/include/ec_inet.h
+++ b/include/ec_inet.h
@@ -27,6 +27,7 @@
  * used in the Null/Loopback encapsulation origined
  * on several BSD derivates
  */
+#define AF_INET6_LINUX 10
 #define AF_INET6_BSD 24
 #define AF_INET6_FREEBSD 28
 #define AF_INET6_DARWIN 30

--- a/src/protocols/ec_null.c
+++ b/src/protocols/ec_null.c
@@ -71,9 +71,19 @@ FUNC_DECODER(decode_null)
       case AF_INET:          /* IPv4 on any system */
          lltype = LL_TYPE_IP;
          break;
+#if AF_INET6 != AF_INET6_BSD
       case AF_INET6_BSD:     /* IPv6 on NetBSD,OpenBSD,BSD/OS */
+#endif
+#if AF_INET6 != AF_INET6_FREEBSD
       case AF_INET6_FREEBSD: /* IPv6 on FreeBSD,DragonFlyBSD */
-      case AF_INET6:         /* IPv6 on Linux and others */
+#endif
+#if AF_INET6 != AF_INET6_DARWIN
+      case AF_INET6_DARWIN:  /* IPv6 on Darwin/Mac OS X */
+#endif
+#if AF_INET6 != AF_INET6_LINUX
+      case AF_INET6_LINUX:   /* IPv6 on Linux */
+#endif
+      case AF_INET6:         /* IPv6 on the compiling system */
          lltype = LL_TYPE_IP6; 
          break;
       default:               /* upper protocol not supported by ettercap */


### PR DESCRIPTION
This pull request addresses build issues on systems other than Linux, because the address family AF_INET6 has different values among the various operating systems.
However, the AF_INET6 values are still necessary to be known on the compiling system for analysing a PCAP traced on a loopback interface also from other systems than Linux.
This reintroduces the value _AF_INET6_DARWIN_ which has been taken out in commit d3c9a6a0c1331aa14f42b4497d9a02de2f6d3da8. I think that was because the built failed on Darwin with the same error.
Now it should work.
It also introduces a new AF_INET6 value for Linux, if ettercap is build on an other operating system and want to analyse a PCAP generated on Linux.
