### PR TITLE
system provided libnet detection for FreeBSD

### DIFF
--- a/cmake/Modules/FindLIBNET.cmake
+++ b/cmake/Modules/FindLIBNET.cmake
@@ -1,6 +1,6 @@
 # Copyright 2013 Ettercap Development Team.
 #
-# Distributed under GPL licnse.
+# Distributed under GPL license.
 #
 
 # Look for the header file


### PR DESCRIPTION
Fixes issue #532.
However the answer from the libnet package maintainer of FreeBSD is still outstanding why it is installed under this "non-standard" directory structure.
