### PR TITLE
check for standalone libiconv if not built in libc

### DIFF
--- a/cmake/Modules/EttercapLibCheck.cmake
+++ b/cmake/Modules/EttercapLibCheck.cmake
@@ -72,16 +72,22 @@ include(CheckLibraryExists)
 include(CheckIncludeFile)
 
 # Iconv
+FIND_LIBRARY(HAVE_ICONV iconv)
 CHECK_FUNCTION_EXISTS(iconv HAVE_UTF8)
-if(NOT HAVE_UTF8)
-    find_library(HAVE_ICONV iconv)
-    if(HAVE_ICONV)
-        set(HAVE_UTF8 1)
-        set(EC_LIBS ${EC_LIBS} ${HAVE_ICONV})
-# Not needed the next one?
-        set(EC_LIBETTERCAP_LIBS ${EC_LIBETTERCAP_LIBS} ${HAVE_ICONV})
-    endif(HAVE_ICONV)
-endif(NOT HAVE_UTF8)
+if(HAVE_ICONV)
+    # Seem that we have a dedicated iconv library not built in libc (e.g. FreeBSD)
+    set(HAVE_UTF8 1)
+    set(EC_LIBS ${EC_LIBS} ${HAVE_ICONV})
+    set(EC_LIBETTERCAP_LIBS ${EC_LIBETTERCAP_LIBS} ${HAVE_ICONV})
+else(HAVE_ICONV)
+    if(HAVE_UTF8)
+       # iconv built in libc
+    else(HAVE_UTF8)
+       message(FATAL_ERROR "iconv not found")
+    endif(HAVE_UTF8)
+endif(HAVE_ICONV)
+
+
 
 # LTDL
 if(ENABLE_PLUGINS)


### PR DESCRIPTION
On FreeBSD libiconv need to be manually linked because there it's not built in the libc. However the `CHECK_FUNCTION_EXISTS` check succeeds.

The file README.PLATFORMS mentions this, but the workaround doesn't work since we're using cmake.
So the intention is that cmake checks dynamically:
If we find a iconv library, we can assume to use it otherwise we just check if the function exists which then indicates that the libc built-in version is being used.
