### PR TITLE
Fix library property for etterfilter and etterlog

### DIFF
--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -22,6 +22,7 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 add_executable(etterfilter ${EF_SRC} ${FLEX_EF_SCANNER_OUTPUTS} ${BISON_EF_PARSER_OUTPUTS})
 target_link_libraries(etterfilter lib_ettercap)
+set_target_properties(etterfilter PROPERTIES INSTALL_RPATH ${INSTALL_LIBDIR})
 
 ## Etterlog
 
@@ -42,5 +43,6 @@ set(EL_SRC
 
 add_executable(etterlog ${EL_SRC})
 target_link_libraries(etterlog lib_ettercap)
+set_target_properties(etterlog PROPERTIES INSTALL_RPATH ${INSTALL_LIBDIR})
 
 install(TARGETS etterfilter etterlog DESTINATION ${INSTALL_BINDIR})


### PR DESCRIPTION
If ettercap is being installed in a non-standard directory, **etterlog** and **etterfilter** doesn't find their library they're linked against:

```
boston:/home/koeppea/tmp/ettercap/bin# ./etterfilter
./etterfilter: error while loading shared libraries: libettercap.so.0: cannot open shared object file: No such file or directory
boston:/home/koeppea/tmp/ettercap/bin# 
```

This pull requests fixes this and makes the setting of the LD_LIBRARY_PATH environment variable obsolete in such cases.
