### PR TITLE
fix initial Gtk child window position

### DIFF
--- a/src/interfaces/gtk/ec_gtk.c
+++ b/src/interfaces/gtk/ec_gtk.c
@@ -557,7 +557,7 @@ static void gtkui_error(const char *msg)
 
    dialog = gtk_message_dialog_new(GTK_WINDOW (window), GTK_DIALOG_MODAL, 
                                    GTK_MESSAGE_ERROR, GTK_BUTTONS_OK, "%s", unicode);
-   gtk_window_set_position(GTK_WINDOW (dialog), GTK_WIN_POS_CENTER);
+   gtk_window_set_position(GTK_WINDOW (dialog), GTK_WIN_POS_CENTER_ON_PARENT);
 
    /* blocking - displays dialog waits for user to click OK */
    gtk_dialog_run(GTK_DIALOG (dialog));
@@ -728,7 +728,7 @@ void gtkui_message(const char *msg)
 
    dialog = gtk_message_dialog_new(GTK_WINDOW (window), GTK_DIALOG_MODAL, 
                                    GTK_MESSAGE_INFO, GTK_BUTTONS_OK, "%s", msg);
-   gtk_window_set_position(GTK_WINDOW (dialog), GTK_WIN_POS_CENTER);
+   gtk_window_set_position(GTK_WINDOW (dialog), GTK_WIN_POS_CENTER_ON_PARENT);
 
    /* blocking - displays dialog waits for user to click OK */
    gtk_dialog_run(GTK_DIALOG (dialog));

--- a/src/interfaces/gtk/ec_gtk_mitm.c
+++ b/src/interfaces/gtk/ec_gtk_mitm.c
@@ -498,7 +498,7 @@ void gtkui_mitm_stop(void)
    /* create the dialog */
    dialog = gtk_message_dialog_new(GTK_WINDOW (window), GTK_DIALOG_MODAL,
             GTK_MESSAGE_INFO, 0, "Stopping the mitm attack...");
-   gtk_window_set_position(GTK_WINDOW (dialog), GTK_WIN_POS_CENTER);
+   gtk_window_set_position(GTK_WINDOW (dialog), GTK_WIN_POS_CENTER_ON_PARENT);
    gtk_window_set_resizable(GTK_WINDOW (dialog), FALSE);
    gtk_widget_queue_draw(dialog);
    gtk_widget_show_now(dialog);


### PR DESCRIPTION
Some child windows are positioned relative to the screen.
This becomes irritating if Ettercap isn't running in full screen on a bigger monitor.
This pull uses the newer constant to center all child window relative to the parent main window.
It makes this behaviour consistent for all child windows.
