### PR TITLE
Fix ignored dn_expand error

### DIFF
--- a/plug-ins/mdns_spoof/mdns_spoof.c
+++ b/plug-ins/mdns_spoof/mdns_spoof.c
@@ -309,7 +309,8 @@ static int parse_line (const char *str, int line, int *type_p, char **ip_p, u_in
     for (x = 0; x < mdns->questions; x++) {
 
       name_len = dn_expand((u_char*)mdns, end, q, name, sizeof(name));
-
+      if (name_len == -1)
+          return;
       q = data + name_len;
 
       if (q >= end || name_len == 0)


### PR DESCRIPTION
mdns_spoof does not check for the return value of dn_expand. The return value of dn_expand is used for copying the name later in the program, if the value is -1 will lead to stack overflow and denial of service attack
