### PR TITLE
Fix TN3270 out of bounds write

### DIFF
--- a/src/dissectors/ec_TN3270.c
+++ b/src/dissectors/ec_TN3270.c
@@ -118,7 +118,7 @@ FUNC_DECODER(dissector_TN3270)
 
                  int l = strlen(username);
                  if (l < 2)
-                     return;
+                     return NULL;
                  username[l-2] = 0;
                  DISSECT_MSG("%s:%d <= z/OS TSO Username : %s\n", ip_addr_ntoa(&PACKET->L3.dst, tmp), ntohs(PACKET->L4.dst), username);
          }
@@ -128,7 +128,7 @@ FUNC_DECODER(dissector_TN3270)
 		 password[511] = 0; /* Boundary */
                  int l = strlen(password);
                  if (l < 2)
-                     return;
+                     return NULL;
                  password[l-2] = 0;
                  DISSECT_MSG("%s:%d <= z/OS TSO Password : %s\n", ip_addr_ntoa(&PACKET->L3.dst, tmp), ntohs(PACKET->L4.dst), password);
          }


### PR DESCRIPTION
write to out of bounds of buffers if the username or password does not provided
