### PR TITLE
Fix radius stack overflow

### DIFF
--- a/src/dissectors/ec_radius.c
+++ b/src/dissectors/ec_radius.c
@@ -203,7 +203,7 @@ static u_char * radius_get_attribute(u_int8 attr, u_int16 *attr_len, u_char *beg
    while (begin < end) {
 
       /* get the len of the attribute and subtract the header len */
-      *attr_len = *(begin + 1) - 2;
+      *attr_len = (u_char)*(begin + 1) - 2;
      
       /* we have found our attribute */
       if (*begin == attr) {


### PR DESCRIPTION
function radius_get_attribute pass by reference attr_len, which is used as length argument in strncpy. radius_get_attribute does a subtraction -2, which may have a negative result (0xffff-0xfffe for u_int16). This value will lead to stack corruption 
