### PR TITLE
Fix cvs ignore end checking

### DIFF
--- a/src/dissectors/ec_cvs.c
+++ b/src/dissectors/ec_cvs.c
@@ -96,16 +96,16 @@ FUNC_DECODER(dissector_cvs)
    /* move over the cvsroot path */
    ptr += strlen(CVS_LOGIN) + 1;
 
+   if (ptr >= end) 
+       return NULL;
    /* go until \n */
    while(*ptr != '\n' && ptr != end) ptr++;
    if (ptr == end) return NULL;
-
    PACKET->DISSECTOR.user = strdup((const char*)++ptr);
    
    /* cut the username on \n */
    if ( (p = strchr(PACKET->DISSECTOR.user, '\n')) != NULL )
       *p = '\0';
-   
    /* go until \n */
    while(*ptr != '\n' && ptr != end) ptr++;
    if (ptr == end) return NULL;


### PR DESCRIPTION
cvs accepts only packets with CVS_LOGIN signature, and then does the addition with length of the signature plus 1 and searches for '\n' character while ptr !=end. The problem occurs when we provide a packet containing only the signature, this will lead to out of bounds loop because ptr will have a pointer value greater than the end
