### PR TITLE
Fixes Issue:583 Sequence Number Incorrect After TCP Injection

### DIFF
--- a/src/protocols/ec_tcp.c
+++ b/src/protocols/ec_tcp.c
@@ -414,7 +414,6 @@ FUNC_INJECTOR(inject_tcp)
    PACKET->DATA.len = LENGTH; 
    tcph->csum = L4_checksum(PACKET);
   
-   session_del(s->ident, TCP_IDENT_LEN); 
    return E_SUCCESS;
 }
 


### PR DESCRIPTION
Fix for Issue 583: https://github.com/Ettercap/ettercap/issues/583
Removing session delete from TCP Injection will allow code to adjust sequence numbers properly.
