### PR TITLE
GTK box wrapper

### DIFF
--- a/src/interfaces/gtk/ec_gtk.c
+++ b/src/interfaces/gtk/ec_gtk.c
@@ -415,11 +415,7 @@ void gtkui_about(void)
    notebook = gtk_notebook_new();
 
    /* General page */
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 10);
-#else
-   vbox = gtk_vbox_new(FALSE, 10);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 10, FALSE);
 
    path = INSTALL_DATADIR "/" EC_PROGRAM "/" LOGO_FILE_SMALL;
    if(g_file_test(path, G_FILE_TEST_EXISTS))
@@ -601,11 +597,7 @@ void gtkui_input(const char *title, char *input, size_t n, void (*callback)(void
 #endif
    gtk_container_set_border_width(GTK_CONTAINER (dialog), 5);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
-#else
-   hbox = gtk_hbox_new (FALSE, 6);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 6, FALSE);
 
    content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
    gtk_container_add(GTK_CONTAINER(content_area), hbox);
@@ -663,11 +655,7 @@ static void gtkui_progress(char *title, int value, int max)
       gtk_container_set_border_width(GTK_CONTAINER (progress_dialog), 5);
       g_signal_connect(G_OBJECT (progress_dialog), "delete_event", G_CALLBACK (gtkui_progress_cancel), NULL);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-      hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 3);
-#else
-      hbox = gtk_hbox_new(FALSE, 3);
-#endif
+      hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 3, FALSE);
       gtk_container_add(GTK_CONTAINER (progress_dialog), hbox);
     
       progress_bar = gtk_progress_bar_new();
@@ -999,11 +987,7 @@ static void gtkui_setup(void)
    gtk_window_add_accel_group (GTK_WINDOW (window), accel_group);
    gtk_window_add_accel_group(GTK_WINDOW(window), gtk_ui_manager_get_accel_group(menu_manager));
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-#else
-   vbox = gtk_vbox_new(FALSE, 0);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 0, FALSE);
    gtk_container_add(GTK_CONTAINER (window), vbox);
    gtk_widget_show(vbox);
 
@@ -1227,11 +1211,7 @@ static void gtkui_unified_sniff(void)
 #endif
    gtk_container_set_border_width(GTK_CONTAINER (dialog), 5);
   
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
-#else
-   hbox = gtk_hbox_new (FALSE, 6);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 6, FALSE);
 
    content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
    gtk_container_add(GTK_CONTAINER(content_area), hbox);
@@ -1263,11 +1243,7 @@ static void gtkui_unified_sniff(void)
    gtk_cell_layout_set_attributes( GTK_CELL_LAYOUT( iface_combo ), cell, "text", 0, NULL );
    gtk_combo_box_set_active(GTK_COMBO_BOX(iface_combo), 0);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-#else
-   vbox = gtk_vbox_new(FALSE, 0);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 0, FALSE);
    gtk_box_pack_start(GTK_BOX(vbox), iface_combo, TRUE, FALSE, 0);
    gtk_box_pack_start(GTK_BOX(hbox), vbox, FALSE, FALSE, 0);
 
@@ -1363,60 +1339,36 @@ static void gtkui_bridged_sniff(void)
    gtk_dialog_set_has_separator(GTK_DIALOG (dialog), FALSE);
 #endif
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox_big = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-#else
-   hbox_big = gtk_hbox_new (FALSE, 5);
-#endif
+   hbox_big = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 5, FALSE);
 
    content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
    gtk_container_add(GTK_CONTAINER(content_area), hbox_big);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-#else
-   vbox = gtk_vbox_new(FALSE, 0);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 0, FALSE);
    image = gtk_image_new_from_stock (GTK_STOCK_DIALOG_QUESTION, GTK_ICON_SIZE_DIALOG);
    gtk_misc_set_alignment (GTK_MISC (image), 0.5, 0.1);
    gtk_box_pack_start (GTK_BOX (vbox), image, TRUE, FALSE, 5);
    gtk_box_pack_start(GTK_BOX(hbox_big), vbox, FALSE, FALSE, 0);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 2);
-#else
-   vbox = gtk_vbox_new (FALSE, 2);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 2, FALSE);
    gtk_container_set_border_width(GTK_CONTAINER (vbox), 5);
    gtk_box_pack_start (GTK_BOX (hbox_big), vbox, TRUE, TRUE, 0);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-#else
-   hbox = gtk_hbox_new(FALSE, 0);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 0, FALSE);
    gtk_box_pack_start(GTK_BOX (vbox), hbox, TRUE, TRUE, 0);
 
    label = gtk_label_new ("First network interface  : ");
    gtk_misc_set_alignment(GTK_MISC (label), 0, 0.5);
    gtk_box_pack_start(GTK_BOX (hbox), label, TRUE, TRUE, 0);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-#else
-   hbox = gtk_hbox_new(FALSE, 0);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 0, FALSE);
    gtk_box_pack_start(GTK_BOX (vbox), hbox, TRUE, TRUE, 0);
 
    label = gtk_label_new ("Second network interface : ");
    gtk_misc_set_alignment(GTK_MISC (label), 0, 0.5);
    gtk_box_pack_start(GTK_BOX (hbox), label, TRUE, TRUE, 0);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-#else
-   vbox = gtk_vbox_new(FALSE, 0);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 0, FALSE);
    gtk_box_pack_start(GTK_BOX(hbox_big), vbox, TRUE, TRUE, 0);
 
    /* make a list of network interfaces */
@@ -1640,11 +1592,7 @@ GtkWidget *gtkui_page_new(char *title, void (*callback)(void), void (*detacher)(
    GtkWidget *hbox, *button, *image;
 
    /* a container to hold the close button and tab label */
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-#else
-   hbox = gtk_hbox_new(FALSE, 0);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 0, FALSE);
    gtk_widget_show(hbox);
 
    /* the label for the tab title */
@@ -1876,6 +1824,20 @@ char *gtkui_utf8_validate(char *data) {
    }
 
    return(unicode);
+}
+
+GtkWidget *gtkui_box_new(gint orientation, gint spacing, gboolean homogenious) 
+{
+#if GTK_CHECK_VERSION(3, 0, 0)
+   (void) homogenious;
+   return gtk_box_new(orientation, spacing);
+#else
+   if (orientation == GTK_ORIENTATION_VERTICAL)
+      return gtk_vbox_new(homogenious, spacing);
+   else 
+      return gtk_hbox_new(homogenious, spacing);
+
+#endif
 }
 
 /* EOF */

--- a/src/interfaces/gtk/ec_gtk.h
+++ b/src/interfaces/gtk/ec_gtk.h
@@ -55,6 +55,7 @@ extern void gtkui_dialog_enter(GtkWidget *widget, gpointer data);
 extern gboolean gtkui_context_menu(GtkWidget *widget, GdkEventButton *event, gpointer data);
 extern void gtkui_filename_browse(GtkWidget *widget, gpointer data);
 extern char *gtkui_utf8_validate(char *data);
+extern GtkWidget *gtkui_box_new(gint orientation, gint spacing, gboolean homogenious);
 
 /* MDI pages */
 extern GtkWidget *gtkui_page_new(char *title, void (*callback)(void), void (*detacher)(GtkWidget *));

--- a/src/interfaces/gtk/ec_gtk_help.c
+++ b/src/interfaces/gtk/ec_gtk_help.c
@@ -72,11 +72,7 @@ void gtkui_help(void)
 #endif
    gtk_container_set_border_width(GTK_CONTAINER (dialog), 5);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
-#else
-   hbox = gtk_hbox_new (FALSE, 6);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 6, FALSE);
    content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
    gtk_box_pack_start(GTK_BOX(content_area), hbox, TRUE, TRUE, 0);
 

--- a/src/interfaces/gtk/ec_gtk_hosts.c
+++ b/src/interfaces/gtk/ec_gtk_hosts.c
@@ -212,11 +212,7 @@ void gtkui_host_list(void)
    
    hosts_window = gtkui_page_new("Host List", &gtkui_hosts_destroy, &gtkui_hosts_detach);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-#else
-   vbox = gtk_vbox_new(FALSE, 0);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 0, FALSE);
    gtk_container_add(GTK_CONTAINER (hosts_window), vbox);
    gtk_widget_show(vbox);
 
@@ -254,11 +250,7 @@ void gtkui_host_list(void)
    /* set the elements */
    gtk_tree_view_set_model(GTK_TREE_VIEW (treeview), GTK_TREE_MODEL (liststore));
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-#else
-   hbox = gtk_hbox_new(TRUE, 0);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 0, TRUE);
    gtk_box_pack_start(GTK_BOX (vbox), hbox, FALSE, FALSE, 0);
    gtk_widget_show(hbox);
 

--- a/src/interfaces/gtk/ec_gtk_mitm.c
+++ b/src/interfaces/gtk/ec_gtk_mitm.c
@@ -56,11 +56,7 @@ void gtkui_arp_poisoning(void)
    gtk_dialog_set_has_separator(GTK_DIALOG (dialog), FALSE);
 #endif
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-#else
-   hbox = gtk_hbox_new (FALSE, 5);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 5, FALSE);
    content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
    gtk_container_add(GTK_CONTAINER(content_area), hbox);
    gtk_widget_show(hbox);
@@ -75,11 +71,7 @@ void gtkui_arp_poisoning(void)
    gtk_box_pack_start (GTK_BOX (hbox), frame, TRUE, TRUE, 0);
    gtk_widget_show(frame);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 2);
-#else
-   vbox = gtk_vbox_new (FALSE, 2);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 2, FALSE);
    gtk_container_set_border_width(GTK_CONTAINER (vbox), 5);
    gtk_container_add(GTK_CONTAINER (frame), vbox);
    gtk_widget_show(vbox);
@@ -142,11 +134,7 @@ void gtkui_icmp_redir(void)
    gtk_dialog_set_has_separator(GTK_DIALOG (dialog), FALSE);
 #endif
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-#else
-   hbox = gtk_hbox_new (FALSE, 5);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 5, FALSE);
    content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
    gtk_container_add(GTK_CONTAINER(content_area), hbox);
    gtk_widget_show(hbox);
@@ -225,11 +213,7 @@ void gtkui_port_stealing(void)
    gtk_dialog_set_has_separator(GTK_DIALOG (dialog), FALSE);
 #endif
          
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-#else
-   hbox = gtk_hbox_new (FALSE, 5);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 5, FALSE);
    content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
    gtk_container_add(GTK_CONTAINER(content_area), hbox);
    gtk_widget_show(hbox);
@@ -244,11 +228,7 @@ void gtkui_port_stealing(void)
    gtk_box_pack_start (GTK_BOX (hbox), frame, TRUE, TRUE, 0);
    gtk_widget_show(frame);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 2);
-#else
-   vbox = gtk_vbox_new (FALSE, 2);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 2, FALSE);
    gtk_container_set_border_width(GTK_CONTAINER (vbox), 5);
    gtk_container_add(GTK_CONTAINER (frame), vbox);
    gtk_widget_show(vbox);
@@ -306,11 +286,7 @@ void gtkui_dhcp_spoofing(void)
    gtk_dialog_set_has_separator(GTK_DIALOG (dialog), FALSE);
 #endif
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-#else
-   hbox = gtk_hbox_new (FALSE, 5);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 5, FALSE);
    content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
    gtk_container_add(GTK_CONTAINER(content_area), hbox);
    gtk_widget_show(hbox);
@@ -402,11 +378,7 @@ void gtkui_ndp_poisoning(void)
    gtk_dialog_set_has_separator(GTK_DIALOG (dialog), FALSE);
 #endif
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-#else
-   hbox = gtk_hbox_new (FALSE, 5);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 5, FALSE);
    content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
    gtk_container_add(GTK_CONTAINER(content_area), hbox);
    gtk_widget_show(hbox);
@@ -421,11 +393,7 @@ void gtkui_ndp_poisoning(void)
    gtk_box_pack_start (GTK_BOX (hbox), frame, TRUE, TRUE, 0);
    gtk_widget_show(frame);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 2);
-#else
-   vbox = gtk_vbox_new (FALSE, 2);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 2, FALSE);
    gtk_container_set_border_width(GTK_CONTAINER (vbox), 5);
    gtk_container_add(GTK_CONTAINER (frame), vbox);
    gtk_widget_show(vbox);

--- a/src/interfaces/gtk/ec_gtk_plugins.c
+++ b/src/interfaces/gtk/ec_gtk_plugins.c
@@ -148,11 +148,7 @@ void gtkui_plugin_mgmt(void)
 
    plugins_window = gtkui_page_new("Plugins", &gtkui_plug_destroy, &gtkui_plugins_detach);
    
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-#else
-   vbox = gtk_vbox_new(FALSE, 0);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 0, FALSE);
    gtk_container_add(GTK_CONTAINER (plugins_window), vbox);
    gtk_widget_show(vbox);
    

--- a/src/interfaces/gtk/ec_gtk_targets.c
+++ b/src/interfaces/gtk/ec_gtk_targets.c
@@ -102,11 +102,7 @@ void gtkui_select_protocol(void)
    frame = gtk_frame_new("Select the protocol");
    gtk_container_add(GTK_CONTAINER(content), frame);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 10);
-#else
-   hbox = gtk_hbox_new(FALSE, 10);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 10, FALSE);
    gtk_container_add(GTK_CONTAINER(frame), hbox);
 
    radio = gtk_radio_button_new_with_mnemonic(NULL, "a_ll");
@@ -409,19 +405,11 @@ void gtkui_current_targets(void)
 
    targets_window = gtkui_page_new("Targets", &gtkui_targets_destroy, &gtkui_targets_detach);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-#else
-   vbox = gtk_vbox_new(FALSE, 0);
-#endif
+   vbox= gtkui_box_new(GTK_ORIENTATION_VERTICAL, 0, FALSE);
    gtk_container_add(GTK_CONTAINER (targets_window), vbox);
    gtk_widget_show(vbox);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-#else
-   hbox = gtk_hbox_new(TRUE, 5);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 5, TRUE);
    gtk_box_pack_start(GTK_BOX(vbox), hbox, TRUE, TRUE, 0);
    gtk_widget_show(hbox);
 
@@ -466,11 +454,7 @@ void gtkui_current_targets(void)
    gtk_tree_view_append_column (GTK_TREE_VIEW(treeview), column);
 
    /* buttons */
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-#else
-   hbox = gtk_hbox_new(TRUE, 5);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 5, TRUE);
    gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 0);
 
    button = gtk_button_new_with_mnemonic("Delete");

--- a/src/interfaces/gtk/ec_gtk_view.c
+++ b/src/interfaces/gtk/ec_gtk_view.c
@@ -337,11 +337,7 @@ void gtkui_vis_method(void)
 
    content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-#else
-   vbox = gtk_vbox_new(FALSE, 0);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 0, FALSE);
    gtk_container_add(GTK_CONTAINER(content_area), vbox);
 
    button = gtk_radio_button_new_with_label(NULL, 
@@ -387,11 +383,7 @@ void gtkui_vis_method(void)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON (button), TRUE);
    prev = button;
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 6);
-#else
-   hbox = gtk_hbox_new (FALSE, 6);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 6, FALSE);
    gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 0);
 
    label = gtk_label_new ("Character encoding : ");

--- a/src/interfaces/gtk/ec_gtk_view_connections.c
+++ b/src/interfaces/gtk/ec_gtk_view_connections.c
@@ -155,28 +155,16 @@ void gtkui_show_connections(void)
 
    conns_window = gtkui_page_new("Connections", &gtkui_kill_connections, &gtkui_connections_detach);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-#else
-   vbox = gtk_vbox_new(FALSE, 0);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 0, FALSE);
    gtk_container_add(GTK_CONTAINER (conns_window), vbox);
    gtk_widget_show(vbox);
 
    /* filter bar */
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 10);
-#else
-   hbox = gtk_hbox_new(FALSE, 10);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 10, FALSE);
    gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 0);
 
    frame = gtk_frame_new("Host filter");
-#if GTK_CHECK_VERSION(3, 0, 0)
-   tbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-#else
-   tbox = gtk_hbox_new(FALSE, 0);
-#endif
+   tbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 0, FALSE);
    gtk_container_add(GTK_CONTAINER(frame), tbox);
 
    entry = gtk_entry_new();
@@ -190,11 +178,7 @@ void gtkui_show_connections(void)
    gtk_box_pack_start(GTK_BOX(hbox), frame, FALSE, FALSE, 0);
 
    frame = gtk_frame_new("Protocol filter");
-#if GTK_CHECK_VERSION(3, 0, 0)
-   tbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-#else
-   tbox = gtk_hbox_new(FALSE, 0);
-#endif
+   tbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 0, FALSE);
    gtk_container_add(GTK_CONTAINER(frame), tbox);
 
    chkb_tcp = gtk_check_button_new_with_label("TCP");
@@ -218,11 +202,7 @@ void gtkui_show_connections(void)
    gtk_box_pack_start(GTK_BOX(hbox), frame, FALSE, FALSE, 0);
 
    frame = gtk_frame_new("Connection state filter");
-#if GTK_CHECK_VERSION(3, 0, 0)
-   tbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-#else
-   tbox = gtk_hbox_new(FALSE, 0);
-#endif
+   tbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 0, FALSE);
    gtk_container_add(GTK_CONTAINER(frame), tbox);
 
    chkb_active = gtk_check_button_new_with_label("Active");
@@ -323,11 +303,7 @@ void gtkui_show_connections(void)
    gtk_tree_view_column_set_sort_column_id (column, 9);
    gtk_tree_view_append_column (GTK_TREE_VIEW(treeview), column);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-#else
-   hbox = gtk_hbox_new(TRUE, 5);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 5, TRUE);
    gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 0);
    gtk_widget_show(hbox);
 
@@ -669,11 +645,7 @@ static void gtkui_connection_detail(void)
    g_signal_connect(G_OBJECT(dwindow), "delete-event", 
          G_CALLBACK(gtkui_connection_detail_destroy), NULL);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
-#else
-   vbox = gtk_vbox_new(FALSE, 5);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 5, FALSE);
    gtk_container_add(GTK_CONTAINER(dwindow), vbox);
 
    table = gtk_table_new(nrows, ncols, FALSE);
@@ -881,11 +853,7 @@ static void gtkui_connection_detail(void)
    }
 
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-#else
-   hbox = gtk_hbox_new(FALSE, 0);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 0, FALSE);
    gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 0);
 
    button = gtk_button_new_from_stock(GTK_STOCK_CLOSE);
@@ -981,20 +949,12 @@ static void gtkui_connection_data_split(void)
    /* don't timeout this connection */
    curr_conn->flags |= CONN_VIEWING;
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox_big = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-#else
-   hbox_big = gtk_hbox_new(TRUE, 5);
-#endif
+   hbox_big = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 5, TRUE);
    gtk_container_add(GTK_CONTAINER(data_window), hbox_big);
    gtk_widget_show(hbox_big);
 
   /*** left side ***/
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-#else
-   vbox = gtk_vbox_new(FALSE, 0);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 0, FALSE);
    gtk_box_pack_start(GTK_BOX(hbox_big), vbox, TRUE, TRUE, 0);
    gtk_widget_show(vbox);
 
@@ -1030,11 +990,7 @@ static void gtkui_connection_data_split(void)
    endmark1 = gtk_text_buffer_create_mark(splitbuf1, "end", &iter, FALSE);
 
   /* first two buttons */
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox_small = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-#else
-   hbox_small = gtk_hbox_new(TRUE, 5);
-#endif
+   hbox_small = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 5, TRUE);
    gtk_box_pack_start(GTK_BOX(vbox), hbox_small, FALSE, FALSE, 0);
    gtk_widget_show(hbox_small);
 
@@ -1049,11 +1005,7 @@ static void gtkui_connection_data_split(void)
    gtk_widget_show(button);
 
   /*** right side ***/
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-#else
-   vbox = gtk_vbox_new(FALSE, 0);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 0, FALSE);
    gtk_box_pack_start(GTK_BOX(hbox_big), vbox, TRUE, TRUE, 0);
    gtk_widget_show(vbox);
 
@@ -1089,11 +1041,7 @@ static void gtkui_connection_data_split(void)
    endmark2 = gtk_text_buffer_create_mark(splitbuf2, "end", &iter, FALSE);
 
   /* second two buttons */
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox_small = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-#else
-   hbox_small = gtk_hbox_new(TRUE, 5);
-#endif
+   hbox_small = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 5, TRUE);
    gtk_box_pack_start(GTK_BOX(vbox), hbox_small, FALSE, FALSE, 0);
    gtk_widget_show(hbox_small);
 
@@ -1312,11 +1260,7 @@ static void gtkui_connection_data_join(void)
    /* don't timeout this connection */
    curr_conn->flags |= CONN_VIEWING;
    
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-#else
-   vbox = gtk_vbox_new(FALSE, 0);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 0, FALSE);
    gtk_container_add(GTK_CONTAINER(data_window), vbox);
    gtk_widget_show(vbox);
    
@@ -1352,11 +1296,7 @@ static void gtkui_connection_data_join(void)
    gtk_text_buffer_get_end_iter(joinedbuf, &iter);
    endmark3 = gtk_text_buffer_create_mark(joinedbuf, "end", &iter, FALSE);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-#else
-   hbox = gtk_hbox_new(TRUE, 5);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 5, TRUE);
    gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 0);
    gtk_widget_show(hbox);
 
@@ -1565,22 +1505,14 @@ static void gtkui_connection_inject(void)
    gtk_container_set_border_width(GTK_CONTAINER (dialog), 5);
    content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-#else
-   vbox = gtk_vbox_new(FALSE, 0);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 0, FALSE);
    gtk_box_pack_start(GTK_BOX(content_area), vbox, FALSE, FALSE, 0);
 
    label = gtk_label_new ("Packet destination:");
    gtk_misc_set_alignment(GTK_MISC (label), 0, 0.5);
    gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-#else
-   hbox = gtk_hbox_new(FALSE, 5);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 5, FALSE);
    gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 0);
 
    button1 = gtk_radio_button_new_with_label(NULL, ip_addr_ntoa(&curr_conn->L3_addr2, tmp));
@@ -1672,22 +1604,14 @@ static void gtkui_connection_inject_file(void)
    gtk_container_set_border_width(GTK_CONTAINER (dialog), 5);
    content_area = gtk_dialog_get_content_area(GTK_DIALOG(dialog));
    
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-#else
-   vbox = gtk_vbox_new(FALSE, 0);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 0, FALSE);
    gtk_box_pack_start(GTK_BOX(content_area), vbox, FALSE, FALSE, 0);
 
    label = gtk_label_new ("Packet destination:");
    gtk_misc_set_alignment(GTK_MISC (label), 0, 0.5);
    gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-#else
-   hbox = gtk_hbox_new(FALSE, 5);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 5, FALSE);
    gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, FALSE, 0);
       
    button1 = gtk_radio_button_new_with_label(NULL, ip_addr_ntoa(&curr_conn->L3_addr2, tmp));
@@ -1702,11 +1626,7 @@ static void gtkui_connection_inject_file(void)
    gtk_misc_set_alignment(GTK_MISC (label), 0, 0.5);
    gtk_box_pack_start (GTK_BOX (vbox), label, FALSE, FALSE, 0);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-#else
-   hbox = gtk_hbox_new(FALSE, 5);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 5, FALSE);
    gtk_box_pack_start (GTK_BOX (vbox), hbox, FALSE, FALSE, 0);
 
    entry = gtk_entry_new();

--- a/src/interfaces/gtk/ec_gtk_view_profiles.c
+++ b/src/interfaces/gtk/ec_gtk_view_profiles.c
@@ -76,11 +76,7 @@ void gtkui_show_profiles(void)
    
    profiles_window = gtkui_page_new("Profiles", &gtkui_kill_profiles, &gtkui_profiles_detach);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-#else
-   vbox = gtk_vbox_new(FALSE, 0);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 0, FALSE);
    gtk_container_add(GTK_CONTAINER (profiles_window), vbox);
    gtk_widget_show(vbox);
 
@@ -117,11 +113,7 @@ void gtkui_show_profiles(void)
    refresh_profiles(NULL);
    gtk_tree_view_set_model(GTK_TREE_VIEW (treeview), GTK_TREE_MODEL (ls_profiles));
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 5);
-#else
-   hbox = gtk_hbox_new(TRUE, 5);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 5, TRUE);
    gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 0);
 
    button = gtk_button_new_with_mnemonic("Purge _Local");
@@ -323,11 +315,7 @@ static void gtkui_profile_detail(void)
    g_signal_connect(G_OBJECT(dwindow), "delete-event", 
          G_CALLBACK(gtkui_profile_detail_destroy), NULL);
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   vbox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 5);
-#else
-   vbox = gtk_vbox_new(FALSE, 5);
-#endif
+   vbox = gtkui_box_new(GTK_ORIENTATION_VERTICAL, 5, FALSE);
    gtk_container_add(GTK_CONTAINER(dwindow), vbox);
 
    table = gtk_table_new(nrows, ncols, FALSE);
@@ -547,11 +535,7 @@ static void gtkui_profile_detail(void)
    gtk_table_resize(GTK_TABLE(table), row, ncols);
 
 
-#if GTK_CHECK_VERSION(3, 0, 0)
-   hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 0);
-#else
-   hbox = gtk_hbox_new(FALSE, 0);
-#endif
+   hbox = gtkui_box_new(GTK_ORIENTATION_HORIZONTAL, 0, FALSE);
    gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 0);
 
    button = gtk_button_new_from_stock(GTK_STOCK_CLOSE);


### PR DESCRIPTION
As GTK3 and GTK2 use functions for creating a _box_ that are incompatible, this pull introduces a wrapper function to unify this call in the code.
