### PR TITLE
fix snapshot length retrieval

### DIFF
--- a/include/ec_globals.h
+++ b/include/ec_globals.h
@@ -117,7 +117,7 @@ struct pcap_env {
    u_int8         align;         /* alignment needed on sparc 4*n - sizeof(media_hdr) */
    char           promisc;
    char          *filter;        /* pcap filter */
-   u_int16        snaplen;
+   u_int32        snaplen;
    int            dlt;
    pcap_dumper_t *dump;
    u_int32        dump_size;     /* total dump size */

--- a/src/ec_network.c
+++ b/src/ec_network.c
@@ -55,7 +55,7 @@ void network_init()
 
    DEBUG_MSG("init_network");
 
-   GBL_PCAP->snaplen = UINT16_MAX;
+   GBL_PCAP->snaplen = UINT32_MAX;
    
    if(GBL_OPTIONS->read) {
       source_init(GBL_OPTIONS->pcapfile_in, GBL_IFACE, true, false);
@@ -155,7 +155,7 @@ static int source_init(char *name, struct iface_env *source, bool primary, bool 
    struct bpf_program bpf;
    char pcap_errbuf[PCAP_ERRBUF_SIZE];
    char lnet_errbuf[LIBNET_ERRBUF_SIZE];
-   u_int16 snaplen;
+   u_int32 snaplen;
 
    struct libnet_ether_addr *mac;
    struct sockaddr_in *sa4;


### PR DESCRIPTION
This pull request fixes #626.
At some point in time, the libpcap function pcap_snapshot has changed the return value type.
tcpdump uses for this information also still 16 bit short to save the capture. Wireshark seem to use 32 bit integer instead. This overflows the stack variable snaplen which is also 16 bit.
