### PR TITLE
set proper initial value for pcap snaplen

### DIFF
--- a/src/ec_network.c
+++ b/src/ec_network.c
@@ -55,7 +55,7 @@ void network_init()
 
    DEBUG_MSG("init_network");
 
-   GBL_PCAP->snaplen = INT32_MAX;
+   GBL_PCAP->snaplen = UINT16_MAX;
    
    if(GBL_OPTIONS->read) {
       source_init(GBL_OPTIONS->pcapfile_in, GBL_IFACE, true, false);


### PR DESCRIPTION
This pull requests fixes a infinite loop within libpcap.
One condition for this loop is the initial value of `GBL_PCAP->snaplen` set to **INT32_MAX** which means **0x7fffffff**.

The loop occurs in _pcap-linux.c_ in the function `create_ring()`:

``` c
    req.tp_block_size = getpagesize();
    while (req.tp_block_size < req.tp_frame_size)
        req.tp_block_size <<= 1;
```

If the _ethtool_ can not be leveraged to read the offload capability and the MTU, the value of _req.tp_frame_size_ is derived from `GBL_PCAP->snaplen`, otherwize it's derived from the interface MTU which doesn't introduce a problem.

Some more offset is beeing added to the snaplen so that the value of _req.tp_frame_size_ is on my system **0x80000050** (note that _req.tp_frame_size_ is of type _unsigned int_).
The value of _req.tp_block_size_ (as well _unsigned int_) is on my system **0x00001000**.

Now the while loop bit-shifts _req.tp_block_size_ until it's greater than _req.tp_frame_size_. Unfortunately under these initial conditions, this is not possible. The iterations of the loop look like:

```
initial tp_block_size: 0x00001000, tp_frame_size: 0x80000050
tp_block_size: 0x00001000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x00002000
tp_block_size: 0x00002000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x00004000
tp_block_size: 0x00004000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x00008000
tp_block_size: 0x00008000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x00010000
tp_block_size: 0x00010000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x00020000
tp_block_size: 0x00020000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x00040000
tp_block_size: 0x00040000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x00080000
tp_block_size: 0x00080000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x00100000
tp_block_size: 0x00100000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x00200000
tp_block_size: 0x00200000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x00400000
tp_block_size: 0x00400000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x00800000
tp_block_size: 0x00800000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x01000000
tp_block_size: 0x01000000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x02000000
tp_block_size: 0x02000000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x04000000
tp_block_size: 0x04000000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x08000000
tp_block_size: 0x08000000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x10000000
tp_block_size: 0x10000000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x20000000
tp_block_size: 0x20000000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x40000000
tp_block_size: 0x40000000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x80000000
tp_block_size: 0x80000000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x00000000
tp_block_size: 0x00000000 < tp_frame_size: 0x80000050 - shifting tp_block_size: 0x00000000
[...]
```

This can be easily reproduced by running ... 

```
ettercap -Tqilo
```

My wifi interface is also not capable to be queried by **ethtool**, so using this interface, the issue occurs as well. My Ethernet interface has no issues, as the MTU is being used rather than the initial value of `GBL_PCAP->snaplen`.

Resetting the value to the default of 65535 (**UINT16_MAX**) fixes the issue.
