### PR TITLE
fix truncation of packets with VLAN header

### DIFF
--- a/src/protocols/ec_vlan.c
+++ b/src/protocols/ec_vlan.c
@@ -60,6 +60,8 @@ FUNC_DECODER(decode_vlan)
 
    /* HOOK POINT : HOOK_PACKET_VLAN */
    hook_point(HOOK_PACKET_VLAN, po);
+
+   po->L2.len += sizeof(struct vlan_header);
    
    /* leave the control to the next decoder */   
    next_decoder = get_decoder(NET_LAYER, ntohs(vlan->proto));


### PR DESCRIPTION
Using ettercap bridged sniffing truncates 802.1Q tagged packets.