### PR TITLE
Freebsd pfctl

### DIFF
--- a/share/etter.conf.v4
+++ b/share/etter.conf.v4
@@ -203,6 +203,21 @@ remote_browser = "xdg-open http://%host%url"
  #   fi
  # ----- cut here -------
 
+#---------------
+#   FreeBSD
+#---------------
+
+# Before OF can be used, make sure the kernel module has been loaded by
+# `kldstat | grep pf.ko`. If the rusult is empty, you can load it by
+# `kldload pf.ko` or add 'pf_enable="YES"' to the /etc/rc.conf and reboot.
+
+# Check if the PF status is enabled by 
+# `pfctl -si | grep Status | awk '{print $2;}'`. If "Disabled", enable it with
+# `pfctl -e`.
+
+   #redir_command_on = "(pfctl -a sslsniff -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to any port %port -> localhost port %rport') | pfctl -a sslsniff -f - 2> /dev/null"
+   #redir_command_off = "pfctl -a sslsniff -Fn 2> /dev/null"
+
 
 #---------------
 #   Open BSD

--- a/share/etter.conf.v4
+++ b/share/etter.conf.v4
@@ -214,7 +214,7 @@ remote_browser = "xdg-open http://%host%url"
 # `pfctl -si | grep Status | awk '{print $2;}'`. If "Disabled", enable it with
 # `pfctl -e`.
 
-   #redir_command_on = "(pfctl -a sslsniff -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to any port %port -> localhost port %rport') | pfctl -a sslsniff -f - 2> /dev/null"
+   #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to any port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
    #redir_command_off = "pfctl -a sslsniff -Fn 2> /dev/null"
 
 

--- a/share/etter.conf.v4
+++ b/share/etter.conf.v4
@@ -215,7 +215,7 @@ remote_browser = "xdg-open http://%host%url"
 # `pfctl -e`.
 
    #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to any port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
-   #redir_command_off = "pfctl -a sslsniff -Fn 2> /dev/null"
+   #redir_command_off = "pfctl -Psn 2> /dev/null | grep -v %port | pfctl -f - 2> /dev/null"
 
 
 #---------------

--- a/share/etter.conf.v4
+++ b/share/etter.conf.v4
@@ -207,9 +207,10 @@ remote_browser = "xdg-open http://%host%url"
 #   FreeBSD
 #---------------
 
-# Before OF can be used, make sure the kernel module has been loaded by
-# `kldstat | grep pf.ko`. If the rusult is empty, you can load it by
-# `kldload pf.ko` or add 'pf_enable="YES"' to the /etc/rc.conf and reboot.
+# Before PF can be used, make sure the kernel module has been loaded by
+# `kldstat | grep pf.ko`. If the rusult is empty, you can load it by `kldload pf.ko`.
+# To enable PF at startup add 'pf_enable="YES"' to the /etc/rc.conf, 
+# 'pf_load="YES"' to /boot/loader.conf and 'pfctl -e' to /etc/rc.local.
 
 # Check if the PF status is enabled by 
 # `pfctl -si | grep Status | awk '{print $2;}'`. If "Disabled", enable it with

--- a/share/etter.conf.v4
+++ b/share/etter.conf.v4
@@ -157,9 +157,7 @@ remote_browser = "xdg-open http://%host%url"
 # they are dropped on startup). so you have to either: provide a setuid program
 # or set the ec_uid to 0, in order to be sure the cleanup script will be
 # executed properly
-# NOTE: this script is executed with an execve(), so you can't use pipes or
-# output redirection as if you were in a shell. We suggest you to make a script if
-# you need those commands.
+# NOTE: the script must fit into one line with a maximum of 255 characters
 
 #---------------
 #     Linux 

--- a/share/etter.conf.v6
+++ b/share/etter.conf.v6
@@ -220,7 +220,7 @@ remote_browser = "xdg-open http://%host%url"
 # `pfctl -e`.
 
    #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to any port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
-   #redir_command_off = "pfctl -a sslsniff -Fn 2> /dev/null"
+   #redir_command_off = "pfctl -Psn 2> /dev/null | grep -v %port | pfctl -f - 2> /dev/null"
 
 
 #---------------

--- a/share/etter.conf.v6
+++ b/share/etter.conf.v6
@@ -209,6 +209,21 @@ remote_browser = "xdg-open http://%host%url"
  #   fi
  # ----- cut here -------
 
+#---------------
+#   FreeBSD
+#---------------
+
+# Before OF can be used, make sure the kernel module has been loaded by
+# `kldstat | grep pf.ko`. If the rusult is empty, you can load it by
+# `kldload pf.ko` or add 'pf_enable="YES"' to the /etc/rc.conf and reboot.
+
+# Check if the PF status is enabled by 
+# `pfctl -si | grep Status | awk '{print $2;}'`. If "Disabled", enable it with
+# `pfctl -e`.
+
+   #redir_command_on = "(pfctl -a sslsniff -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to any port %port -> localhost port %rport') | pfctl -a sslsniff -f - 2> /dev/null"
+   #redir_command_off = "pfctl -a sslsniff -Fn 2> /dev/null"
+
 
 #---------------
 #   Open BSD

--- a/share/etter.conf.v6
+++ b/share/etter.conf.v6
@@ -163,9 +163,7 @@ remote_browser = "xdg-open http://%host%url"
 # they are dropped on startup). so you have to either: provide a setuid program
 # or set the ec_uid to 0, in order to be sure the cleanup script will be
 # executed properly
-# NOTE: this script is executed with an execve(), so you can't use pipes or
-# output redirection as if you were in a shell. We suggest you to make a script if
-# you need those commands.
+# NOTE: the script must fit into one line with a maximum of 255 characters
 
 #---------------
 #     Linux 

--- a/share/etter.conf.v6
+++ b/share/etter.conf.v6
@@ -219,7 +219,7 @@ remote_browser = "xdg-open http://%host%url"
 # `pfctl -si | grep Status | awk '{print $2;}'`. If "Disabled", enable it with
 # `pfctl -e`.
 
-   #redir_command_on = "(pfctl -a sslsniff -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to any port %port -> localhost port %rport') | pfctl -a sslsniff -f - 2> /dev/null"
+   #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to any port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
    #redir_command_off = "pfctl -a sslsniff -Fn 2> /dev/null"
 
 

--- a/src/dissectors/ec_ftp.c
+++ b/src/dissectors/ec_ftp.c
@@ -1,5 +1,5 @@
 /*
-    ettercap -- dissector FTP -- TCP 21 992
+    ettercap -- dissector FTP -- TCP 21 990
 
     Copyright (C) ALoR & NaGA
 
@@ -40,7 +40,7 @@ void ftp_init(void);
 void __init ftp_init(void)
 {
    dissect_add("ftp", APP_LAYER_TCP, 21, dissector_ftp);
-   sslw_dissect_add("ftps", 992, dissector_ftp, SSL_ENABLED);
+   sslw_dissect_add("ftps", 990, dissector_ftp, SSL_ENABLED);
 }
 
 FUNC_DECODER(dissector_ftp)

--- a/src/ec_conf.c
+++ b/src/ec_conf.c
@@ -254,7 +254,7 @@ static void sanity_checks()
 void load_conf(void)
 {
    FILE *fc;
-   char line[128];
+   char line[256];
    char *p, *q, **tmp;
    int lineno = 0;
    size_t tmplen;
@@ -278,7 +278,7 @@ void load_conf(void)
    }
   
    /* read the file */
-   while (fgets(line, 128, fc) != 0) {
+   while (fgets(line, 256, fc) != 0) {
       
       /* update the line count */
       lineno++;


### PR DESCRIPTION
This pull request fixes the handling of the Packet Filter of FreeBSD.
The way, `pfctl` is being used, requires more functionality on the redirect*_command options in *etter.conf*.
To make this kind of automatic / transparent handling work, the execution of the redirect*_command need to be enabled for piping support.
Furthermore, by accident I observed a wrong port number for FTPS being hard coded in the FTP dissector.