### PR TITLE
Fix possible flag full name error

### DIFF
--- a/src/ec_parser.c
+++ b/src/ec_parser.c
@@ -196,7 +196,7 @@ void parse_options(int argc, char **argv)
       { "only-mitm", no_argument, NULL, 'o' },
       { "bridge", required_argument, NULL, 'B' },
       { "broadcast", required_argument, NULL, 'b' },
-      { "promisc", no_argument, NULL, 'p' },
+      { "nopromisc", no_argument, NULL, 'p' },
       { "gateway", required_argument, NULL, 'Y' },
       { "certificate", required_argument, NULL, 0 },
       { "private-key", required_argument, NULL, 0 },


### PR DESCRIPTION
Else we get:

ettercap: unrecognized option '--nopromisc'