### PR TITLE
Reset logfile ownership upon dropping privileges

### DIFF
--- a/include/ec_log.h
+++ b/include/ec_log.h
@@ -8,6 +8,7 @@
 
 #include <zlib.h>
 #include <sys/time.h>
+#include <unistd.h>
 
 
 struct log_fd {
@@ -125,6 +126,8 @@ EC_API_EXTERN int set_loglevel(int level, char *filename);
 EC_API_EXTERN int set_msg_loglevel(int level, char *filename);
 #define LOG_TRUE     1
 #define LOG_FALSE    0
+
+EC_API_EXTERN void reset_logfile_owners(uid_t old_uid, gid_t old_gid, uid_t new_uid, gid_t new_gid);
 
 EC_API_EXTERN int log_open(struct log_fd *fd, char *filename);
 EC_API_EXTERN void log_close(struct log_fd *fd);

--- a/src/ec_log.c
+++ b/src/ec_log.c
@@ -37,8 +37,11 @@
 
 /* globals */
 
-static struct log_fd fdp;
-static struct log_fd fdi;
+/* zero is formally a valid value for an opened file descriptor
+ * so we need a custom initializer
+ */
+static struct log_fd fdp = {0, NULL, -1};
+static struct log_fd fdi = {0, NULL, -1};
 
 /* protos */
 
@@ -79,7 +82,7 @@ int set_loglevel(int level, char *filename)
    /* all the host type will be unknown, warn the user */
    if (GBL_OPTIONS->read) {
       USER_MSG("*********************************************************\n");
-      USER_MSG("WARNING: while reading form file we cannot determine    \n");
+      USER_MSG("WARNING: while reading form file we cannot determine     \n");
       USER_MSG("if an host is local or not because the ip address of     \n");
       USER_MSG("the NIC may have been changed from the time of the dump. \n");
       USER_MSG("*********************************************************\n\n");
@@ -168,23 +171,30 @@ void log_stop(void)
 
 /*
  * open a file in the appropriate log_fd struct
+ *
+ * whether or not the log is compressed
+ * fd->fd becomes to always be a file descriptor of the opened file
+ * and fd->cfd is a non-NULL gzip stream descriptor when the log is to be compressed
+ *
+ * TODO: it is likely that we dont need 'type' field in 'log_fd' struct
+ *       to mark a compressed log; non-NULL 'cfd' field becomes such a flag
  */
 int log_open(struct log_fd *fd, char *filename)
 {
-   int zerr;
 
-   if (fd->type == LOG_COMPRESSED) {
-      fd->cfd = gzopen(filename, "wb9");
-      if (fd->cfd == NULL)
-         SEMIFATAL_ERROR("%s", gzerror(fd->cfd, &zerr));
-   } else {
-      fd->fd = open(filename, O_CREAT | O_TRUNC | O_RDWR | O_BINARY, S_IRUSR | S_IWUSR);
-      if (fd->fd == -1)
-         SEMIFATAL_ERROR("Can't create %s: %s", filename, strerror(errno));
-   }
-   
-   /* set the permissions */
-   chmod(filename, 0600);
+   fd->fd = open(filename, O_CREAT|O_TRUNC|O_RDWR|O_BINARY, S_IRUSR|S_IWUSR|S_IRGRP|S_IWGRP|S_IROTH|S_IWOTH);
+   if (fd->fd == -1)
+      SEMIFATAL_ERROR("Can't create %s: %s", filename, strerror(errno));
+   else
+   {
+      if (GBL_OPTIONS->compress)
+      {
+         int zerr;
+         fd->cfd = gzdopen(fd->fd, "wb9");
+         if (fd->cfd == NULL)
+            SEMIFATAL_ERROR("%s", gzerror(fd->cfd, &zerr));
+      };
+   };
 
    return E_SUCCESS;
 }
@@ -195,14 +205,66 @@ int log_open(struct log_fd *fd, char *filename)
 void log_close(struct log_fd *fd)
 {
    DEBUG_MSG("log_close: type: %d [%p][%d]", fd->type, fd->cfd, fd->fd);
-   
-   if (fd->type == LOG_COMPRESSED && fd->cfd) {
+
+   if (fd->cfd)
+   {
+      /* gzclose() on the gzip stream descriptor (fd->cfd)
+       * will also close the file descriptor (fd->fd)
+       */
       gzclose(fd->cfd);
       fd->cfd = NULL;
-   } else if (fd->type == LOG_UNCOMPRESSED && fd->fd) {
+      fd->fd = -1;  /* to prevent double closing the file descriptor */
+   };
+
+   if (fd->fd >= 0)
+   {
       close(fd->fd);
-      fd->fd = 0;
-   }
+      fd->fd = -1;
+   };
+}
+
+/*
+ * set the owner:group of the packet and info logfiles to new_uid:new_gid
+ * if the current owners are old_uid:old_gid respectively
+ *
+ * prefer this way to unconditionally setting the new ownership as far as
+ * the file may be intentionally located in the set-group-ID directory
+ */
+void reset_logfile_owners(uid_t old_uid, gid_t old_gid, uid_t new_uid, gid_t new_gid)
+{
+   struct stat f;
+   uid_t uid;
+   gid_t gid;
+
+   /* packet logfile */
+   if (fdp.fd >= 0)
+   {
+      DEBUG_MSG("reset_logfile_owners: packet log file");
+      if (fstat(fdp.fd, &f) == 0)
+      {
+         uid = (f.st_uid == old_uid) ? new_uid : (uid_t)-1;
+         gid = (f.st_gid == old_gid) ? new_gid : (gid_t)-1;
+         if ( fchown(fdp.fd, uid, gid) != 0 )
+            ERROR_MSG("fchown()");
+      }
+      else
+         ERROR_MSG("fstat()");
+   };
+
+   /* info logfile */
+   if (fdi.fd >= 0)
+   {
+      DEBUG_MSG("reset_logfile_owners: info log file");
+      if (fstat(fdi.fd, &f) == 0)
+      {
+         uid = (f.st_uid == old_uid) ? new_uid : (uid_t)-1;
+         gid = (f.st_gid == old_gid) ? new_gid : (gid_t)-1;
+         if ( fchown(fdi.fd, uid, gid) != 0 )
+            ERROR_MSG("fchown()");
+      }
+      else
+         ERROR_MSG("fstat()");
+   };
 }
 
 /* 

--- a/src/ec_utils.c
+++ b/src/ec_utils.c
@@ -225,17 +225,17 @@ void drop_privs(void)
    else
       gid = GBL_CONF->ec_gid;
 
-   DEBUG_MSG("drop_privs: setuid(%d) setgid(%d)", uid, gid);
+   DEBUG_MSG("drop_privs: seteuid(%d) setegid(%d)", uid, gid);
 
    /* drop to a good uid/gid ;) */
-   if ( setgid(gid) < 0 )
-      ERROR_MSG("setgid()");
+   if ( setegid(gid) < 0 )
+      ERROR_MSG("setegid()");
 
    if ( seteuid(uid) < 0 )
       ERROR_MSG("seteuid()");
 
    DEBUG_MSG("privs: UID: %d %d  GID: %d %d", (int)getuid(), (int)geteuid(), (int)getgid(), (int)getegid() );
-   USER_MSG("Privileges dropped to UID %d GID %d...\n\n", (int)getuid(), (int)getgid() );
+   USER_MSG("Privileges dropped to EUID %d EGID %d...\n\n", (int)geteuid(), (int)getegid() );
 }
 
 /* base64 stuff */

--- a/src/ec_utils.c
+++ b/src/ec_utils.c
@@ -225,6 +225,8 @@ void drop_privs(void)
    else
       gid = GBL_CONF->ec_gid;
 
+   reset_logfile_owners(geteuid(), getegid(), uid, gid);
+
    DEBUG_MSG("drop_privs: seteuid(%d) setegid(%d)", uid, gid);
 
    /* drop to a good uid/gid ;) */


### PR DESCRIPTION
If logging is started from the GUI menu item the log files are created after privileges have been dropped by the ettercap and the user with dropped UID:GID becomes the owner of the created log files.
In contrast, the log files specified on the command line remain to be owned by the root user even if privileges are dropped.
This proposal is about to reset the ownership of the log files each time when dropping the privileges to the new UID:GID.