### PR TITLE
Add displaying the payload length in the packet header output

### DIFF
--- a/include/ec_packet.h
+++ b/include/ec_packet.h
@@ -55,14 +55,14 @@ struct packet_object {
        * buffer containing the data to be displayed.
        * some dissector decripts the traffic, but the packet must be forwarded as
        * is, so the decripted data must be placed in a different buffer. 
-       * this is that bufffer and it is malloced by tcp or udp dissector.
+       * this is that buffer and it is malloced by tcp or udp dissector.
        */
       size_t disp_len;
       u_char * disp_data;
       /* for modified packet this is the delta for the length */
       int delta;  
       size_t inject_len;      /* len of the injection */
-      u_char *inject;         /* the fuffer used for injection */
+      u_char *inject;         /* the buffer used for injection */
 
    } DATA;
 

--- a/src/interfaces/text/ec_text_display.c
+++ b/src/interfaces/text/ec_text_display.c
@@ -75,8 +75,6 @@ void text_print_packet(struct packet_object *po)
    /* sync steram/descriptor output and print the packet */
    fflush(stdout);
    write(fileno(stdout), tmp, ret);
-
-   printf("\n");
 }     
 
 
@@ -122,11 +120,9 @@ static void display_headers(struct packet_object *po)
    /* display the ip addresses */
    ip_addr_ntoa(&po->L3.src, tmp1);
    ip_addr_ntoa(&po->L3.dst, tmp2);
-   fprintf(stdout, "%s  %s:%d --> %s:%d | %s\n", proto, tmp1, ntohs(po->L4.src), 
+   fprintf(stdout, "%s  %s:%d --> %s:%d | %s (%zu)\n", proto, tmp1, ntohs(po->L4.src),
                                                         tmp2, ntohs(po->L4.dst),
-                                                        flags);
-
-   fprintf(stdout, "\n");
+                                                        flags, po->DATA.disp_len);
 }
 
 

--- a/utils/etterlog/el_display.c
+++ b/utils/etterlog/el_display.c
@@ -184,9 +184,9 @@ static void display_headers(struct log_header_packet *pck)
    /* display the ip addresses */
    ip_addr_ntoa(&pck->L3_src, tmp1);
    ip_addr_ntoa(&pck->L3_dst, tmp2);
-   fprintf(stdout, "%s  %s:%d --> %s:%d | %s\n\n", proto, tmp1, ntohs(pck->L4_src),
+   fprintf(stdout, "%s  %s:%d --> %s:%d | %s (%u)\n", proto, tmp1, ntohs(pck->L4_src),
                                                         tmp2, ntohs(pck->L4_dst),
-                                                        flags);
+                                                        flags, pck->len);
 }
 
 /*


### PR DESCRIPTION
This is an proposal accompanying to pull request #656, which can be applied independently. 