### PR TITLE
Intercept dualstack

### DIFF
--- a/cmake/Modules/EttercapVariableCheck.cmake
+++ b/cmake/Modules/EttercapVariableCheck.cmake
@@ -1,2 +1,12 @@
 # Check if PTHREAD_MUTEX_RECURSIVE_NP exists
 CHECK_VARIABLE_IN_HEADERS(PTHREAD_MUTEX_RECURSIVE_NP "pthread.h" HAVE_MUTEX_RECURSIVE_NP)
+
+# Check if IP6T_SO_ORIGINAL_DST socket option is available - necessary for IPv6 SSL interception
+if(OS_LINUX AND ENABLE_IPV6)
+   include(CheckSymbolExists)
+   check_symbol_exists(
+         IP6T_SO_ORIGINAL_DST
+         "net/if.h;netinet/in.h;linux/netfilter_ipv6/ip6_tables.h"
+         HAVE_IP6T_SO_ORIGINAL_DST
+   )
+endif(OS_LINUX AND ENABLE_IPV6)

--- a/cmake/Modules/FindLIBNET.cmake
+++ b/cmake/Modules/FindLIBNET.cmake
@@ -45,8 +45,8 @@ function(_LIBNET_GET_VERSION _OUT_version _OUT_version_major _OUT_version_minor 
 
         set(${_OUT_version} ${${_OUT_version}} PARENT_SCOPE)
         
-        string(REGEX REPLACE "^([0-9]+)[0-9.]+.*" "\\1" ${_OUT_version_major} "${${_OUT_version}}")
-        string(REGEX REPLACE "^[0-9.]+([0-9]+).*" "\\1" ${_OUT_version_minor} "${${_OUT_version}}")
+        string(REGEX REPLACE "^([0-9]+)\\.[0-9]+.*" "\\1" ${_OUT_version_major} "${${_OUT_version}}")
+        string(REGEX REPLACE "^[0-9]+\\.([0-9]+).*" "\\1" ${_OUT_version_minor} "${${_OUT_version}}")
 
         if(NOT ${_OUT_version_major} MATCHES "[0-9]+" OR NOT ${_OUT_version_minor} MATCHES "[0-9]+")
             message(FATAL_ERROR "Version parsing failed for detailed LIBNET_VERSION!: '${_OUT_version}' '${_OUT_version_major}' '${_OUT_version_minor}'")

--- a/include/config.h.cmake
+++ b/include/config.h.cmake
@@ -24,6 +24,7 @@
 #cmakedefine HAVE_CTYPE_H
 #cmakedefine HAVE_INTTYPES_H
 #cmakedefine HAVE_MUTEX_RECURSIVE_NP
+#cmakedefine HAVE_IP6T_SO_ORIGINAL_DST
 #cmakedefine HAVE_LIBGEN_H
 
 #cmakedefine HAVE_PCRE

--- a/include/ec_globals.h
+++ b/include/ec_globals.h
@@ -58,6 +58,10 @@ struct ec_conf {
    struct curses_color colors;
    char *redir_command_on;
    char *redir_command_off;
+#ifdef WITH_IPV6
+   char *redir6_command_on;
+   char *redir6_command_off;
+#endif
    char *remote_browser;
    char *utf8_encoding;
    char *geoip_data_file;

--- a/include/ec_inet.h
+++ b/include/ec_inet.h
@@ -54,6 +54,7 @@
 #define IP6_SOL_NODE "\xff\x02\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01\xff\x00\x00\x00"
 
 #define IP6_DSTOPT_UNKN "\x80\x01\x00\x00\x00"
+#define LLA_IP6_ALLNODES_MULTICAST "\x33\x33\x00\x00\x00\x01"
 
 /* 
  * this structure is used by ettercap to handle 
@@ -84,7 +85,7 @@ EC_API_EXTERN int ip_addr_cmp(struct ip_addr *sa, struct ip_addr *sb);
 EC_API_EXTERN int ip_addr_null(struct ip_addr *sa);
 EC_API_EXTERN int ip_addr_is_zero(struct ip_addr *sa);
 EC_API_EXTERN int ip_addr_random(struct ip_addr* ip, u_int16 type);
-EC_API_EXTERN int ip_addr_init_sol(struct ip_addr* sn, struct ip_addr* ip);
+EC_API_EXTERN int ip_addr_init_sol(struct ip_addr* sn, struct ip_addr* ip, u_int8 *tmac);
 
 EC_API_EXTERN char *ip_addr_ntoa(struct ip_addr *sa, char *dst);
 EC_API_EXTERN int ip_addr_pton(char *str, struct ip_addr *addr);

--- a/include/ec_send.h
+++ b/include/ec_send.h
@@ -25,10 +25,11 @@ EC_API_EXTERN int send_tcp_ether(u_int8 *dmac, struct ip_addr *sip, struct ip_ad
 EC_API_EXTERN int send_L3_icmp_unreach(struct packet_object *po);
 
 #ifdef WITH_IPV6
-EC_API_EXTERN int send_icmp6_echo(struct ip_addr *sip, struct ip_addr *tip);
-EC_API_EXTERN int send_icmp6_echo_opt(struct ip_addr *sip, struct ip_addr *tip, u_int8* o_data, u_int32 o_len);
-EC_API_EXTERN int send_icmp6_nsol(struct ip_addr *sip, struct ip_addr *tip, struct ip_addr *tgt, u_int8 *macaddr);
-EC_API_EXTERN int send_icmp6_nadv(struct ip_addr *sip, struct ip_addr *tip, u_int8 *macaddr, int router);
+EC_API_EXTERN int send_L3_icmp6_echo(struct ip_addr *sip, struct ip_addr *tip);
+EC_API_EXTERN int send_L2_icmp6_echo(struct ip_addr *sip, struct ip_addr *tip, u_int8 *tmac);
+EC_API_EXTERN int send_L2_icmp6_echo_opt(struct ip_addr *sip, struct ip_addr *tip, u_int8* o_data, u_int32 o_len, u_int8 *tmac);
+EC_API_EXTERN int send_L2_icmp6_nsol(struct ip_addr *sip, struct ip_addr *tip, struct ip_addr *tgt, u_int8 *macaddr, u_int8 *tmac);
+EC_API_EXTERN int send_L2_icmp6_nadv(struct ip_addr *sip, struct ip_addr *tip, u_int8 *macaddr, int router, u_int8 *tmac);
 #endif
 
 EC_API_EXTERN void capture_only_incoming(pcap_t *p, libnet_t *l);

--- a/plug-ins/dos_attack/dos_attack.c
+++ b/plug-ins/dos_attack/dos_attack.c
@@ -216,7 +216,7 @@ static void parse_icmp6(struct packet_object *po)
    struct ip_addr ip;
    ip_addr_init(&ip, AF_INET6, po->L4.options);
    if(!ip_addr_cmp(&fake_host, &ip))
-      send_icmp6_nadv(&fake_host, &po->L3.src, GBL_IFACE->mac, 0);
+      send_L2_icmp6_nadv(&fake_host, &po->L3.src, GBL_IFACE->mac, 0, po->L2.src);
 }
 #endif
 

--- a/plug-ins/smurf_attack/smurf_attack.c
+++ b/plug-ins/smurf_attack/smurf_attack.c
@@ -116,7 +116,7 @@ static EC_THREAD_FUNC(smurfer)
          break;
 #ifdef WITH_IPV6
       case AF_INET6:
-         icmp_send = send_icmp6_echo;
+         icmp_send = send_L3_icmp6_echo;
          ips = (struct ip_list_t *)&GBL_TARGET2->ip6;
          break;
 #endif

--- a/plug-ins/sslstrip/sslstrip.c
+++ b/plug-ins/sslstrip/sslstrip.c
@@ -831,7 +831,9 @@ static void http_handle_request(struct http_connection *connection, struct packe
    char *r = (char*)po->DATA.data;
 
    //Skip the first line of request
-   r = strstr((const char*)po->DATA.data, "\r\n");
+   if ((r = strstr((const char*)po->DATA.data, "\r\n")) == NULL)
+      return; // This doesn't seem to look as a HTTP header
+
    r += 2; //Skip \r\n
 
    char *h = strdup(r);

--- a/plug-ins/sslstrip/sslstrip.c
+++ b/plug-ins/sslstrip/sslstrip.c
@@ -77,8 +77,8 @@
 
 #define REQUEST_TIMEOUT 120 /* If a request has not been used in 120 seconds, remove it from list */
 
-#define HTTP_RETRY 5
-#define HTTP_WAIT 10
+#define HTTP_RETRY 500
+#define HTTP_WAIT 10 /* milliseconds */
 
 #define PROTO_HTTP 1
 #define PROTO_HTTPS 2
@@ -721,7 +721,7 @@ static int http_get_peer(struct http_connection *connection)
 
    /* Wait for sniffing thread */
    for (i=0; i<HTTP_RETRY && session_get_and_del(&s, ident, HTTP_IDENT_LEN)!=E_SUCCESS; i++)
-   ec_usleep(SEC2MICRO(HTTP_WAIT));
+   ec_usleep(MILLI2MICRO(HTTP_WAIT));
 
    if (i==HTTP_RETRY) {
       SAFE_FREE(ident);

--- a/plug-ins/sslstrip/sslstrip.c
+++ b/plug-ins/sslstrip/sslstrip.c
@@ -101,43 +101,43 @@
 
 /* lists */
 struct http_ident {
-	u_int32 magic;
-	#define HTTP_MAGIC 0x0501e77f
-	struct ip_addr L3_src;
-	u_int16 L4_src;
-	u_int16 L4_dst;
+   u_int32 magic;
+   #define HTTP_MAGIC 0x0501e77f
+   struct ip_addr L3_src;
+   u_int16 L4_src;
+   u_int16 L4_dst;
 };
 
 #define HTTP_IDENT_LEN sizeof(struct http_ident)
 
 struct https_link {
-	char *url;
-	time_t last_used;
-	LIST_ENTRY (https_link) next;	
+   char *url;
+   time_t last_used;
+   LIST_ENTRY (https_link) next;   
 };
 
 struct http_request {
-	int method;
-	struct curl_slist *headers;
-	char *url;
-	char *payload;
+   int method;
+   struct curl_slist *headers;
+   char *url;
+   char *payload;
 };
 
 struct http_response {
-	char *html;
-	unsigned long int len;
+   char *html;
+   unsigned long int len;
 };
 
 struct http_connection {
-	int fd; 
-	u_int16 port[2];
-	struct ip_addr ip[2];
-	CURL *handle; 
-	struct http_request *request;
-	struct http_response *response;
-	char curl_err_buffer[CURL_ERROR_SIZE];
-	#define HTTP_CLIENT 0
-	#define HTTP_SERVER 1
+   int fd; 
+   u_int16 port[2];
+   struct ip_addr ip[2];
+   CURL *handle; 
+   struct http_request *request;
+   struct http_response *response;
+   char curl_err_buffer[CURL_ERROR_SIZE];
+   #define HTTP_CLIENT 0
+   #define HTTP_SERVER 1
 };
 
 LIST_HEAD(, https_link) https_links;
@@ -203,63 +203,63 @@ static EC_THREAD_FUNC(http_accept_thread);
 #define PO_FROMSSLSTRIP ((u_int16)(1<<13))
 
 struct plugin_ops sslstrip_ops = {
-	.ettercap_version =	EC_VERSION, /* must match global EC_VERSION */
-	.name =			"sslstrip",
-	.info =			"SSLStrip plugin",
-	.version =		"1.2",
-	.init =			&sslstrip_init,
-	.fini =			&sslstrip_fini,
+   .ettercap_version =   EC_VERSION, /* must match global EC_VERSION */
+   .name =         "sslstrip",
+   .info =         "SSLStrip plugin",
+   .version =      "1.2",
+   .init =         &sslstrip_init,
+   .fini =         &sslstrip_fini,
 };
 
 int plugin_load(void *handle)
 {
-	return plugin_register(handle, &sslstrip_ops);
+   return plugin_register(handle, &sslstrip_ops);
 }
 
 static int sslstrip_init(void *dummy)
 {
-	const char *error;
-	int erroroffset;
-	int err;
-	char errbuf[100];
+   const char *error;
+   int erroroffset;
+   int err;
+   char errbuf[100];
 
    /* variable not used */
    (void) dummy;
 
-	/*
-	 * Add IPTables redirect for port 80
+   /*
+    * Add IPTables redirect for port 80
          */
-	if (http_bind_wrapper() != E_SUCCESS) {
-		USER_MSG("SSLStrip: plugin load failed: Could not set up HTTP redirect\n");
-		return PLUGIN_FINISHED;
-	}
+   if (http_bind_wrapper() != E_SUCCESS) {
+      USER_MSG("SSLStrip: plugin load failed: Could not set up HTTP redirect\n");
+      return PLUGIN_FINISHED;
+   }
 
-	https_url_pcre = pcre_compile(URL_PATTERN, PCRE_MULTILINE|PCRE_CASELESS, &error, &erroroffset, NULL);
+   https_url_pcre = pcre_compile(URL_PATTERN, PCRE_MULTILINE|PCRE_CASELESS, &error, &erroroffset, NULL);
 
-	if (!https_url_pcre) {
-		USER_MSG("SSLStrip: plugin load failed: pcre_compile failed (offset: %d), %s\n", erroroffset, error);
-		http_remove_redirect(bind_port);
-		return PLUGIN_FINISHED;
-	}	
+   if (!https_url_pcre) {
+      USER_MSG("SSLStrip: plugin load failed: pcre_compile failed (offset: %d), %s\n", erroroffset, error);
+      http_remove_redirect(bind_port);
+      return PLUGIN_FINISHED;
+   }   
 
-	err = regcomp(&find_cookie_re, COOKIE_PATTERN, REG_EXTENDED | REG_NEWLINE | REG_ICASE);
-	if (err) {
-		regerror(err, &find_cookie_re, errbuf, sizeof(errbuf));
-		USER_MSG("SSLStrip: plugin load failed: Could not compile find_cookie regex: %d\n", err);
-		pcre_free(https_url_pcre);
-		http_remove_redirect(bind_port);
-		return PLUGIN_FINISHED;
-	}
+   err = regcomp(&find_cookie_re, COOKIE_PATTERN, REG_EXTENDED | REG_NEWLINE | REG_ICASE);
+   if (err) {
+      regerror(err, &find_cookie_re, errbuf, sizeof(errbuf));
+      USER_MSG("SSLStrip: plugin load failed: Could not compile find_cookie regex: %d\n", err);
+      pcre_free(https_url_pcre);
+      http_remove_redirect(bind_port);
+      return PLUGIN_FINISHED;
+   }
 
-	hook_add(HOOK_HANDLED, &sslstrip);
+   hook_add(HOOK_HANDLED, &sslstrip);
 
-	/* start HTTP accept thread */
+   /* start HTTP accept thread */
 
 
-	ec_thread_new_detached("http_accept_thread", "HTTP Accept thread", &http_accept_thread, NULL, 1);
+   ec_thread_new_detached("http_accept_thread", "HTTP Accept thread", &http_accept_thread, NULL, 1);
 
-	USER_MSG("SSLStrip Plugin version 1.2 is still under experimental mode. Please reports any issues to the development team.\n");
-	return PLUGIN_RUNNING;
+   USER_MSG("SSLStrip Plugin version 1.2 is still under experimental mode. Please reports any issues to the development team.\n");
+   return PLUGIN_RUNNING;
 }
 
 static int sslstrip_fini(void *dummy)
@@ -268,100 +268,100 @@ static int sslstrip_fini(void *dummy)
    /* variable not used */
    (void) dummy;
 
-	DEBUG_MSG("SSLStrip: Removing redirect\n");
-	if (http_remove_redirect(bind_port) != E_SUCCESS) {
-		USER_MSG("SSLStrip: Unable to remove HTTP redirect, please do so manually.\n");
-	}
+   DEBUG_MSG("SSLStrip: Removing redirect\n");
+   if (http_remove_redirect(bind_port) != E_SUCCESS) {
+      USER_MSG("SSLStrip: Unable to remove HTTP redirect, please do so manually.\n");
+   }
 
-        // Free regexes.
-        if (https_url_pcre)
-          pcre_free(https_url_pcre);
+   // Free regexes.
+   if (https_url_pcre)
+     pcre_free(https_url_pcre);
 
-        regfree(&find_cookie_re);
+   regfree(&find_cookie_re);
 
-       /* stop accept wrapper */
-       pthread_t pid = ec_thread_getpid("http_accept_thread");
-       
-       if (!pthread_equal(pid, EC_PTHREAD_NULL))
-               ec_thread_destroy(pid);
+   /* stop accept wrapper */
+   pthread_t pid = ec_thread_getpid("http_accept_thread");
+   
+   if (!pthread_equal(pid, EC_PTHREAD_NULL))
+           ec_thread_destroy(pid);
 
-	/* now destroy all http_child_thread */
-	do {
-		pid = ec_thread_getpid("http_child_thread");
-		
-		if(!pthread_equal(pid, EC_PTHREAD_NULL))
-			ec_thread_destroy(pid);
+   /* now destroy all http_child_thread */
+   do {
+      pid = ec_thread_getpid("http_child_thread");
+      
+      if(!pthread_equal(pid, EC_PTHREAD_NULL))
+         ec_thread_destroy(pid);
 
-	} while (!pthread_equal(pid, EC_PTHREAD_NULL));
+   } while (!pthread_equal(pid, EC_PTHREAD_NULL));
 
-	close(main_fd);
+   close(main_fd);
 #ifdef WITH_IPV6
    close(main_fd6);
 #endif
 
-	/* Remove hook point */
-	hook_del(HOOK_HANDLED, &sslstrip);
+   /* Remove hook point */
+   hook_del(HOOK_HANDLED, &sslstrip);
 
-	return PLUGIN_FINISHED;
+   return PLUGIN_FINISHED;
 }
 
 static int sslstrip_is_http(struct packet_object *po)
 {
-	/* if already coming from SSLStrip or proto is not TCP */
-	if (po->flags & PO_FROMSSLSTRIP || po->L4.proto != NL_TYPE_TCP)
-		return 0;
+   /* if already coming from SSLStrip or proto is not TCP */
+   if (po->flags & PO_FROMSSLSTRIP || po->L4.proto != NL_TYPE_TCP)
+      return 0;
 
-	if (ntohs(po->L4.dst) == 80 ||
-	    ntohs(po->L4.src) == 80)
-		return 1;
+   if (ntohs(po->L4.dst) == 80 ||
+       ntohs(po->L4.src) == 80)
+      return 1;
 
-	if (strstr((const char*)po->DATA.data, "HTTP/1.1") ||
-	    strstr((const char*)po->DATA.data, "HTTP/1.0"))
-		return 1;
-	return 0;
+   if (strstr((const char*)po->DATA.data, "HTTP/1.1") ||
+       strstr((const char*)po->DATA.data, "HTTP/1.0"))
+      return 1;
+   return 0;
 }
 
 #ifndef OS_LINUX
 static int sslstrip_match(void *id_sess, void *id_curr)
 {
-	struct  http_ident *ids = id_sess;
-	struct http_ident *id = id_curr;
+   struct  http_ident *ids = id_sess;
+   struct http_ident *id = id_curr;
 
-	/* sanity checks */
-	BUG_IF(ids == NULL);
-	BUG_IF(id == NULL);
+   /* sanity checks */
+   BUG_IF(ids == NULL);
+   BUG_IF(id == NULL);
 
-	/* check magic */
-	if (ids->magic != id->magic)
-		return 0;
+   /* check magic */
+   if (ids->magic != id->magic)
+      return 0;
 
-	if (ids->L4_src == id->L4_src &&
-	    ids->L4_dst == id->L4_dst &&
-	    !ip_addr_cmp(&ids->L3_src, &id->L3_src))
-	return 1;
+   if (ids->L4_src == id->L4_src &&
+       ids->L4_dst == id->L4_dst &&
+       !ip_addr_cmp(&ids->L3_src, &id->L3_src))
+   return 1;
 
-	return 0;
+   return 0;
 }
 
 static void sslstrip_create_session(struct ec_session **s, struct packet_object *po)
 {
-	void *ident;
-	DEBUG_MSG("sslstrip_create_session");
-	
-	/* allocate the session */
-	SAFE_CALLOC(*s, 1, sizeof(struct ec_session));
+   void *ident;
+   DEBUG_MSG("sslstrip_create_session");
+   
+   /* allocate the session */
+   SAFE_CALLOC(*s, 1, sizeof(struct ec_session));
 
-	/* create the ident */
-	(*s)->ident_len = http_create_ident(&ident, po);
+   /* create the ident */
+   (*s)->ident_len = http_create_ident(&ident, po);
 
-	/* link to the session */
-	(*s)->ident = ident;
+   /* link to the session */
+   (*s)->ident = ident;
 
-	/* the matching function */
-	(*s)->match = sslstrip_match;
+   /* the matching function */
+   (*s)->match = sslstrip_match;
 
-	/* alloc of data elements */
-	SAFE_CALLOC((*s)->data, 1, sizeof(struct ip_addr));
+   /* alloc of data elements */
+   SAFE_CALLOC((*s)->data, 1, sizeof(struct ip_addr));
 }
 #endif
 
@@ -371,26 +371,26 @@ static void sslstrip_create_session(struct ec_session **s, struct packet_object 
 static void sslstrip(struct packet_object *po)
 {
 
-	if (!sslstrip_is_http(po))
-		return;	
+   if (!sslstrip_is_http(po))
+      return;   
 
-	/* If it's an HTTP packet, don't forward it */
- 	po->flags |= PO_DROPPED;
+   /* If it's an HTTP packet, don't forward it */
+    po->flags |= PO_DROPPED;
 
 
-	if ( (po->flags & PO_FORWARDABLE) &&
-	     (po->L4.flags & TH_SYN) &&
-             !(po->L4.flags & TH_ACK) ) {
+   if ( (po->flags & PO_FORWARDABLE) &&
+        (po->L4.flags & TH_SYN) &&
+       !(po->L4.flags & TH_ACK) ) {
 #ifndef OS_LINUX
-		struct ec_session *s = NULL;
-		sslstrip_create_session(&s, PACKET);	
-		memcpy(s->data, &po->L3.dst, sizeof(struct ip_addr));
-		session_put(s);
-		
+      struct ec_session *s = NULL;
+      sslstrip_create_session(&s, PACKET);   
+      memcpy(s->data, &po->L3.dst, sizeof(struct ip_addr));
+      session_put(s);
+      
 #endif
-	} else {
-		po->flags |= PO_IGNORE;
-	}
+   } else {
+      po->flags |= PO_IGNORE;
+   }
 
 }
 
@@ -457,124 +457,124 @@ static void Find_Url(u_char *to_parse, char **ret)
 /* HTTP handling functions */
 static int http_insert_redirect(u_int16 dport)
 {
-	char asc_dport[16];
-	int ret_val = 0;
-	char *command;
-	char *param[4];
+   char asc_dport[16];
+   int ret_val = 0;
+   char *command;
+   char *param[4];
 
-	if (GBL_CONF->redir_command_on == NULL)
-	{
-		USER_MSG("SSLStrip: cannot setup the redirect, did you uncomment the redir_command_on command on your etter.conf file?\n");
-		return -E_FATAL;
-	}
-	snprintf(asc_dport, 16, "%u", dport);
+   if (GBL_CONF->redir_command_on == NULL)
+   {
+      USER_MSG("SSLStrip: cannot setup the redirect, did you uncomment the redir_command_on command on your etter.conf file?\n");
+      return -E_FATAL;
+   }
+   snprintf(asc_dport, 16, "%u", dport);
 
-	command = strdup(GBL_CONF->redir_command_on);
-	str_replace(&command, "%iface", GBL_OPTIONS->iface);
-	str_replace(&command, "%port", "80");
-	str_replace(&command, "%rport", asc_dport);
+   command = strdup(GBL_CONF->redir_command_on);
+   str_replace(&command, "%iface", GBL_OPTIONS->iface);
+   str_replace(&command, "%port", "80");
+   str_replace(&command, "%rport", asc_dport);
 #if defined(OS_DARWIN) || defined(OS_BSD)
-	str_replace(&command, "%set", SSLSTRIP_SET);
+   str_replace(&command, "%set", SSLSTRIP_SET);
 #endif
 
-	DEBUG_MSG("http_insert_redirect: [%s]", command);
+   DEBUG_MSG("http_insert_redirect: [%s]", command);
 
    /* construct the params array for execvp */
-	param[0] = "sh";
-	param[1] = "-c";
-	param[2] = command;
-	param[3] = NULL;
+   param[0] = "sh";
+   param[1] = "-c";
+   param[2] = command;
+   param[3] = NULL;
 
-	switch(fork()) {
-		case 0:
-			regain_privs();
-			execvp(param[0], param);
-			drop_privs();
-			WARN_MSG("Cannot setup http redirect (command: %s), please edit your etter.conf file and put a valid value in redir_command_on field\n", param[0]);
-			SAFE_FREE(command);
-			_exit(-E_INVALID);
-		case -1:
-			SAFE_FREE(command);
-			return -E_INVALID;
-		default:
-			wait(&ret_val);
-			if (WIFEXITED(ret_val) && WEXITSTATUS(ret_val)) {
-			    USER_MSG("SSLStrip: redir_command_on had non-zero exit status (%d): [%s]\n", WEXITSTATUS(ret_val), command);
-			    SAFE_FREE(command);
-			    return -E_INVALID;
-			}
-			break;
-	}
+   switch(fork()) {
+      case 0:
+         regain_privs();
+         execvp(param[0], param);
+         drop_privs();
+         WARN_MSG("Cannot setup http redirect (command: %s), please edit your etter.conf file and put a valid value in redir_command_on field\n", param[0]);
+         SAFE_FREE(command);
+         _exit(-E_INVALID);
+      case -1:
+         SAFE_FREE(command);
+         return -E_INVALID;
+      default:
+         wait(&ret_val);
+         if (WIFEXITED(ret_val) && WEXITSTATUS(ret_val)) {
+             USER_MSG("SSLStrip: redir_command_on had non-zero exit status (%d): [%s]\n", WEXITSTATUS(ret_val), command);
+             SAFE_FREE(command);
+             return -E_INVALID;
+         }
+         break;
+   }
 
-	SAFE_FREE(command);
+   SAFE_FREE(command);
 
-	return E_SUCCESS;
+   return E_SUCCESS;
 }
 
 static int http_remove_redirect(u_int16 dport)
 {
-        char asc_dport[16];
-        int ret_val = 0;
-        char *command;
-        char *param[4];
+   char asc_dport[16];
+   int ret_val = 0;
+   char *command;
+   char *param[4];
 
 
-        if (GBL_CONF->redir_command_off == NULL)
-	{
-		USER_MSG("SSLStrip: cannot remove the redirect, did you uncomment the redir_command_off command on your etter.conf file?");
-		return -E_FATAL;
-	}
+   if (GBL_CONF->redir_command_off == NULL)
+   {
+      USER_MSG("SSLStrip: cannot remove the redirect, did you uncomment the redir_command_off command on your etter.conf file?");
+      return -E_FATAL;
+   }
 
-        snprintf(asc_dport, 16, "%u", dport);
+   snprintf(asc_dport, 16, "%u", dport);
 
-        command = strdup(GBL_CONF->redir_command_off);
-        str_replace(&command, "%iface", GBL_OPTIONS->iface);
-        str_replace(&command, "%port", "80");
-        str_replace(&command, "%rport", asc_dport);
+   command = strdup(GBL_CONF->redir_command_off);
+   str_replace(&command, "%iface", GBL_OPTIONS->iface);
+   str_replace(&command, "%port", "80");
+   str_replace(&command, "%rport", asc_dport);
 #if defined(OS_DARWIN) || defined(OS_BSD)
-	str_replace(&command, "%set", SSLSTRIP_SET);
+   str_replace(&command, "%set", SSLSTRIP_SET);
 #endif
-        DEBUG_MSG("http_remove_redirect: [%s]", command);
+   DEBUG_MSG("http_remove_redirect: [%s]", command);
 
-        /* construct the params array for execvp */
-        param[0] = "sh";
-        param[1] = "-c";
-        param[2] = command;
-        param[3] = NULL;
+   /* construct the params array for execvp */
+   param[0] = "sh";
+   param[1] = "-c";
+   param[2] = command;
+   param[3] = NULL;
 
-        switch(fork()) {
-		case 0:
-			regain_privs();
-			execvp(param[0], param);
-			drop_privs();
-			WARN_MSG("Cannot remove http redirect (command: %s), please edit your etter.conf file and put a valid value in redir_command_on field\n", param[0]);
+   switch(fork()) {
+      case 0:
+         regain_privs();
+         execvp(param[0], param);
+         drop_privs();
+         WARN_MSG("Cannot remove http redirect (command: %s), please edit your etter.conf file and put a valid value in redir_command_on field\n", param[0]);
          SAFE_FREE(command);
-			_exit(-E_INVALID);
-                case -1:
-                        SAFE_FREE(command);
-                        return -E_INVALID;
-                default:
-                        wait(&ret_val);
-                        if (WIFEXITED(ret_val) && WEXITSTATUS(ret_val)) {
-                            USER_MSG("SSLStrip: redir_command_off had non-zero exit status (%d): [%s]\n", WEXITSTATUS(ret_val), command);
-                            SAFE_FREE(command);
-                            return -E_INVALID;
-                        }
-                        break;
-        }
+         _exit(-E_INVALID);
+      case -1:
+         SAFE_FREE(command);
+         return -E_INVALID;
+      default:
+         wait(&ret_val);
+         if (WIFEXITED(ret_val) && WEXITSTATUS(ret_val)) {
+            USER_MSG("SSLStrip: redir_command_off had non-zero exit status (%d): [%s]\n", WEXITSTATUS(ret_val), command);
+            SAFE_FREE(command);
+            return -E_INVALID;
+         }
+         break;
+   }
 
-        SAFE_FREE(command);
+   SAFE_FREE(command);
 
-        return E_SUCCESS;
+   return E_SUCCESS;
 }
 
 static EC_THREAD_FUNC(http_accept_thread)
 {
-	struct http_connection *connection;
+   struct http_connection *connection;
    struct sockaddr_storage client_ss;
-	u_int len = sizeof(client_ss);
-	int optval = 1, fd = 0, nfds = 1;
-	socklen_t optlen = sizeof(optval);
+   u_int len = sizeof(client_ss);
+   int optval = 1, fd = 0, nfds = 1;
+   socklen_t optlen = sizeof(optval);
    struct sockaddr *sa;
    struct sockaddr_in *sa4;
 #ifdef WITH_IPV6
@@ -585,9 +585,9 @@ static EC_THREAD_FUNC(http_accept_thread)
    /* variable not used */
    (void) EC_THREAD_PARAM;
 
-	ec_thread_init();
+   ec_thread_init();
 
-	DEBUG_MSG("SSLStrip: http_accept_thread initialized and ready");
+   DEBUG_MSG("SSLStrip: http_accept_thread initialized and ready");
 
    poll_fd[0].fd = main_fd;
    poll_fd[0].events = POLLIN;
@@ -597,7 +597,7 @@ static EC_THREAD_FUNC(http_accept_thread)
    nfds++;
 #endif
 
-	LOOP {
+   LOOP {
 
       /* wait until one file descriptor becomes active */
       poll(poll_fd, nfds, -1);
@@ -613,25 +613,25 @@ static EC_THREAD_FUNC(http_accept_thread)
          continue;
 
       /* accept incoming connection */
-		SAFE_CALLOC(connection, 1, sizeof(struct http_connection));
-		BUG_IF(connection==NULL);
+      SAFE_CALLOC(connection, 1, sizeof(struct http_connection));
+      BUG_IF(connection==NULL);
 
-		SAFE_CALLOC(connection->request, 1, sizeof(struct http_request));
-		BUG_IF(connection->request==NULL);
+      SAFE_CALLOC(connection->request, 1, sizeof(struct http_request));
+      BUG_IF(connection->request==NULL);
 
-		SAFE_CALLOC(connection->response, 1, sizeof(struct http_response));
-		BUG_IF(connection->response==NULL);
+      SAFE_CALLOC(connection->response, 1, sizeof(struct http_response));
+      BUG_IF(connection->response==NULL);
 
-		connection->fd = accept(fd, (struct sockaddr *)&client_ss, &len);
+      connection->fd = accept(fd, (struct sockaddr *)&client_ss, &len);
 
-		DEBUG_MSG("SSLStrip: Received connection: %p %p\n", connection, connection->request);
-		if (connection->fd == -1) {
+      DEBUG_MSG("SSLStrip: Received connection: %p %p\n", connection, connection->request);
+      if (connection->fd == -1) {
          DEBUG_MSG("SSLStrip: Failed to accept connection: %s.", strerror(errno));
-			SAFE_FREE(connection->request);
-			SAFE_FREE(connection->response);
-			SAFE_FREE(connection);
-			continue;
-		}
+         SAFE_FREE(connection->request);
+         SAFE_FREE(connection->response);
+         SAFE_FREE(connection);
+         continue;
+      }
 
       sa = (struct sockaddr *)&client_ss;
       switch (sa->sa_family) {
@@ -649,74 +649,74 @@ static EC_THREAD_FUNC(http_accept_thread)
 #endif
       }
 
-		connection->port[HTTP_SERVER] = htons(80);
-		//connection->request->len = 0;
+      connection->port[HTTP_SERVER] = htons(80);
+      //connection->request->len = 0;
 
-		/* set SO_KEEPALIVE */
-		if (setsockopt(connection->fd, SOL_SOCKET, SO_KEEPALIVE, &optval, optlen) < 0) {
-			DEBUG_MSG("SSLStrip: Could not set up SO_KEEPALIVE");
-		}
-		/* create detached thread */
-		ec_thread_new_detached("http_child_thread", "http child", &http_child_thread, connection, 1);	
-	}
+      /* set SO_KEEPALIVE */
+      if (setsockopt(connection->fd, SOL_SOCKET, SO_KEEPALIVE, &optval, optlen) < 0) {
+         DEBUG_MSG("SSLStrip: Could not set up SO_KEEPALIVE");
+      }
+      /* create detached thread */
+      ec_thread_new_detached("http_child_thread", "http child", &http_child_thread, connection, 1);   
+   }
 
-	return NULL;
+   return NULL;
 }
 
 static int http_get_peer(struct http_connection *connection)
 {
 
 #ifndef OS_LINUX
-	struct ec_session *s = NULL;
-	struct packet_object po;
-	void *ident= NULL;
-	int i;
+   struct ec_session *s = NULL;
+   struct packet_object po;
+   void *ident= NULL;
+   int i;
 
-	memcpy(&po.L3.src, &connection->ip[HTTP_CLIENT], sizeof(struct ip_addr));
-	po.L4.src = connection->port[HTTP_CLIENT];
-	po.L4.dst = connection->port[HTTP_SERVER]; 
+   memcpy(&po.L3.src, &connection->ip[HTTP_CLIENT], sizeof(struct ip_addr));
+   po.L4.src = connection->port[HTTP_CLIENT];
+   po.L4.dst = connection->port[HTTP_SERVER]; 
 
-	http_create_ident(&ident, &po);
+   http_create_ident(&ident, &po);
 
-	/* Wait for sniffing thread */
-	for (i=0; i<HTTP_RETRY && session_get_and_del(&s, ident, HTTP_IDENT_LEN)!=E_SUCCESS; i++)
-	ec_usleep(SEC2MICRO(HTTP_WAIT));
+   /* Wait for sniffing thread */
+   for (i=0; i<HTTP_RETRY && session_get_and_del(&s, ident, HTTP_IDENT_LEN)!=E_SUCCESS; i++)
+   ec_usleep(SEC2MICRO(HTTP_WAIT));
 
-	if (i==HTTP_RETRY) {
-		SAFE_FREE(ident);
-		return -E_INVALID;
-	}
+   if (i==HTTP_RETRY) {
+      SAFE_FREE(ident);
+      return -E_INVALID;
+   }
 
-	memcpy(&connection->ip[HTTP_SERVER], s->data, sizeof(struct ip_addr));
+   memcpy(&connection->ip[HTTP_SERVER], s->data, sizeof(struct ip_addr));
 
-	SAFE_FREE(s->data);
-	SAFE_FREE(s);
-	SAFE_FREE(ident);
+   SAFE_FREE(s->data);
+   SAFE_FREE(s);
+   SAFE_FREE(ident);
 #else
    struct sockaddr_storage ss;
-	 struct sockaddr_in *sa4;
+   struct sockaddr_in *sa4;
 #if defined WITH_IPV6 && defined HAVE_IP6T_SO_ORIGINAL_DST
-    struct sockaddr_in6 *sa6;
+   struct sockaddr_in6 *sa6;
 #endif
-	 socklen_t ss_len = sizeof(struct sockaddr_storage);
-    switch (ntohs(connection->ip[HTTP_CLIENT].addr_type)) {
-       case AF_INET:
-          getsockopt (connection->fd, SOL_IP, SO_ORIGINAL_DST, (struct sockaddr*)&ss, &ss_len);
-          sa4 = (struct sockaddr_in *)&ss;
-          ip_addr_init(&(connection->ip[HTTP_SERVER]), AF_INET, (u_char *)&(sa4->sin_addr.s_addr));
-          break;
+   socklen_t ss_len = sizeof(struct sockaddr_storage);
+   switch (ntohs(connection->ip[HTTP_CLIENT].addr_type)) {
+      case AF_INET:
+         getsockopt (connection->fd, SOL_IP, SO_ORIGINAL_DST, (struct sockaddr*)&ss, &ss_len);
+         sa4 = (struct sockaddr_in *)&ss;
+         ip_addr_init(&(connection->ip[HTTP_SERVER]), AF_INET, (u_char *)&(sa4->sin_addr.s_addr));
+         break;
 #if defined WITH_IPV6 && defined HAVE_IP6T_SO_ORIGINAL_DST
-       case AF_INET6:
-          getsockopt (connection->fd, IPPROTO_IPV6, IP6T_SO_ORIGINAL_DST, (struct sockaddr*)&ss, &ss_len);
-          sa6 = (struct sockaddr_in6 *)&ss;
-          ip_addr_init(&(connection->ip[HTTP_SERVER]), AF_INET6, (u_char *)&(sa6->sin6_addr.s6_addr));
-          break;
+      case AF_INET6:
+         getsockopt (connection->fd, IPPROTO_IPV6, IP6T_SO_ORIGINAL_DST, (struct sockaddr*)&ss, &ss_len);
+         sa6 = (struct sockaddr_in6 *)&ss;
+         ip_addr_init(&(connection->ip[HTTP_SERVER]), AF_INET6, (u_char *)&(sa6->sin6_addr.s6_addr));
+         break;
 #endif
-    }
+   }
 
 #endif
-	
-	return E_SUCCESS;
+
+   return E_SUCCESS;
 
 }
 
@@ -724,537 +724,537 @@ static int http_get_peer(struct http_connection *connection)
 #ifndef OS_LINUX
 static size_t http_create_ident(void **i, struct packet_object *po)
 {
-	struct http_ident *ident;
+   struct http_ident *ident;
 
-	SAFE_CALLOC(ident, 1, sizeof(struct http_ident));
+   SAFE_CALLOC(ident, 1, sizeof(struct http_ident));
 
-	ident->magic = HTTP_MAGIC;
+   ident->magic = HTTP_MAGIC;
 
-	memcpy(&ident->L3_src, &po->L3.src, sizeof(struct ip_addr));
-	ident->L4_src = po->L4.src;
-	ident->L4_dst = po->L4.dst;
+   memcpy(&ident->L3_src, &po->L3.src, sizeof(struct ip_addr));
+   ident->L4_src = po->L4.src;
+   ident->L4_dst = po->L4.dst;
 
-	/* return the ident */
-	*i = ident;
-	return sizeof(struct http_ident);
+   /* return the ident */
+   *i = ident;
+   return sizeof(struct http_ident);
 }
 #endif
 
 static int http_sync_conn(struct http_connection *connection) 
 {
-	if (http_get_peer(connection) != E_SUCCESS)
-		return -E_INVALID;
+   if (http_get_peer(connection) != E_SUCCESS)
+      return -E_INVALID;
 
 
-	set_blocking(connection->fd, 0);
-	return E_SUCCESS;
+   set_blocking(connection->fd, 0);
+   return E_SUCCESS;
 }
 
 static int http_read(struct http_connection *connection, struct packet_object *po)
 {
-	int len = 0;	
+   int len = 0;   
 
-	len = read(connection->fd, po->DATA.data, HTTP_MAX);
+   len = read(connection->fd, po->DATA.data, HTTP_MAX);
 
-	po->DATA.len = len;
+   po->DATA.len = len;
 
-	if(len <= 0)
-		return -E_INVALID;
+   if(len <= 0)
+      return -E_INVALID;
 
-	return len;	
+   return len;   
 }
 
 static void http_handle_request(struct http_connection *connection, struct packet_object *po)
 {
-	struct https_link *link;
+   struct https_link *link;
 
-	SAFE_CALLOC(connection->request->url, 1, 512);
+   SAFE_CALLOC(connection->request->url, 1, 512);
 
-	if (connection->request->url==NULL)
-		return;
+   if (connection->request->url==NULL)
+      return;
 
-	Find_Url(po->DATA.data, &connection->request->url);
+   Find_Url(po->DATA.data, &connection->request->url);
 
-	if (connection->request->url == NULL) {
-		return;
-	}
-
-
-	//parse HTTP request
-	if (!memcmp(po->DATA.data, "GET", 3)) {
-		connection->request->method = HTTP_GET;
-	} else if (!memcmp(po->DATA.data, "POST", 4)) {
-		connection->request->method = HTTP_POST;
-	}
-
-	char *r = (char*)po->DATA.data;
-
-	//Skip the first line of request
-	r = strstr((const char*)po->DATA.data, "\r\n");
-	r += 2; //Skip \r\n
-
-	char *h = strdup(r);
-	char *body = strdup(r);
-	BUG_IF(h==NULL);
-	BUG_IF(body==NULL);
-
-	char *end_header = strstr(h, "\r\n\r\n");
-
-	if (!end_header)
-	{
-		SAFE_FREE(h);
-		SAFE_FREE(body);
-		return; //Something went really wrong here
-	}
-	*end_header = '\0';
-
-	char *header;
-	char *saveptr;
-	header = ec_strtok(h, "\r\n", &saveptr);
-
-	while(header) {
-		connection->request->headers = curl_slist_append(connection->request->headers, header);
-		header = ec_strtok(NULL, "\r\n", &saveptr);
-	}
-
-	SAFE_FREE(h);
-
-	char *b = strstr(body, "\r\n\r\n");
-
-	if (b != NULL) {
-		b += 4;
-		connection->request->payload = strdup(b);
-		BUG_IF(connection->request->payload == NULL);
-	}
-
-	SAFE_FREE(body);
+   if (connection->request->url == NULL) {
+      return;
+   }
 
 
-	int proto = PROTO_HTTP;
+   //parse HTTP request
+   if (!memcmp(po->DATA.data, "GET", 3)) {
+      connection->request->method = HTTP_GET;
+   } else if (!memcmp(po->DATA.data, "POST", 4)) {
+      connection->request->method = HTTP_POST;
+   }
 
-	LIST_LOCK;
-	LIST_FOREACH(link, &https_links, next) {
-		if (!strcmp(link->url, connection->request->url)) {
-			proto = PROTO_HTTPS;
-			break;
-		}
-	}
+   char *r = (char*)po->DATA.data;
 
-	LIST_UNLOCK;
+   //Skip the first line of request
+   r = strstr((const char*)po->DATA.data, "\r\n");
+   r += 2; //Skip \r\n
+
+   char *h = strdup(r);
+   char *body = strdup(r);
+   BUG_IF(h==NULL);
+   BUG_IF(body==NULL);
+
+   char *end_header = strstr(h, "\r\n\r\n");
+
+   if (!end_header)
+   {
+      SAFE_FREE(h);
+      SAFE_FREE(body);
+      return; //Something went really wrong here
+   }
+   *end_header = '\0';
+
+   char *header;
+   char *saveptr;
+   header = ec_strtok(h, "\r\n", &saveptr);
+
+   while(header) {
+      connection->request->headers = curl_slist_append(connection->request->headers, header);
+      header = ec_strtok(NULL, "\r\n", &saveptr);
+   }
+
+   SAFE_FREE(h);
+
+   char *b = strstr(body, "\r\n\r\n");
+
+   if (b != NULL) {
+      b += 4;
+      connection->request->payload = strdup(b);
+      BUG_IF(connection->request->payload == NULL);
+   }
+
+   SAFE_FREE(body);
 
 
-	switch(proto) {
-		case PROTO_HTTP:
-			DEBUG_MSG("SSLStrip: Sending HTTP request");
-			break;
-		case PROTO_HTTPS:
-			DEBUG_MSG("SSLStrip: Sending HTTPs request");
-			break;
-	}
+   int proto = PROTO_HTTP;
 
-	http_send(connection,po, proto);
+   LIST_LOCK;
+   LIST_FOREACH(link, &https_links, next) {
+      if (!strcmp(link->url, connection->request->url)) {
+         proto = PROTO_HTTPS;
+         break;
+      }
+   }
+
+   LIST_UNLOCK;
+
+
+   switch(proto) {
+      case PROTO_HTTP:
+         DEBUG_MSG("SSLStrip: Sending HTTP request");
+         break;
+      case PROTO_HTTPS:
+         DEBUG_MSG("SSLStrip: Sending HTTPs request");
+         break;
+   }
+
+   http_send(connection,po, proto);
 }
 
 static void http_send(struct http_connection *connection, struct packet_object *po, int proto)
 {
 
-	curl_global_init(CURL_GLOBAL_ALL);
-	connection->handle = curl_easy_init();
+   curl_global_init(CURL_GLOBAL_ALL);
+   connection->handle = curl_easy_init();
 
-	if(!connection->handle) {
-		DEBUG_MSG("SSLStrip: Not enough memory to allocate CURL handle");
-		return;
-	}
+   if(!connection->handle) {
+      DEBUG_MSG("SSLStrip: Not enough memory to allocate CURL handle");
+      return;
+   }
 
-	char *url;
+   char *url;
 
-	//Allow decoders to run for request
-	if (proto == PROTO_HTTPS) {
-		curl_easy_setopt(connection->handle, CURLOPT_SSL_VERIFYPEER, 0L);
-		curl_easy_setopt(connection->handle, CURLOPT_SSL_VERIFYHOST, 0L);
+   //Allow decoders to run for request
+   if (proto == PROTO_HTTPS) {
+      curl_easy_setopt(connection->handle, CURLOPT_SSL_VERIFYPEER, 0L);
+      curl_easy_setopt(connection->handle, CURLOPT_SSL_VERIFYHOST, 0L);
 
-		SAFE_CALLOC(url, 1, strlen(connection->request->url)+strlen("https://")+1);
-		snprintf(url, strlen(connection->request->url)+strlen("https://")+1, "https://%s", connection->request->url);
-	} else {
-		SAFE_CALLOC(url, 1, strlen(connection->request->url)+strlen("http://")+1);
-		snprintf(url, strlen(connection->request->url)+strlen("http://")+1, "http://%s", connection->request->url);
-	}
-
-
-	if (url==NULL) {
-		DEBUG_MSG("Not enough memory to allocate for URL %s\n", connection->request->url);
-		return;
-	}	
+      SAFE_CALLOC(url, 1, strlen(connection->request->url)+strlen("https://")+1);
+      snprintf(url, strlen(connection->request->url)+strlen("https://")+1, "https://%s", connection->request->url);
+   } else {
+      SAFE_CALLOC(url, 1, strlen(connection->request->url)+strlen("http://")+1);
+      snprintf(url, strlen(connection->request->url)+strlen("http://")+1, "http://%s", connection->request->url);
+   }
 
 
-	curl_easy_setopt(connection->handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
-	curl_easy_setopt(connection->handle, CURLOPT_URL, url);
-	curl_easy_setopt(connection->handle, CURLOPT_WRITEFUNCTION, http_receive_from_server);
-	curl_easy_setopt(connection->handle, CURLOPT_WRITEDATA, connection);
-	curl_easy_setopt(connection->handle, CURLOPT_ERRORBUFFER, connection->curl_err_buffer);
-	curl_easy_setopt(connection->handle, CURLOPT_HEADER, 1L);
-	curl_easy_setopt(connection->handle, CURLOPT_HTTPHEADER, connection->request->headers);
-	curl_easy_setopt(connection->handle, CURLOPT_ACCEPT_ENCODING, "gzip");
-	curl_easy_setopt(connection->handle, CURLOPT_ACCEPT_ENCODING, "deflate");
-	curl_easy_setopt(connection->handle, CURLOPT_COOKIEFILE, ""); //Initialize cookie engine
-
-	/* Only allow HTTP and HTTPS */
-	curl_easy_setopt(connection->handle, CURLOPT_PROTOCOLS, (long) CURLPROTO_HTTP | 
-						(long)CURLPROTO_HTTPS);
-	curl_easy_setopt(connection->handle, CURLOPT_REDIR_PROTOCOLS, (long) CURLPROTO_HTTP | 
-						(long) CURLPROTO_HTTPS);
+   if (url==NULL) {
+      DEBUG_MSG("Not enough memory to allocate for URL %s\n", connection->request->url);
+      return;
+   }   
 
 
-	if(connection->request->method == HTTP_POST) {
-		curl_easy_setopt(connection->handle, CURLOPT_POST, 1L);
-		curl_easy_setopt(connection->handle, CURLOPT_POSTFIELDS, connection->request->payload);
-		curl_easy_setopt(connection->handle, CURLOPT_POSTFIELDSIZE, strlen(connection->request->payload));
-	}	
+   curl_easy_setopt(connection->handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+   curl_easy_setopt(connection->handle, CURLOPT_URL, url);
+   curl_easy_setopt(connection->handle, CURLOPT_WRITEFUNCTION, http_receive_from_server);
+   curl_easy_setopt(connection->handle, CURLOPT_WRITEDATA, connection);
+   curl_easy_setopt(connection->handle, CURLOPT_ERRORBUFFER, connection->curl_err_buffer);
+   curl_easy_setopt(connection->handle, CURLOPT_HEADER, 1L);
+   curl_easy_setopt(connection->handle, CURLOPT_HTTPHEADER, connection->request->headers);
+   curl_easy_setopt(connection->handle, CURLOPT_ACCEPT_ENCODING, "gzip");
+   curl_easy_setopt(connection->handle, CURLOPT_ACCEPT_ENCODING, "deflate");
+   curl_easy_setopt(connection->handle, CURLOPT_COOKIEFILE, ""); //Initialize cookie engine
+
+   /* Only allow HTTP and HTTPS */
+   curl_easy_setopt(connection->handle, CURLOPT_PROTOCOLS, (long) CURLPROTO_HTTP | 
+                  (long)CURLPROTO_HTTPS);
+   curl_easy_setopt(connection->handle, CURLOPT_REDIR_PROTOCOLS, (long) CURLPROTO_HTTP | 
+                  (long) CURLPROTO_HTTPS);
 
 
-	if(curl_easy_perform(connection->handle) != CURLE_OK) {
-		DEBUG_MSG("Unable to send request to HTTP server: %s\n", connection->curl_err_buffer);
-		return;
-	} else {
-		DEBUG_MSG("SSLStrip: Sent request to server");
-	}
-
-	DEBUG_MSG("Before removing https: %s", connection->response->html);
-	DEBUG_MSG("SSLStrip: Removing HTTPS");
-	http_remove_https(connection);
-	http_remove_secure_from_cookie(connection);
-
-	if(strstr(connection->response->html, "\r\nContent-Encoding:") ||
-	   strstr(connection->response->html, "\r\nTransfer-Encoding:")) {
-		http_remove_header("Content-Encoding", connection);
-		http_remove_header("Transfer-Encoding", connection);
-		http_update_content_length(connection);
-	}
+   if(connection->request->method == HTTP_POST) {
+      curl_easy_setopt(connection->handle, CURLOPT_POST, 1L);
+      curl_easy_setopt(connection->handle, CURLOPT_POSTFIELDS, connection->request->payload);
+      curl_easy_setopt(connection->handle, CURLOPT_POSTFIELDSIZE, strlen(connection->request->payload));
+   }   
 
 
-	if(strstr(connection->response->html, "\r\nStrict-Transport-Security:")) {
-		http_remove_header("Strict-Transport-Security", connection);
-	}
+   if(curl_easy_perform(connection->handle) != CURLE_OK) {
+      DEBUG_MSG("Unable to send request to HTTP server: %s\n", connection->curl_err_buffer);
+      return;
+   } else {
+      DEBUG_MSG("SSLStrip: Sent request to server");
+   }
 
-	DEBUG_MSG("SSLStrip: after removing all %s", connection->response->html);
-	//Send result back to client
-	DEBUG_MSG("SSLStrip: Sending response back to client");
-	if (http_write(connection->fd, connection->response->html, connection->response->len) != E_SUCCESS){
-		DEBUG_MSG("Unable to send HTTP response back to client\n");
-	} else {
-		DEBUG_MSG("Sent HTTP response back to client");
-	}
+   DEBUG_MSG("Before removing https: %s", connection->response->html);
+   DEBUG_MSG("SSLStrip: Removing HTTPS");
+   http_remove_https(connection);
+   http_remove_secure_from_cookie(connection);
+
+   if(strstr(connection->response->html, "\r\nContent-Encoding:") ||
+      strstr(connection->response->html, "\r\nTransfer-Encoding:")) {
+      http_remove_header("Content-Encoding", connection);
+      http_remove_header("Transfer-Encoding", connection);
+      http_update_content_length(connection);
+   }
 
 
-	//Allow decoders to run on HTTP response
-	http_initialize_po(po, (u_char*)connection->response->html, connection->response->len);
-	packet_destroy_object(po);
-   	po->len = po->DATA.len;
-   	po->L4.flags |= TH_PSH;
-	packet_disp_data(po, po->DATA.data, po->DATA.len);
+   if(strstr(connection->response->html, "\r\nStrict-Transport-Security:")) {
+      http_remove_header("Strict-Transport-Security", connection);
+   }
 
-	DEBUG_MSG("SSLStrip: Calling parser for response");
-	http_parse_packet(connection, HTTP_SERVER, po);
+   DEBUG_MSG("SSLStrip: after removing all %s", connection->response->html);
+   //Send result back to client
+   DEBUG_MSG("SSLStrip: Sending response back to client");
+   if (http_write(connection->fd, connection->response->html, connection->response->len) != E_SUCCESS){
+      DEBUG_MSG("Unable to send HTTP response back to client\n");
+   } else {
+      DEBUG_MSG("Sent HTTP response back to client");
+   }
 
-	//Free up request
-	if (connection->request->headers) {
-		curl_slist_free_all(connection->request->headers);
-		connection->request->headers = NULL;
-	}
-	
 
-	if (connection->request->method == HTTP_POST) {
-		SAFE_FREE(connection->request->payload);
-	}
+   //Allow decoders to run on HTTP response
+   http_initialize_po(po, (u_char*)connection->response->html, connection->response->len);
+   packet_destroy_object(po);
+      po->len = po->DATA.len;
+      po->L4.flags |= TH_PSH;
+   packet_disp_data(po, po->DATA.data, po->DATA.len);
 
-	SAFE_FREE(connection->request->url);
+   DEBUG_MSG("SSLStrip: Calling parser for response");
+   http_parse_packet(connection, HTTP_SERVER, po);
 
-	SAFE_FREE(url);
+   //Free up request
+   if (connection->request->headers) {
+      curl_slist_free_all(connection->request->headers);
+      connection->request->headers = NULL;
+   }
+   
 
-	if(connection->handle) {
-		curl_easy_cleanup(connection->handle);
-		curl_global_cleanup();
-		connection->handle = NULL;
-	}
+   if (connection->request->method == HTTP_POST) {
+      SAFE_FREE(connection->request->payload);
+   }
 
-	DEBUG_MSG("SSLStrip: Done");
+   SAFE_FREE(connection->request->url);
+
+   SAFE_FREE(url);
+
+   if(connection->handle) {
+      curl_easy_cleanup(connection->handle);
+      curl_global_cleanup();
+      connection->handle = NULL;
+   }
+
+   DEBUG_MSG("SSLStrip: Done");
 }
 
 static int http_write(int fd, char *ptr, unsigned long int total_len)
 {
-	int len, err;
-	unsigned int bytes_sent = 0;
-	int bytes_remaining = total_len;
+   int len, err;
+   unsigned int bytes_sent = 0;
+   int bytes_remaining = total_len;
 
-	DEBUG_MSG("SSLStrip: Total length %lu", total_len);
+   DEBUG_MSG("SSLStrip: Total length %lu", total_len);
 
-	while (bytes_sent < total_len) {
+   while (bytes_sent < total_len) {
 
-		if(!ptr)
-			break;
-		len = write(fd, ptr+bytes_sent, bytes_remaining);
+      if(!ptr)
+         break;
+      len = write(fd, ptr+bytes_sent, bytes_remaining);
 
-		if (len <= 0) {
-			err = GET_SOCK_ERRNO();
-			DEBUG_MSG("http_write: SOCK ERR: %d", err);
-			if (err != EAGAIN && err != EINTR)
-				return -E_INVALID;
-		}
+      if (len <= 0) {
+         err = GET_SOCK_ERRNO();
+         DEBUG_MSG("http_write: SOCK ERR: %d", err);
+         if (err != EAGAIN && err != EINTR)
+            return -E_INVALID;
+      }
 
-		DEBUG_MSG("SSLStrip: Sent %d bytes", len);
-	
-		bytes_sent += len;
-		bytes_remaining -= len;
+      DEBUG_MSG("SSLStrip: Sent %d bytes", len);
+   
+      bytes_sent += len;
+      bytes_remaining -= len;
 
-		DEBUG_MSG("SSLStrip: Bytes sent %d", bytes_sent);
+      DEBUG_MSG("SSLStrip: Bytes sent %d", bytes_sent);
       ec_usleep(MILLI2MICRO(100)); // 100ms
 
-	
-	}
+   
+   }
 
-	return E_SUCCESS;
+   return E_SUCCESS;
 }
 
 #if 0
 static size_t http_write_to_server(void *ptr, size_t size, size_t nmemb, void *stream)
 {
-	struct packet_object *po = (struct packet_object *)stream;
+   struct packet_object *po = (struct packet_object *)stream;
 
-	DEBUG_MSG("SSLStrip: PO LEN : %ld Size: %ld", po->DATA.len, (size*nmemb));
-	DEBUG_MSG("SSLStrip: Copying %s", po->DATA.data);
-	if ((size*nmemb) < po->DATA.len) {	
-		memcpy(ptr, po->DATA.data, size*nmemb);
-		return size*nmemb;
-	} else {
-		memcpy(ptr, po->DATA.data, po->DATA.len);
-		return po->DATA.len;
-	}
+   DEBUG_MSG("SSLStrip: PO LEN : %ld Size: %ld", po->DATA.len, (size*nmemb));
+   DEBUG_MSG("SSLStrip: Copying %s", po->DATA.data);
+   if ((size*nmemb) < po->DATA.len) {   
+      memcpy(ptr, po->DATA.data, size*nmemb);
+      return size*nmemb;
+   } else {
+      memcpy(ptr, po->DATA.data, po->DATA.len);
+      return po->DATA.len;
+   }
 }
 #endif
 
 
 static u_int http_receive_from_server(char *ptr, size_t size, size_t nmemb, void *userdata)
 {
-	struct http_connection *connection = (struct http_connection *)userdata;
+   struct http_connection *connection = (struct http_connection *)userdata;
 
 
-	if (connection->response->len == 0) {
-		//Initiailize buffer
-		SAFE_CALLOC(connection->response->html, 1, size*nmemb);
-		if (connection->response->html == NULL)
-			return 0;
+   if (connection->response->len == 0) {
+      //Initiailize buffer
+      SAFE_CALLOC(connection->response->html, 1, size*nmemb);
+      if (connection->response->html == NULL)
+         return 0;
 
-		memcpy(connection->response->html, ptr, size*nmemb);
-	} else {
-		char *b;
+      memcpy(connection->response->html, ptr, size*nmemb);
+   } else {
+      char *b;
 
-		SAFE_CALLOC(b, 1, connection->response->len+(size*nmemb));
-		BUG_IF(b == NULL);
-	
-		memcpy(b, connection->response->html, connection->response->len);	
-		memcpy(b+connection->response->len, ptr, size*nmemb);
+      SAFE_CALLOC(b, 1, connection->response->len+(size*nmemb));
+      BUG_IF(b == NULL);
+   
+      memcpy(b, connection->response->html, connection->response->len);   
+      memcpy(b+connection->response->len, ptr, size*nmemb);
 
-		SAFE_FREE(connection->response->html);
-		connection->response->html = b;
+      SAFE_FREE(connection->response->html);
+      connection->response->html = b;
 
-		//SAFE_REALLOC(connection->response->html, connection->response->len + (size*nmemb));
-	}
+      //SAFE_REALLOC(connection->response->html, connection->response->len + (size*nmemb));
+   }
 
-	connection->response->len += (size*nmemb);
-	//connection->response->html[connection->response->len] = '\0';
+   connection->response->len += (size*nmemb);
+   //connection->response->html[connection->response->len] = '\0';
 
 
-	return size*nmemb;
+   return size*nmemb;
 }
 
 EC_THREAD_FUNC(http_child_thread)
 {
-	struct packet_object po;
-	int  ret_val;
-	struct http_connection *connection;
+   struct packet_object po;
+   int  ret_val;
+   struct http_connection *connection;
 
-	connection = (struct http_connection *)args;
-	ec_thread_init();
+   connection = (struct http_connection *)args;
+   ec_thread_init();
 
-	/* Get peer and set to non-blocking */
-	if (http_sync_conn(connection) == -E_INVALID) {
-		DEBUG_MSG("SSLStrip: Could not get peer!!");
-		if (connection->fd != -1)
-			close_socket(connection->fd);
-		SAFE_FREE(connection->response);
-		SAFE_FREE(connection->request);
-		SAFE_FREE(connection);	
-		ec_thread_exit();
-	}
+   /* Get peer and set to non-blocking */
+   if (http_sync_conn(connection) == -E_INVALID) {
+      DEBUG_MSG("SSLStrip: Could not get peer!!");
+      if (connection->fd != -1)
+         close_socket(connection->fd);
+      SAFE_FREE(connection->response);
+      SAFE_FREE(connection->request);
+      SAFE_FREE(connection);   
+      ec_thread_exit();
+   }
 
 
-	/* A fake SYN ACK for profiles */
-	http_initialize_po(&po, NULL, 0);
-	po.len = 64;
-	po.L4.flags = (TH_SYN | TH_ACK);
-	packet_disp_data(&po, po.DATA.data, po.DATA.len);
-	http_parse_packet(connection, HTTP_SERVER, &po);
-	http_initialize_po(&po, po.DATA.data, po.DATA.len);
+   /* A fake SYN ACK for profiles */
+   http_initialize_po(&po, NULL, 0);
+   po.len = 64;
+   po.L4.flags = (TH_SYN | TH_ACK);
+   packet_disp_data(&po, po.DATA.data, po.DATA.len);
+   http_parse_packet(connection, HTTP_SERVER, &po);
+   http_initialize_po(&po, po.DATA.data, po.DATA.len);
 
-	
-	LOOP {
-		http_initialize_po(&po, NULL, 0);
-		ret_val = http_read(connection, &po);
-		DEBUG_MSG("SSLStrip: Returned %d", ret_val);
-		BREAK_ON_ERROR(ret_val, connection, po);
+   
+   LOOP {
+      http_initialize_po(&po, NULL, 0);
+      ret_val = http_read(connection, &po);
+      DEBUG_MSG("SSLStrip: Returned %d", ret_val);
+      BREAK_ON_ERROR(ret_val, connection, po);
 
-		if (ret_val > 0)  {
-			/* Look in the https_links list and if the url matches, send to HTTPS server.
-			   Otherwise send to HTTP server */
-	        	po.len = po.DATA.len;
-        		po.L4.flags |= TH_PSH;
+      if (ret_val > 0)  {
+         /* Look in the https_links list and if the url matches, send to HTTPS server.
+            Otherwise send to HTTP server */
+              po.len = po.DATA.len;
+              po.L4.flags |= TH_PSH;
 
-			/* NULL terminate buffer */
-			po.DATA.data[po.DATA.len] = 0;
+         /* NULL terminate buffer */
+         po.DATA.data[po.DATA.len] = 0;
 
-			packet_destroy_object(&po);
-        		packet_disp_data(&po, po.DATA.data, po.DATA.len);
+         packet_destroy_object(&po);
+              packet_disp_data(&po, po.DATA.data, po.DATA.len);
 
-        		//DEBUG_MSG("SSLStrip: Calling parser for request");
-        		http_parse_packet(connection, HTTP_CLIENT, &po);
+              //DEBUG_MSG("SSLStrip: Calling parser for request");
+              http_parse_packet(connection, HTTP_CLIENT, &po);
 
-			http_handle_request(connection, &po);
-		}
-		
-	}
+         http_handle_request(connection, &po);
+      }
+      
+   }
 
-	return NULL;
-	
+   return NULL;
+   
 }
 
 static void http_remove_https(struct http_connection *connection)
 {
-	char *buf_cpy = connection->response->html;
-	size_t https_len = strlen("https://");
-	size_t http_len = strlen("http://");
-	struct https_link *l, *link;
-	size_t offset = 0;
-	int rc;
-	int ovector[30];
-	char changed = 0;
-	char *new_html;
-	size_t new_size = 0;
-	size_t size = connection->response->len;
-	int i = 0;
+   char *buf_cpy = connection->response->html;
+   size_t https_len = strlen("https://");
+   size_t http_len = strlen("http://");
+   struct https_link *l, *link;
+   size_t offset = 0;
+   int rc;
+   int ovector[30];
+   char changed = 0;
+   char *new_html;
+   size_t new_size = 0;
+   size_t size = connection->response->len;
+   int i = 0;
 
-	if(!buf_cpy)
-		return;
+   if(!buf_cpy)
+      return;
 
-	SAFE_CALLOC(new_html, 1, connection->response->len);
-	BUG_IF(new_html==NULL);
+   SAFE_CALLOC(new_html, 1, connection->response->len);
+   BUG_IF(new_html==NULL);
 
-	while(offset < size && (rc = pcre_exec(https_url_pcre, NULL, buf_cpy, size, offset, 0, ovector, 30)) > 0) {
-		memcpy(new_html+new_size, buf_cpy+offset, ovector[2*i]-offset);
-		new_size += ovector[2*i]-offset;
+   while(offset < size && (rc = pcre_exec(https_url_pcre, NULL, buf_cpy, size, offset, 0, ovector, 30)) > 0) {
+      memcpy(new_html+new_size, buf_cpy+offset, ovector[2*i]-offset);
+      new_size += ovector[2*i]-offset;
 
-		char *url = strndup(buf_cpy+ovector[2*i]+https_len, 
-			(ovector[2*i+1] - ovector[2*i]) - https_len);
-		memcpy(new_html+new_size, "http://", http_len);
-		new_size += http_len;
-		memcpy(new_html+new_size, url, (ovector[2*i+1] - ovector[2*i]) - https_len);
-		new_size += (ovector[2*i+1] - ovector[2*i]) - https_len;
-		offset = ovector[1];
+      char *url = strndup(buf_cpy+ovector[2*i]+https_len, 
+         (ovector[2*i+1] - ovector[2*i]) - https_len);
+      memcpy(new_html+new_size, "http://", http_len);
+      new_size += http_len;
+      memcpy(new_html+new_size, url, (ovector[2*i+1] - ovector[2*i]) - https_len);
+      new_size += (ovector[2*i+1] - ovector[2*i]) - https_len;
+      offset = ovector[1];
 
-		//Add URL to list
+      //Add URL to list
 
-		char found = 0;
-		LIST_LOCK;
-		LIST_FOREACH(link, &https_links, next) {
-			if(!strcmp(link->url, url)) {
-				found=1;
-				break;
-			}	
-		}		
+      char found = 0;
+      LIST_LOCK;
+      LIST_FOREACH(link, &https_links, next) {
+         if(!strcmp(link->url, url)) {
+            found=1;
+            break;
+         }   
+      }      
 
-		LIST_UNLOCK;
+      LIST_UNLOCK;
 
-		if(!found) {
-			SAFE_CALLOC(l, 1, sizeof(struct https_link));
-			BUG_IF(l==NULL);
+      if(!found) {
+         SAFE_CALLOC(l, 1, sizeof(struct https_link));
+         BUG_IF(l==NULL);
 
-			SAFE_CALLOC(l->url, 1, 1+((ovector[2*i+1] - ovector[2*i]) - https_len));
-			BUG_IF(l->url==NULL);
-			memcpy(l->url, url, (ovector[2*i+1] - ovector[2*i]) - https_len);
-			Decode_Url((u_char *)l->url);
-			l->last_used = time(NULL);
-			DEBUG_MSG("SSLStrip: Inserting %s to HTTPS List", l->url);
-			LIST_INSERT_HEAD(&https_links, l, next);
-		}
+         SAFE_CALLOC(l->url, 1, 1+((ovector[2*i+1] - ovector[2*i]) - https_len));
+         BUG_IF(l->url==NULL);
+         memcpy(l->url, url, (ovector[2*i+1] - ovector[2*i]) - https_len);
+         Decode_Url((u_char *)l->url);
+         l->last_used = time(NULL);
+         DEBUG_MSG("SSLStrip: Inserting %s to HTTPS List", l->url);
+         LIST_INSERT_HEAD(&https_links, l, next);
+      }
 
-		SAFE_FREE(url);
-		
-		if (!changed)
-			changed=1;
-	}
+      SAFE_FREE(url);
+      
+      if (!changed)
+         changed=1;
+   }
 
-	
-	if (changed) {
-		//Copy rest of data (if any)
-		memcpy(new_html+new_size, buf_cpy+offset, size-offset);
-		SAFE_FREE(connection->response->html);	
-		connection->response->html = new_html;
-		connection->response->len = new_size;	
-	} else {
-		/* Thanks but we don't need it */
-		SAFE_FREE(new_html);
-	}
+   
+   if (changed) {
+      //Copy rest of data (if any)
+      memcpy(new_html+new_size, buf_cpy+offset, size-offset);
+      SAFE_FREE(connection->response->html);   
+      connection->response->html = new_html;
+      connection->response->len = new_size;   
+   } else {
+      /* Thanks but we don't need it */
+      SAFE_FREE(new_html);
+   }
 
-        /* Iterate through all http_request and remove any that have not been used lately */
-        struct https_link *link_tmp;
-        time_t now = time(NULL);
+   /* Iterate through all http_request and remove any that have not been used lately */
+   struct https_link *link_tmp;
+   time_t now = time(NULL);
 
-	LIST_LOCK;
+   LIST_LOCK;
 
-        LIST_FOREACH_SAFE(l, &https_links, next, link_tmp) {
-                if(now - l->last_used >= REQUEST_TIMEOUT) {
-                        LIST_REMOVE(l, next);
-                        SAFE_FREE(l);
-                }
-        }
-	
-	LIST_UNLOCK;
+   LIST_FOREACH_SAFE(l, &https_links, next, link_tmp) {
+      if(now - l->last_used >= REQUEST_TIMEOUT) {
+         LIST_REMOVE(l, next);
+         SAFE_FREE(l);
+      }
+   }
+   
+   LIST_UNLOCK;
 
 }
 
 static void http_parse_packet(struct http_connection *connection, int direction, struct packet_object *po)
 {
-	FUNC_DECODER_PTR(start_decoder);
-	int len;
+   FUNC_DECODER_PTR(start_decoder);
+   int len;
 
-	memcpy(&po->L3.src, &connection->ip[direction], sizeof(struct ip_addr));
-	memcpy(&po->L3.dst, &connection->ip[!direction], sizeof(struct ip_addr));
-	
-	po->L4.src = connection->port[direction];
-	po->L4.dst = connection->port[!direction];
+   memcpy(&po->L3.src, &connection->ip[direction], sizeof(struct ip_addr));
+   memcpy(&po->L3.dst, &connection->ip[!direction], sizeof(struct ip_addr));
+   
+   po->L4.src = connection->port[direction];
+   po->L4.dst = connection->port[!direction];
 
-	po->flags |= PO_FROMSSLSTRIP;	
-	/* get time */
-	gettimeofday(&po->ts, NULL);
+   po->flags |= PO_FROMSSLSTRIP;   
+   /* get time */
+   gettimeofday(&po->ts, NULL);
 
-	switch(ip_addr_is_local(&PACKET->L3.src, NULL)) {
-		case E_SUCCESS:
-			PACKET->PASSIVE.flags &= ~FP_HOST_NONLOCAL;
-			PACKET->PASSIVE.flags |= FP_HOST_LOCAL;
-			break;
-		case -E_NOTFOUND:
-			PACKET->PASSIVE.flags &= ~FP_HOST_LOCAL;
-			PACKET->PASSIVE.flags |= FP_HOST_NONLOCAL;
-			break;
-		case -E_INVALID:
-			PACKET->PASSIVE.flags = FP_UNKNOWN;
-			break;
-	}
+   switch(ip_addr_is_local(&PACKET->L3.src, NULL)) {
+      case E_SUCCESS:
+         PACKET->PASSIVE.flags &= ~FP_HOST_NONLOCAL;
+         PACKET->PASSIVE.flags |= FP_HOST_LOCAL;
+         break;
+      case -E_NOTFOUND:
+         PACKET->PASSIVE.flags &= ~FP_HOST_LOCAL;
+         PACKET->PASSIVE.flags |= FP_HOST_NONLOCAL;
+         break;
+      case -E_INVALID:
+         PACKET->PASSIVE.flags = FP_UNKNOWN;
+         break;
+   }
 
-	/* let's start fromt he last stage of decoder chain */
+   /* let's start fromt he last stage of decoder chain */
 
-	//DEBUG_MSG("SSLStrip: Parsing %s", po->DATA.data);
-	start_decoder = get_decoder(APP_LAYER, PL_DEFAULT);
-	start_decoder(po->DATA.data, po->DATA.len, &len, po);
+   //DEBUG_MSG("SSLStrip: Parsing %s", po->DATA.data);
+   start_decoder = get_decoder(APP_LAYER, PL_DEFAULT);
+   start_decoder(po->DATA.data, po->DATA.len, &len, po);
 }
 
 static void http_initialize_po(struct packet_object *po, u_char *p_data, size_t len)
@@ -1265,7 +1265,7 @@ static void http_initialize_po(struct packet_object *po, u_char *p_data, size_t 
     * XXX - Be sure to not modify these len.
     */
 
-	
+   
    memset(po, 0, sizeof(struct packet_object));
 
    if (p_data == NULL) {
@@ -1297,35 +1297,35 @@ static void http_initialize_po(struct packet_object *po, u_char *p_data, size_t 
 
 static int http_bind_wrapper(void)
 {
-	bind_port = EC_MAGIC_16;
-	struct sockaddr_in sa_in;
+   bind_port = EC_MAGIC_16;
+   struct sockaddr_in sa_in;
 #ifdef WITH_IPV6
    struct sockaddr_in6 sa_in6;
    int optval = 1;
 #endif
 
-	ec_thread_init();
+   ec_thread_init();
 
-	DEBUG_MSG("http_listen_thread: initialized and ready");
-	
-	main_fd = socket(AF_INET, SOCK_STREAM, 0);
-        if (main_fd == -1) { /* oops, unable to create socket */
-            DEBUG_MSG("Unable to create socket() for HTTP...");
-            return -E_FATAL;
-        }
-	memset(&sa_in, 0, sizeof(sa_in));
-	sa_in.sin_family = AF_INET;
-	sa_in.sin_addr.s_addr = INADDR_ANY;
+   DEBUG_MSG("http_listen_thread: initialized and ready");
+   
+   main_fd = socket(AF_INET, SOCK_STREAM, 0);
+   if (main_fd == -1) { /* oops, unable to create socket */
+      DEBUG_MSG("Unable to create socket() for HTTP...");
+      return -E_FATAL;
+   }
+   memset(&sa_in, 0, sizeof(sa_in));
+   sa_in.sin_family = AF_INET;
+   sa_in.sin_addr.s_addr = INADDR_ANY;
 
-	do {
-		bind_port++;
-		sa_in.sin_port = htons(bind_port);	
-	} while (bind(main_fd, (struct sockaddr *)&sa_in, sizeof(sa_in)) != 0);
+   do {
+      bind_port++;
+      sa_in.sin_port = htons(bind_port);   
+   } while (bind(main_fd, (struct sockaddr *)&sa_in, sizeof(sa_in)) != 0);
 
-	if(listen(main_fd, 100) == -1) {
-            DEBUG_MSG("SSLStrip plugin: unable to listen() on socket");
-            return -E_FATAL;
-        }
+   if(listen(main_fd, 100) == -1) {
+      DEBUG_MSG("SSLStrip plugin: unable to listen() on socket");
+      return -E_FATAL;
+   }
 
 #ifdef WITH_IPV6
    /* create & bind IPv6 socket on the same port */
@@ -1366,119 +1366,119 @@ static int http_bind_wrapper(void)
    main_fd6 = 0;
 #endif
 
-	USER_MSG("SSLStrip plugin: bind 80 on %d\n", bind_port);
-	
-	if (http_insert_redirect(bind_port) != E_SUCCESS)
-		return -E_FATAL;
+   USER_MSG("SSLStrip plugin: bind 80 on %d\n", bind_port);
+   
+   if (http_insert_redirect(bind_port) != E_SUCCESS)
+      return -E_FATAL;
 
-	return E_SUCCESS;
+   return E_SUCCESS;
 
 }
 
 static void http_wipe_connection(struct http_connection *connection)
 {
-	DEBUG_MSG("SSLStrip: http_wipe_connection");
-	close_socket(connection->fd);
+   DEBUG_MSG("SSLStrip: http_wipe_connection");
+   close_socket(connection->fd);
 
-	if(connection->response->html)
-		SAFE_FREE(connection->response->html);
+   if(connection->response->html)
+      SAFE_FREE(connection->response->html);
 
-	if(connection->request->payload)
-		SAFE_FREE(connection->request->payload);
+   if(connection->request->payload)
+      SAFE_FREE(connection->request->payload);
 
-	if(connection->request->url)
-		SAFE_FREE(connection->request->url);
+   if(connection->request->url)
+      SAFE_FREE(connection->request->url);
 
-	if(connection->request)
-		SAFE_FREE(connection->request);
+   if(connection->request)
+      SAFE_FREE(connection->request);
 
-	if(connection->response)
-		SAFE_FREE(connection->response);
+   if(connection->response)
+      SAFE_FREE(connection->response);
 
-	if (connection)
-		SAFE_FREE(connection);
+   if (connection)
+      SAFE_FREE(connection);
 }
 
 void http_remove_header(char *header, struct http_connection *connection) {
-	DEBUG_MSG("SSLStrip: http_remove_header");
-	if (strstr(connection->response->html, header)) {
-        	char *r = strdup(connection->response->html);
-        	size_t len = strlen(connection->response->html);
+   DEBUG_MSG("SSLStrip: http_remove_header");
+   if (strstr(connection->response->html, header)) {
+      char *r = strdup(connection->response->html);
+      size_t len = strlen(connection->response->html);
 
-        	char *b = strstr(r, header);
-        	char *end = strstr(b, "\r\n");
-        	end += 2;
+      char *b = strstr(r, header);
+      char *end = strstr(b, "\r\n");
+      end += 2;
 
-        	int header_length = end - b;
-        	len -= header_length;
+      int header_length = end - b;
+      len -= header_length;
 
-        	int start = b - r;
-        	char *remaining = strdup(end);
-		BUG_IF(remaining==NULL);
+      int start = b - r;
+      char *remaining = strdup(end);
+      BUG_IF(remaining==NULL);
 
-        	memcpy(r+start, remaining, strlen(remaining));
-		SAFE_FREE(connection->response->html);
+      memcpy(r+start, remaining, strlen(remaining));
+      SAFE_FREE(connection->response->html);
 
-        	connection->response->html = strndup(r, len);
-		connection->response->len = len;
-	
-		SAFE_FREE(remaining);
-		SAFE_FREE(r);
-        }
+      connection->response->html = strndup(r, len);
+      connection->response->len = len;
+   
+      SAFE_FREE(remaining);
+      SAFE_FREE(r);
+   }
 }
 
 void http_remove_secure_from_cookie(struct http_connection *connection) {
-	if (!strstr(connection->response->html, "Set-Cookie")) {
-		return;
-	}
-	
-	size_t newlen = 0;
-	size_t pos = 0;
-	char *buf_cpy = connection->response->html;
-	char *new_html;
+   if (!strstr(connection->response->html, "Set-Cookie")) {
+      return;
+   }
+   
+   size_t newlen = 0;
+   size_t pos = 0;
+   char *buf_cpy = connection->response->html;
+   char *new_html;
 
-	SAFE_CALLOC(new_html, 1, connection->response->len);
-	char changed = 0;
+   SAFE_CALLOC(new_html, 1, connection->response->len);
+   char changed = 0;
 
-	regmatch_t match[4];
+   regmatch_t match[4];
 
-	while(!regexec(&find_cookie_re, buf_cpy, 4, match, REG_NOTBOL)) {
-		memcpy(new_html+newlen, buf_cpy, match[1].rm_eo);
-		newlen += match[1].rm_eo;
-		
-		memcpy(new_html+newlen, buf_cpy+match[3].rm_so, match[3].rm_eo - match[3].rm_so);
-		newlen += match[3].rm_eo - match[3].rm_so;
-		
-		buf_cpy += match[0].rm_eo-2;
-		pos += match[0].rm_eo-2;
-		changed=1;
-	}
+   while(!regexec(&find_cookie_re, buf_cpy, 4, match, REG_NOTBOL)) {
+      memcpy(new_html+newlen, buf_cpy, match[1].rm_eo);
+      newlen += match[1].rm_eo;
+      
+      memcpy(new_html+newlen, buf_cpy+match[3].rm_so, match[3].rm_eo - match[3].rm_so);
+      newlen += match[3].rm_eo - match[3].rm_so;
+      
+      buf_cpy += match[0].rm_eo-2;
+      pos += match[0].rm_eo-2;
+      changed=1;
+   }
 
-	if (changed) {
-		memcpy(new_html+newlen, buf_cpy, connection->response->len - pos);
-		newlen += connection->response->len - pos;
+   if (changed) {
+      memcpy(new_html+newlen, buf_cpy, connection->response->len - pos);
+      newlen += connection->response->len - pos;
 
-		SAFE_FREE(connection->response->html);
+      SAFE_FREE(connection->response->html);
 
-		connection->response->html = new_html;
-		connection->response->len = newlen;
-	} else {
-		SAFE_FREE(new_html);
-	}
+      connection->response->html = new_html;
+      connection->response->len = newlen;
+   } else {
+      SAFE_FREE(new_html);
+   }
 }
 
 void http_update_content_length(struct http_connection *connection) {
-	if (strstr(connection->response->html, "Content-Length: ")) {
-        	char *buf = connection->response->html;
-                char *content_length = strstr(connection->response->html, "Content-Length:");
-                content_length += strlen("Content-Length: ");
+   if (strstr(connection->response->html, "Content-Length: ")) {
+      char *buf = connection->response->html;
+      char *content_length = strstr(connection->response->html, "Content-Length:");
+      content_length += strlen("Content-Length: ");
 
-                char c_length[20];
-                memset(&c_length, '\0', 20);
-                snprintf(c_length, 20, "%lu", connection->response->len);
+      char c_length[20];
+      memset(&c_length, '\0', 20);
+      snprintf(c_length, 20, "%lu", connection->response->len);
 
-                memcpy(buf+(content_length-buf)-1, c_length, strlen(c_length));
-        }
+      memcpy(buf+(content_length-buf)-1, c_length, strlen(c_length));
+   }
 }
 
 // vim:ts=3:expandtab

--- a/share/etter.conf.v6
+++ b/share/etter.conf.v6
@@ -183,9 +183,9 @@ geoip_data_file_v6 = "/path/to/GeoIPv6.dat"
    #redir_command_on = "iptables -t nat -A PREROUTING -i %iface -p tcp --dport %port -j REDIRECT --to-port %rport"
    #redir_command_off = "iptables -t nat -D PREROUTING -i %iface -p tcp --dport %port -j REDIRECT --to-port %rport"
 
-# pendant for IPv6 - Note that you need iptables 1.4.16 or newer to use IPv6 redirect
-   #redir_command_on = "ip6tables -t nat -A PREROUTING -i %iface -p tcp --dport %port -j REDIRECT --to-port %rport"
-   #redir_command_off = "ip6tables -t nat -D PREROUTING -i %iface -p tcp --dport %port -j REDIRECT --to-port %rport"
+# pendant for IPv6 - Note that you need iptables v1.4.16 or newer to use IPv6 redirect
+   #redir6_command_on = "ip6tables -t nat -A PREROUTING -i %iface -p tcp --dport %port -j REDIRECT --to-port %rport"
+   #redir6_command_off = "ip6tables -t nat -D PREROUTING -i %iface -p tcp --dport %port -j REDIRECT --to-port %rport"
 
 #---------------
 #    Mac Os X

--- a/share/etter.conf.v6
+++ b/share/etter.conf.v6
@@ -183,6 +183,10 @@ geoip_data_file_v6 = "/path/to/GeoIPv6.dat"
    #redir_command_on = "iptables -t nat -A PREROUTING -i %iface -p tcp --dport %port -j REDIRECT --to-port %rport"
    #redir_command_off = "iptables -t nat -D PREROUTING -i %iface -p tcp --dport %port -j REDIRECT --to-port %rport"
 
+# pendant for IPv6 - Note that you need iptables 1.4.16 or newer to use IPv6 redirect
+   #redir_command_on = "ip6tables -t nat -A PREROUTING -i %iface -p tcp --dport %port -j REDIRECT --to-port %rport"
+   #redir_command_off = "ip6tables -t nat -D PREROUTING -i %iface -p tcp --dport %port -j REDIRECT --to-port %rport"
+
 #---------------
 #    Mac Os X
 #---------------
@@ -226,8 +230,11 @@ geoip_data_file_v6 = "/path/to/GeoIPv6.dat"
 # `pfctl -e`.
 
    #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to any port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
-   #redir_command_off = "pfctl -Psn 2> /dev/null | grep -v %port | pfctl -f - 2> /dev/null"
+   #redir_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet .+ %port' | pfctl -f - 2> /dev/null"
 
+# pendant for IPv6
+   #redir6_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet6 proto tcp from any to any port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
+   #redir6_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet6 .+ %port' | pfctl -f - 2> /dev/null"
 
 #---------------
 #   Open BSD

--- a/src/ec_conf.c
+++ b/src/ec_conf.c
@@ -108,6 +108,10 @@ static struct conf_entry curses[] = {
 static struct conf_entry strings[] = {
    { "redir_command_on", NULL },
    { "redir_command_off", NULL },
+#ifdef WITH_IPV6
+   { "redir6_command_on", NULL },
+   { "redir6_command_off", NULL },
+#endif
    { "remote_browser", NULL },
    { "utf8_encoding", NULL },
    { "geoip_data_file", NULL },
@@ -213,6 +217,10 @@ static void init_structures(void)
    /* special case for strings */
    set_pointer(strings, "redir_command_on", &GBL_CONF->redir_command_on);
    set_pointer(strings, "redir_command_off", &GBL_CONF->redir_command_off);
+#ifdef WITH_IPV6
+   set_pointer(strings, "redir6_command_on", &GBL_CONF->redir6_command_on);
+   set_pointer(strings, "redir6_command_off", &GBL_CONF->redir6_command_off);
+#endif
    set_pointer(strings, "remote_browser", &GBL_CONF->remote_browser);
    set_pointer(strings, "utf8_encoding", &GBL_CONF->utf8_encoding);
    set_pointer(strings, "geoip_data_file", &GBL_CONF->geoip_data_file);

--- a/src/ec_inet.c
+++ b/src/ec_inet.c
@@ -156,15 +156,18 @@ int ip_addr_random(struct ip_addr* ip, u_int16 type)
 }
 
 /*
- * initialize a solicited-node address from a given ip address.
- * returns E_SUCCESS on success or -E_INVALID in case of a 
- * unsupported address familily (actually only IPv6 is supported)
+ * initialize a solicited-node IPv6 and link-layer address from a
+ * given ip address.
+ *
+ * returns E_SUCCESS on success or -E_INVALID in case of a unsupported
+ * address familily (actually only IPv6 is supported)
  */
-int ip_addr_init_sol(struct ip_addr* sn, struct ip_addr* ip)
+int ip_addr_init_sol(struct ip_addr* sn, struct ip_addr* ip, u_int8 *tmac)
 {
    switch (ntohs(ip->addr_type)) {
       case AF_INET:
          (void) sn;
+         (void) tmac;
          /* not applicable for IPv4 */
       break;
 #ifdef WITH_IPV6
@@ -176,6 +179,15 @@ int ip_addr_init_sol(struct ip_addr* sn, struct ip_addr* ip)
           */
          ip_addr_init(sn, AF_INET6, (u_char*)IP6_SOL_NODE);
          memcpy((sn->addr + 13), (ip->addr + 13), 3);
+
+         /*
+          * initialize the MAC address derived from the solicited
+          * node multicast IPv6 address by overwriting the tailing
+          * 32-bit of the all-nodes link-layer multicast address for IPv6
+          */
+         memcpy(tmac, LLA_IP6_ALLNODES_MULTICAST, MEDIA_ADDR_LEN);
+         memcpy((tmac + 2), (sn->addr + 12), 4);
+
 
          return E_SUCCESS;
       break;

--- a/src/ec_scan.c
+++ b/src/ec_scan.c
@@ -468,7 +468,7 @@ static void scan_ip6_onlink(void)
        * ping to all-nodes from all ip addresses to get responses from all 
        * IPv6 networks (global, link-local, ...)
        */
-      send_icmp6_echo(&e->ip, &an);
+      send_L2_icmp6_echo(&e->ip, &an, LLA_IP6_ALLNODES_MULTICAST);
 
 #if EC_CHECK_LIBNET_VERSION(1,2)
       /*
@@ -477,7 +477,8 @@ static void scan_ip6_onlink(void)
        * since libnet < 1.2 has a bug when sending IPv6 option headers
        * we can only use this type of probe if we have at least libnet 1.2 or above
        */
-      send_icmp6_echo_opt(&e->ip, &an, IP6_DSTOPT_UNKN, sizeof(IP6_DSTOPT_UNKN));
+      send_L2_icmp6_echo_opt(&e->ip, &an,
+            IP6_DSTOPT_UNKN, sizeof(IP6_DSTOPT_UNKN), LLA_IP6_ALLNODES_MULTICAST);
 #endif
    }
 
@@ -519,6 +520,7 @@ static void scan_targets(void)
 #ifdef WITH_IPV6
    struct ip_addr ip;
    struct ip_addr sn;
+   u_int8 tmac[MEDIA_ADDR_LEN];
 #endif
 
    DEBUG_MSG("scan_targets: merging targets...");
@@ -615,8 +617,8 @@ static void scan_targets(void)
 #ifdef WITH_IPV6
          case AF_INET6:
             if (ip_addr_is_local(&e->ip, &ip) == E_SUCCESS) {
-               ip_addr_init_sol(&sn, &e->ip);
-               send_icmp6_nsol(&ip, &sn, &e->ip, GBL_IFACE->mac);
+               ip_addr_init_sol(&sn, &e->ip, tmac);
+               send_L2_icmp6_nsol(&ip, &sn, &e->ip, GBL_IFACE->mac, tmac);
             }
             break;
 #endif

--- a/src/ec_sslwrap.c
+++ b/src/ec_sslwrap.c
@@ -397,59 +397,79 @@ static int sslw_insert_redirect(u_int16 sport, u_int16 dport)
 {
    char asc_sport[16];
    char asc_dport[16];
-   int ret_val = 0;
+   int i, ret_val = 0;
    char *command;
-   char *param[4];
+   char *param[4], *commands[2] = {NULL, NULL};
  
    /* the script is not defined */
    if (GBL_CONF->redir_command_on == NULL)
    {
-      USER_MSG("SSLStrip: cannot setup the redirect, did you uncomment the redir_command_on command on your etter.conf file?\n");
+      USER_MSG("sslwrap: cannot setup the redirect, did you uncomment the redir_command_on command on your etter.conf file?\n");
       return -E_FATAL;
    }
+   else  {
+      commands[0] = strdup(GBL_CONF->redir_command_on);
+   }
+
+#ifdef WITH_IPV6
+   /* IPv6 redirect script is optional */
+   if (GBL_CONF->redir6_command_on == NULL)
+   {
+      WARN_MSG("sslwrap: cannot setup the redirect for IPv6, did you uncomment the redir6_command_on command on your etter.conf file?\n");
+   }
+   else {
+      commands[1] = strdup(GBL_CONF->redir6_command_on);
+   }
+#endif
+
    snprintf(asc_sport, 16, "%u", sport);
    snprintf(asc_dport, 16, "%u", dport);
 
-   /* make the substitutions in the script */
-   command = strdup(GBL_CONF->redir_command_on);
-   str_replace(&command, "%iface", GBL_OPTIONS->iface);
-   str_replace(&command, "%port", asc_sport);
-   str_replace(&command, "%rport", asc_dport);
+   for (i = 0; i < 2 && commands[i] != NULL; i++) {
+      command = commands[i];
+
+      /* make the substitutions in the script */
+      str_replace(&command, "%iface", GBL_OPTIONS->iface);
+      str_replace(&command, "%port", asc_sport);
+      str_replace(&command, "%rport", asc_dport);
 
 #if defined(OS_DARWIN) || defined(OS_BSD)
-   str_replace(&command, "%set", SSLW_SET);
+      str_replace(&command, "%set", SSLW_SET);
 #endif
-   
-   DEBUG_MSG("sslw_insert_redirect: [%s]", command);
-   
-   /* construct the params array for execvp */
-   param[0] = "sh";
-   param[1] = "-c";
-   param[2] = command;
-   param[3] = NULL;
-               
-   /* execute the script */ 
-   switch (fork()) {
-      case 0:
-         regain_privs();
-         execvp(param[0], param);
-         drop_privs();
-         WARN_MSG("Cannot setup http redirect (command: %s), please edit your etter.conf file and put a valid value in redir_command_on field\n", param[0]);
-         SAFE_FREE(command);
-         _exit(-E_INVALID);
-      case -1:
-         SAFE_FREE(command);
-         return -E_INVALID;
-      default:
-         wait(&ret_val);
-         if (WIFEXITED(ret_val) && WEXITSTATUS(ret_val)) {
-            USER_MSG("sslwrap: redir_command_on had non-zero exit status (%d): [%s]\n", WEXITSTATUS(ret_val), command);
+
+      DEBUG_MSG("sslw_insert_redirect: [%s]", command);
+
+      /* construct the params array for execvp */
+      param[0] = "sh";
+      param[1] = "-c";
+      param[2] = command;
+      param[3] = NULL;
+
+      /* execute the script */
+      switch (fork()) {
+         case 0:
+            regain_privs();
+            execvp(param[0], param);
+            drop_privs();
+            WARN_MSG("Cannot setup http redirect (command: %s), please edit your etter.conf file and put a valid value in redir_command_on field\n", param[0]);
+            SAFE_FREE(command);
+            _exit(-E_INVALID);
+         case -1:
             SAFE_FREE(command);
             return -E_INVALID;
-         }
-   }    
-   
-   SAFE_FREE(command);
+         default:
+            wait(&ret_val);
+            if (WIFEXITED(ret_val) && WEXITSTATUS(ret_val)) {
+               DEBUG_MSG("sslw_insert_redirect: child exited with non-zero return code: %d",
+                     WEXITSTATUS(ret_val));
+               USER_MSG("sslwrap: redir_command_on had non-zero exit status (%d): [%s]\n", WEXITSTATUS(ret_val), command);
+               SAFE_FREE(command);
+               return -E_INVALID;
+            }
+      }
+
+      SAFE_FREE(command);
+   }
    return E_SUCCESS;
 }
 
@@ -460,57 +480,75 @@ static int sslw_remove_redirect(u_int16 sport, u_int16 dport)
 {
    char asc_sport[16];
    char asc_dport[16];
-   int ret_val = 0;
+   int i, ret_val = 0;
    char *command;
-   char *param[4];
- 
+   char *param[4], *commands[2] = {NULL, NULL};
+
    /* the script is not defined */
    if (GBL_CONF->redir_command_off == NULL)
    {
-      USER_MSG("SSLStrip: cannot remove the redirect, did you uncomment the redir_command_off command on your etter.conf file?");
+      USER_MSG("sslwrap: cannot remove the redirect, did you uncomment the redir_command_off command on your etter.conf file?");
       return -E_FATAL;
    }
+   else {
+      commands[0] = strdup(GBL_CONF->redir_command_off);
+   }
+
+#ifdef WITH_IPV6
+   /* the script for IPv6 is optional */
+   if (GBL_CONF->redir6_command_off == NULL)
+   {
+      WARN_MSG("sslwrap: cannot remove the redirect for IPv6, did you uncommend the redir6_command_off command in your etter.conf file?");
+   }
+   else {
+      commands[1] = strdup(GBL_CONF->redir6_command_off);
+   }
+#endif
 
    snprintf(asc_sport, 16, "%u", sport);
    snprintf(asc_dport, 16, "%u", dport);
 
    /* make the substitutions in the script */
-   command = strdup(GBL_CONF->redir_command_off);
-   str_replace(&command, "%iface", GBL_OPTIONS->iface);
-   str_replace(&command, "%port", asc_sport);
-   str_replace(&command, "%rport", asc_dport);
+   for (i = 0; i < 2 && commands[i] != NULL; i++) {
+
+      command = commands[i];
+
+      str_replace(&command, "%iface", GBL_OPTIONS->iface);
+      str_replace(&command, "%port", asc_sport);
+      str_replace(&command, "%rport", asc_dport);
 
 #if defined(OS_DARWIN) || defined(OS_BSD)
-   str_replace(&command, "%set", SSLW_SET);
+      str_replace(&command, "%set", SSLW_SET);
 #endif
-   
-   DEBUG_MSG("sslw_remove_redirect: [%s]", command);
-   
-   /* construct the params array for execvp */
-   param[0] = "sh";
-   param[1] = "-c";
-   param[2] = command;
-   param[3] = NULL;
 
-   /* execute the script */ 
-   switch (fork()) {
-      case 0:
-         regain_privs();
-         execvp(param[0], param);
-         drop_privs();
-         WARN_MSG("Cannot remove http redirect (command: %s), please edit your etter.conf file and put a valid value in redir_command_on field\n", param[0]);
-         SAFE_FREE(command);
-         _exit(-E_INVALID);
-      case -1:
-         SAFE_FREE(command);
-         return -E_INVALID;
-      default:
-         wait(&ret_val);
-         SAFE_FREE(command);
-         if (ret_val == -E_INVALID)
+      DEBUG_MSG("sslw_remove_redirect: [%s]", command);
+
+      /* construct the params array for execvp */
+      param[0] = "sh";
+      param[1] = "-c";
+      param[2] = command;
+      param[3] = NULL;
+
+      /* execute the script */
+      switch (fork()) {
+         case 0:
+            regain_privs();
+            execvp(param[0], param);
+            drop_privs();
+            WARN_MSG("Cannot remove http redirect (command: %s), please edit your etter.conf file and put a valid value in redir_command_on field\n", param[0]);
+            SAFE_FREE(command);
+            _exit(-E_INVALID);
+         case -1:
+            SAFE_FREE(command);
             return -E_INVALID;
-   }    
-   
+         default:
+            wait(&ret_val);
+            SAFE_FREE(command);
+            if (ret_val == -E_INVALID)
+               return -E_INVALID;
+      }
+   }
+
    return E_SUCCESS;
 }
 

--- a/src/ec_sslwrap.c
+++ b/src/ec_sslwrap.c
@@ -107,8 +107,8 @@ struct sslw_ident {
 };
 #define SSLW_IDENT_LEN sizeof(struct sslw_ident)
 
-#define SSLW_RETRY 5
-#define SSLW_WAIT 10 /* 10 seconds */
+#define SSLW_RETRY 500
+#define SSLW_WAIT 10 /* 10 milliseconds */
 
 #if defined(OS_DARWIN) || defined(OS_BSD)
 #define SSLW_SET "20"
@@ -789,7 +789,7 @@ static int sslw_get_peer(struct accepted_entry *ae)
     * which creates the session, may be slower than this
     */
    for (i=0; i<SSLW_RETRY && session_get_and_del(&s, ident, SSLW_IDENT_LEN)!=E_SUCCESS; i++)
-      ec_usleep(SEC2MICRO(SSLW_WAIT));
+      ec_usleep(MILLI2MICRO(SSLW_WAIT));
 
    if (i==SSLW_RETRY) {
       SAFE_FREE(ident);

--- a/src/mitm/ec_ip6nd_poison.c
+++ b/src/mitm/ec_ip6nd_poison.c
@@ -197,8 +197,10 @@ EC_THREAD_FUNC(ndp_poisoner)
       }
 
       /* first warm up then release poison frequency */
-      if (i < 5) 
+      if (i < 5) {
+         i++;
          ec_usleep(SEC2MICRO(GBL_CONF->ndp_poison_warm_up));
+      }
       else 
          ec_usleep(SEC2MICRO(GBL_CONF->ndp_poison_delay));
 

--- a/src/mitm/ec_ip6nd_poison.c
+++ b/src/mitm/ec_ip6nd_poison.c
@@ -182,15 +182,15 @@ EC_THREAD_FUNC(ndp_poisoner)
              * entry in the victims cache
              */
            if (i == 1 && GBL_CONF->ndp_poison_icmp) {
-              send_icmp6_echo(&t2->ip, &t1->ip);
+              send_L2_icmp6_echo(&t2->ip, &t1->ip, t1->mac);
               /* from T2 to T1 */
               if (!(flags & ND_ONEWAY)) 
-                 send_icmp6_echo(&t1->ip, &t2->ip);
+                 send_L2_icmp6_echo(&t1->ip, &t2->ip, t2->mac);
            } 
 
-            send_icmp6_nadv(&t1->ip, &t2->ip, GBL_IFACE->mac, flags);
+            send_L2_icmp6_nadv(&t1->ip, &t2->ip, GBL_IFACE->mac, flags, t2->mac);
             if(!(flags & ND_ONEWAY))
-               send_icmp6_nadv(&t2->ip, &t1->ip, GBL_IFACE->mac, flags & ND_ROUTER);
+               send_L2_icmp6_nadv(&t2->ip, &t1->ip, GBL_IFACE->mac, flags & ND_ROUTER, t1->mac);
 
             ec_usleep(GBL_CONF->ndp_poison_send_delay);
          }
@@ -390,9 +390,9 @@ static void ndp_antidote(void)
                   continue;
 
             /* send neighbor advertisements with the correct information */
-            send_icmp6_nadv(&h1->ip, &h2->ip, h1->mac, flags);
+            send_L2_icmp6_nadv(&h1->ip, &h2->ip, h1->mac, flags, h2->mac);
             if(!(flags & ND_ONEWAY))
-               send_icmp6_nadv(&h2->ip, &h1->ip, h2->mac, flags & ND_ROUTER);
+               send_L2_icmp6_nadv(&h2->ip, &h1->ip, h2->mac, flags & ND_ROUTER, h1->mac);
 
             ec_usleep(GBL_CONF->ndp_poison_send_delay);
          }


### PR DESCRIPTION
This pull request mainly adds IPv6 support for SSL interception. As a consequence **poll()** syscalls is being substituted by **select()**.
It also fixes a number of smaller issues
 * IPv6 Scan on FreeBSD aborts with a FATAL_ERROR
 * Content-Length issue in sslstrip plugin
 * 10 seconds delay with SSL interception on non-Linux
 * infinite ping in NDP poisoner
 * improve LIBNET version determination

and some cosmetic things
 * align whitespaces in *ec_sslwrap.c* and *sslstrip.c*
 * make pattern matching code in *sslstrip.c* easier to understand by speaking offset names and additonal comments