### PR TITLE
DNS TTL customizability for dns_spoof plugin

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -58,6 +58,10 @@ CONTRIBUTORS:
    Eric Milam (Brav0Hax) <jbrav.hax@gmail.com> {
        User Testing
    }
+   
+   Frekky {
+       dns_spoof plugin TTL option
+   }
 
 
 CONTRIBUTORS (Lazarus):

--- a/man/ettercap_plugins.8.in
+++ b/man/ettercap_plugins.8.in
@@ -82,13 +82,18 @@ is not started yet. You have to launch it from the proper menu.
 .TP
 .B dns_spoof
 .Sp
-This plugin intercepts DNS query and reply with a spoofed answer. You can chose
-to which address the plugin has to reply by modifying the etter.dns file. The
-plugin intercepts A, AAAA, PTR, MX, WINS, SRV and TXT request. If it was an A
-request, the name is searched in the file and the IP address is returned
-(you can use wildcards in the name).
+This plugin intercepts DNS query and reply with a spoofed answer. You can choose
+to which addresses the plugin has to reply, and the expiry time in seconds (TTL)
+by modifying the etter.dns file. The plugin intercepts A, AAAA, PTR, MX, WINS,
+SRV and TXT request. If it was an A request, the name is searched in the file
+and the IP address is returned (you can use wildcards in the name).
 .br
 The same applies if it was a AAAA request.
+.Sp
+TTL is an optional field which is specified as the last option in an entry in
+the etter.dns file. The TTL is specified in a number of seconds from 0 to 2^31-1
+(see RFC 2181). TTL is specified on a per-host basis. If the TTL is not specified
+for a particular host, the default value is 3600 seconds (1 hour).
 .Sp
 If it was a PTR request, the IP address is searched in the file and the name is
 returned (except for those name containing a wildcard). For PTR requests, IPv4
@@ -132,7 +137,9 @@ file called etter.mdns. Due to the nature of mDNS, the plugin intercepts only A,
 AAAA, PTR and SRV requests.
 .Sp
 The way the mdns_spoof plugin interprets the etter.mdns file and the rules that
-apply are the same as with the dns_spoof plugin.
+apply are the same as with the dns_spoof plugin, although currently the
+mdns_spoof plugin lacks support for custom TTL. The TTL for all spoofed mDNS
+replies is 3600 seconds (1 hour).
 
 
 .TP

--- a/plug-ins/dns_spoof/dns_spoof.c
+++ b/plug-ins/dns_spoof/dns_spoof.c
@@ -521,13 +521,13 @@ static int prepare_dns_reply(u_char *data, const char *name, int type, int *dns_
    struct rr_entry *rr;
    bool is_negative;
    int len;
-   u_int32 ttl, ttl_bige;
+   u_int32 ttl, dns_ttl;
    u_char *answer, *p;
    char tmp[MAX_ASCII_ADDR_LEN];
 
    /* set TTL to 1 hour by default or in case something goes wrong */
    ttl = 3600;
-   ttl_bige = 0x10e00000; /* big endian for network stuff */
+   dns_ttl = htonl(ttl); /* big endian for network stuff */
 
    /* by default we want to spoof actual data */
    is_negative = false;
@@ -570,13 +570,13 @@ static int prepare_dns_reply(u_char *data, const char *name, int type, int *dns_
          p = answer;
 
          /* make TTL big-endian to work with DNS */
-         ttl_bige = htonl(ttl);
+         dns_ttl = htonl(ttl);
 
          /* prepare the answer */
          memcpy(p, "\xc0\x0c", 2);                        /* compressed name offset */
          memcpy(p + 2, "\x00\x01", 2);                    /* type A */
          memcpy(p + 4, "\x00\x01", 2);                    /* class */
-         memcpy(p + 6, &ttl_bige, 4);                     /* TTL */
+         memcpy(p + 6, &dns_ttl, 4);                     /* TTL */
          memcpy(p + 10, "\x00\x04", 2);                   /* datalen */
          ip_addr_cpy(p + 12, reply);                      /* data */
 
@@ -633,13 +633,13 @@ any_aaaa:
          p = answer;
 
          /* make TTL big-endian to work with DNS */
-         ttl_bige = htonl(ttl);
+         dns_ttl = htonl(ttl);
 
          /* prepare the answer */
          memcpy(p, "\xc0\x0c", 2);         /* compressed name offset */
          memcpy(p + 2, "\x00\x1c", 2);         /* type AAAA */
          memcpy(p + 4, "\x00\x01", 2);         /* class IN */
-         memcpy(p + 6, &ttl_bige, 4);          /* TTL */
+         memcpy(p + 6, &dns_ttl, 4);          /* TTL */
          memcpy(p + 10, "\x00\x10", 2);        /* datalen */
          ip_addr_cpy(p + 12, reply);           /* data */
 
@@ -676,13 +676,13 @@ any_mx:
       p = answer;
 
       /* make TTL big-endian to work with DNS */
-      ttl_bige = htonl(ttl);
+      dns_ttl = htonl(ttl);
 
       /* prepare the answer */
       memcpy(p, "\xc0\x0c", 2);                          /* compressed name offset */
       memcpy(p + 2, "\x00\x0f", 2);                      /* type MX */
       memcpy(p + 4, "\x00\x01", 2);                      /* class */
-      memcpy(p + 6, &ttl_bige, 4);                       /* TTL */
+      memcpy(p + 6, &dns_ttl, 4);                       /* TTL */
       memcpy(p + 10, "\x00\x09", 2);                     /* datalen */
       memcpy(p + 12, "\x00\x0a", 2);                     /* preference (highest) */
       /* 
@@ -712,7 +712,7 @@ any_mx:
          memcpy(p, "\x04mail\xc0\x0c", 7);             /* compressed name offset */
          memcpy(p + 7, "\x00\x01", 2);                 /* type A */
          memcpy(p + 9, "\x00\x01", 2);                 /* class */
-         memcpy(p + 11, &ttl, 4);                      /* TTL */
+         memcpy(p + 11, &dns_ttl, 4);                      /* TTL */
          memcpy(p + 15, "\x00\x04", 2);                /* datalen */
          ip_addr_cpy(p + 17, reply);                   /* data */
       }
@@ -728,7 +728,7 @@ any_mx:
          memcpy(p, "\x04mail\xc0\x0c", 7);            /* compressed name offset */
          memcpy(p + 7, "\x00\x1c", 2);                /* type AAAA */
          memcpy(p + 9, "\x00\x01", 2);                /* class */
-         memcpy(p + 11, &ttl, 4);                     /* TTL */
+         memcpy(p + 11, &dns_ttl, 4);                     /* TTL */
          memcpy(p + 15, "\x00\x10", 2);               /* datalen */
          ip_addr_cpy(p + 17, reply);                  /* data */
       }
@@ -776,13 +776,13 @@ any_wins:
       p = answer;
 
       /* make TTL big-endian to work with DNS */
-      ttl_bige = htonl(ttl);
+      dns_ttl = htonl(ttl);
 
       /* prepare the answer */
       memcpy(p, "\xc0\x0c", 2);                        /* compressed name offset */
       memcpy(p + 2, "\xff\x01", 2);                    /* type WINS */
       memcpy(p + 4, "\x00\x01", 2);                    /* class IN */
-      memcpy(p + 6, &ttl_bige, 4);                     /* TTL */
+      memcpy(p + 6, &dns_ttl, 4);                     /* TTL */
       memcpy(p + 10, "\x00\x04", 2);                   /* datalen */
       ip_addr_cpy((u_char*)p + 12, reply);             /* data */
 
@@ -825,13 +825,13 @@ any_txt:
       p = answer;
 
       /* make TTL big-endian to work with DNS */
-      ttl_bige = htonl(ttl);
+      dns_ttl = htonl(ttl);
 
       /* prepare the answer */
       memcpy(p,     "\xc0\x0c", 2);         /* compressed name offset */
       memcpy(p + 2, "\x00\x10", 2);         /* type TXT */
       memcpy(p + 4, "\x00\x01", 2);         /* class IN */
-      memcpy(p + 6, &ttl_bige, 4);          /* TTL */
+      memcpy(p + 6, &dns_ttl, 4);          /* TTL */
       memcpy(p + 10, &datalen, 2);          /* data len */
       memcpy(p + 12, &txtlen, 1);           /* TXT len */
       memcpy(p + 13, txt, txtlen);          /* string */
@@ -869,13 +869,13 @@ any_txt:
       p = answer;
 
       /* make TTL big-endian to work with DNS */
-      ttl_bige = htonl(ttl);
+      dns_ttl = htonl(ttl);
 
       /* prepare the answer */
       memcpy(p, "\xc0\x0c", 2);                        /* compressed name offset */
       memcpy(p + 2, "\x00\x0c", 2);                    /* type PTR */
       memcpy(p + 4, "\x00\x01", 2);                    /* class */
-      memcpy(p + 6, &ttl_bige, 4);                     /* TTL */
+      memcpy(p + 6, &dns_ttl, 4);                     /* TTL */
       /* put the length before the dn_comp'd string */
       p += 10;
       NS_PUT16(rlen, p);
@@ -928,13 +928,13 @@ any_txt:
       tgtoffset[1] = 12 + dn_offset; /* offset to the actual domain name */
 
       /* make TTL big-endian to work with DNS */
-      ttl_bige = htonl(ttl);
+      dns_ttl = htonl(ttl);
 
       /* prepare the answer */
       memcpy(p, "\xc0\x0c", 2);                    /* compressed name offset */
       memcpy(p + 2, "\x00\x21", 2);                /* type SRV */
       memcpy(p + 4, "\x00\x01", 2);                /* class IN */
-      memcpy(p + 6, &ttl_bige, 4);                 /* TTL */
+      memcpy(p + 6, &dns_ttl, 4);                 /* TTL */
       memcpy(p + 10, "\x00\x0c", 2);               /* data length */
       memcpy(p + 12, "\x00\x00", 2);               /* priority */
       memcpy(p + 14, "\x00\x00", 2);               /* weight */
@@ -970,7 +970,7 @@ any_txt:
          memcpy(p + 4, tgtoffset, 2);             /* compressed name offset */
          memcpy(p + 6, "\x00\x01", 2);            /* type A */
          memcpy(p + 8, "\x00\x01", 2);            /* class */
-         memcpy(p + 10, &ttl_bige, 4);            /* TTL */
+         memcpy(p + 10, &dns_ttl, 4);            /* TTL */
          memcpy(p + 14, "\x00\x04", 2);           /* datalen */
          ip_addr_cpy(p + 16, reply);              /* data */
       }
@@ -986,7 +986,7 @@ any_txt:
          memcpy(p + 4, tgtoffset, 2);             /* compressed name offset */
          memcpy(p + 6, "\x00\x1c", 2);            /* type AAAA */
          memcpy(p + 8, "\x00\x01", 2);            /* class */
-         memcpy(p + 10, &ttl_bige, 4);            /* TTL */
+         memcpy(p + 10, &dns_ttl, 4);            /* TTL */
          memcpy(p + 14, "\x00\x10", 2);           /* datalen */
          ip_addr_cpy(p + 16, reply);              /* data */
       }
@@ -1015,13 +1015,13 @@ any_txt:
       p = answer;
 
       /* make TTL big-endian to work with DNS */
-      ttl_bige = htonl(ttl);
+      dns_ttl = htonl(ttl);
 
       /* prepare the authorative record */
       memcpy(p, "\xc0\x0c", 2);                        /* compressed name offset */
       memcpy(p + 2, "\x00\x06", 2);                    /* type SOA */
       memcpy(p + 4, "\x00\x01", 2);                    /* class */
-      memcpy(p + 6, &ttl_bige, 4);                     /* TTL (seconds) */
+      memcpy(p + 6, &dns_ttl, 4);                     /* TTL (seconds) */
       memcpy(p + 10, "\x00\x22", 2);                   /* datalen */
       memcpy(p + 12, "\x03ns1", 4);                    /* primary server */
       memcpy(p + 16, "\xc0\x0c", 2);                   /* compressed name offeset */   

--- a/plug-ins/dns_spoof/dns_spoof.c
+++ b/plug-ins/dns_spoof/dns_spoof.c
@@ -1082,6 +1082,7 @@ static int get_spoofed_aaaa(const char *a, struct ip_addr **ip, u_int32 *ttl)
         if (d->type == ns_t_aaaa && match_pattern(a, d->name)) {
             /* return the pointer to the struct */
             *ip = &d->ip;
+            *ttl = d->ttl;
 
             return E_SUCCESS;
         }

--- a/share/etter.dns
+++ b/share/etter.dns
@@ -14,40 +14,42 @@
 # Sample hosts file for dns_spoof plugin                                   #
 #                                                                          #
 # the format is (for A query):                                             #
-#   www.myhostname.com A 168.11.22.33                                      #
-#   *.foo.com          A 168.44.55.66                                      #
+#   www.myhostname.com A 168.11.22.33 3600                                 #
+#   *.foo.com          A 168.44.55.66 [optional TTL]                       #
 #                                                                          #
 # ... for a AAAA query (same hostname allowed):                            #
 #   www.myhostname.com AAAA 2001:db8::1                                    #
-#   *.foo.com          AAAA 2001:db8::2                                    #
+#   *.foo.com          AAAA 2001:db8::2 [optional TTL]                     #
 #                                                                          #
 # or to skip a protocol family (useful with dual-stack):                   #
 #   www.hotmail.com    AAAA ::                                             #
 #   www.yahoo.com      A    0.0.0.0                                        #
 #                                                                          #
 # or for PTR query:                                                        #
-#   www.bar.com    PTR 10.0.0.10                                           #
-#   www.google.com PTR ::1                                                 #
+#   www.bar.com    PTR 10.0.0.10 [TTL]                                     #
+#   www.google.com PTR ::1 [TTL]                                           #
 #                                                                          #
 # or for MX query (either IPv4 or IPv6):                                   #
-#    domain.com MX xxx.xxx.xxx.xxx                                         #
+#    domain.com MX xxx.xxx.xxx.xxx [TTL]                                   #
 #    domain2.com MX xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx                #
 #    domain3.com MX xxxx:xxxx::y                                           #
 #                                                                          #
 # or for WINS query:                                                       #
-#    workgroup WINS 127.0.0.1                                              #
+#    workgroup WINS 127.0.0.1 [TTL]                                        #
 #    PC*       WINS 127.0.0.1                                              #
 #                                                                          #
 # or for SRV query (either IPv4 or IPv6):                                  #
-#    service._tcp|_udp.domain SRV 192.168.1.10:port                        #
+#    service._tcp|_udp.domain SRV 192.168.1.10:port [TTL]                  #
 #    service._tcp|_udp.domain SRV [2001:db8::3]:port                       #
 #                                                                          #
 # or for TXT query (value must be wrapped in double quotes):               #
-#    google.com TXT "v=spf1 ip4:192.168.0.3/32 ~all"                       #
+#    google.com TXT "v=spf1 ip4:192.168.0.3/32 ~all" [TTL]                 #
 #                                                                          #
 # NOTE: the wildcarded hosts can't be used to poison the PTR requests      #
 #       so if you want to reverse poison you have to specify a plain       #
 #       host. (look at the www.microsoft.com example)                      #
+#                                                                          #
+# NOTE: Default DNS TTL is 3600s (1 hour). All TTL fields are optional.    #
 #                                                                          #
 ############################################################################
 
@@ -56,17 +58,17 @@
 # redirect it to www.linux.org
 #
 
-microsoft.com      A   107.170.40.56
-*.microsoft.com    A   107.170.40.56
+microsoft.com      A   107.170.40.56 1800
+*.microsoft.com    A   107.170.40.56 3600
 www.microsoft.com  PTR 107.170.40.56      # Wildcards in PTR are not allowed
 
 ##########################################
 # no one out there can have our domains...
 #
 
-www.alor.org  A 127.0.0.1
-www.naga.org  A 127.0.0.1
-www.naga.org  AAAA 2001:db8::2
+www.alor.org  A 127.0.0.1 2147483647         # It shall last forever!
+www.naga.org  A 127.0.0.1 30                 # Or only 30 seconds
+www.naga.org  AAAA 2001:db8::2               # Default is 3600 seconds (1 hour)
 
 ##########################################
 # dual stack enabled hosts does not make life easy
@@ -114,6 +116,5 @@ ldap._udp.mynet.com SRV [2001:db8:c001:beef::1]:389
 #
 
 naga.org TXT "v=spf1 ip4:192.168.1.2 ip6:2001:db8:d0b1:beef::2 -all"
-
 
 # vim:ts=8:noexpandtab


### PR DESCRIPTION
This adds an option to all entries in etter.dns which allows the spoofed DNS record's TTL/expiry time to be set to any arbitrary value within the DNS spec (see RFC 2181 for details).

This has been tested locally using a few different record types, although it's entirely possible I omitted something.

If TTL field isn't specified in the etter.dns file, it should default to 3600 for that entry.