### PR TITLE
flush max messages per interval in text interface

### DIFF
--- a/plug-ins/CMakeLists.txt
+++ b/plug-ins/CMakeLists.txt
@@ -50,7 +50,8 @@ search_promisc
 smb_clear
 smb_down
 smurf_attack
-stp_mangler)
+stp_mangler
+umsg_test)
 
 foreach(plugin ${PLUGINS})
 	add_library(${plugin} MODULE ${plugin}/${plugin}.c)

--- a/plug-ins/umsg_test/umsg_test.c
+++ b/plug-ins/umsg_test/umsg_test.c
@@ -1,0 +1,79 @@
+#include <ec.h>                        /* required for global variables */
+#include <ec_plugins.h>                /* required for plugin ops */
+#include <ec_hook.h>
+
+#include <stdlib.h>
+#include <string.h>
+
+
+int plugin_load(void *);
+
+static int umsg_test_init(void *);
+static int umsg_test_fini(void *);
+void umsg_test_fn(struct packet_object *po);
+
+
+struct plugin_ops umsg_test_ops = { 
+   .ettercap_version =  EC_VERSION,                        
+   .name =              "umsg_test",  
+   .info =              "A plugin to test a possible bug in USER_MSG",  
+   .version =           "1.0",   
+   .init =              &umsg_test_init,
+   .fini =              &umsg_test_fini,
+};
+
+/**********************************************************/
+
+/* this function is called on plugin load */
+int plugin_load(void *handle) 
+{
+   DEBUG_MSG("umsg_test plugin load function");
+   return plugin_register(handle, &umsg_test_ops);
+}
+
+/*********************************************************/
+
+static int umsg_test_init(void *umsg_test) 
+{
+
+   (void) umsg_test;
+
+   USER_MSG("UMSG_TEST: plugin running...\n");
+   hook_add(HOOK_PACKET_IP, &umsg_test_fn);
+   hook_add(HOOK_PACKET_IP6, &umsg_test_fn);
+   return PLUGIN_RUNNING;
+}
+
+
+static int umsg_test_fini(void *umsg_test) 
+{
+
+   (void) umsg_test;
+
+   hook_del(HOOK_PACKET_IP, &umsg_test_fn);
+   hook_del(HOOK_PACKET_IP6, &umsg_test_fn);
+   USER_MSG("UMSG_TEST: plugin finalization\n");
+   return PLUGIN_FINISHED;
+}
+
+void umsg_test_fn(struct packet_object *po){
+	static int count = 0;
+	u_char test[] = "here is the test string";
+	USER_MSG("received packet %d:  %p\n", count,po);
+	USER_MSG("here is another string to speed this up %d %d %d\n", count, count, count);
+	USER_MSG("here is a string with a string inside of it: %s\n",test);
+	USER_MSG("received packet %d:  %p\n", count,po);
+	USER_MSG("here is another string to speed this up %d %d %d\n", count, count, count);
+	USER_MSG("here is a string with a string inside of it: %s\n",test);
+	USER_MSG("received packet %d:  %p\n", count,po);
+	USER_MSG("here is another string to speed this up %d %d %d\n", count, count, count);
+	USER_MSG("here is a string with a string inside of it: %s\n",test);
+
+	count++;
+
+
+}
+
+
+// vim:ts=3:expandtab
+

--- a/src/ec_ui.c
+++ b/src/ec_ui.c
@@ -303,6 +303,7 @@ int ui_msg_purge_all(void)
       /* free the message */
       SAFE_FREE(msg->message);
       SAFE_FREE(msg);
+      i++;
    }
    
    UI_MSG_UNLOCK;

--- a/src/interfaces/text/ec_text.c
+++ b/src/interfaces/text/ec_text.c
@@ -378,7 +378,7 @@ void text_interface(void)
       }
 
       /* print pending USER_MSG messages */
-      ui_msg_flush(10);
+      ui_msg_flush(INT_MAX);
                                  
    }
   


### PR DESCRIPTION
This Pull Request is just to test if this addresses the issue #769. 
Text interface is the only one that pulls only a small amount of messages off the queue per cycle.
However, the referred issue is somewhat theoretic from my point of view as it contradicts the purpose of the messages pane.

So ATM I don't like to see this PR merged. More being a educated test.