### PR TITLE
Fix 774: reliable reflect spoofed DNS reply on same interface

### DIFF
--- a/include/ec_send.h
+++ b/include/ec_send.h
@@ -17,7 +17,7 @@ EC_API_EXTERN int send_L3_icmp(u_char type, struct ip_addr *sip, struct ip_addr 
 EC_API_EXTERN int send_L3_icmp_echo(struct ip_addr *src, struct ip_addr *tgt);
 EC_API_EXTERN int send_icmp_redir(u_char type, struct ip_addr *sip, struct ip_addr *gw, struct packet_object *po);
 EC_API_EXTERN int send_dhcp_reply(struct ip_addr *sip, struct ip_addr *tip, u_int8 *tmac, u_int8 *dhcp_hdr, u_int8 *options, size_t optlen);
-EC_API_EXTERN int send_dns_reply(u_int16 dport, struct ip_addr *sip, struct ip_addr *tip, u_int8 *tmac, u_int16 id, u_int8 *data, size_t datalen, u_int16 anws_rr, u_int16 auth_rr, u_int16 addi_rr);
+EC_API_EXTERN int send_dns_reply(struct iface_env *iface, u_int16 dport, struct ip_addr *sip, struct ip_addr *tip, u_int8 *tmac, u_int16 id, u_int8 *data, size_t datalen, u_int16 anws_rr, u_int16 auth_rr, u_int16 addi_rr);
 EC_API_EXTERN int send_mdns_reply(u_int16 dport, struct ip_addr *sip, struct ip_addr *tip, u_int8 *tmac, u_int16 id, u_int8 *data, size_t datalen, u_int16 anws_rr, u_int16 auth_rr, u_int16 addi_rr);
 EC_API_EXTERN int send_tcp(struct ip_addr *sip, struct ip_addr *tip, u_int16 sport, u_int16 dport, u_int32 seq, u_int32 ack, u_int8 flags, u_int8 *payload, size_t length);
 EC_API_EXTERN int send_udp(struct ip_addr *sip, struct ip_addr *tip, u_int8 *tmac, u_int16 sport, u_int16 dport, u_int8 *payload, size_t length);

--- a/include/ec_send.h
+++ b/include/ec_send.h
@@ -18,7 +18,7 @@ EC_API_EXTERN int send_L3_icmp_echo(struct ip_addr *src, struct ip_addr *tgt);
 EC_API_EXTERN int send_icmp_redir(u_char type, struct ip_addr *sip, struct ip_addr *gw, struct packet_object *po);
 EC_API_EXTERN int send_dhcp_reply(struct ip_addr *sip, struct ip_addr *tip, u_int8 *tmac, u_int8 *dhcp_hdr, u_int8 *options, size_t optlen);
 EC_API_EXTERN int send_dns_reply(struct iface_env *iface, u_int16 dport, struct ip_addr *sip, struct ip_addr *tip, u_int8 *tmac, u_int16 id, u_int8 *data, size_t datalen, u_int16 anws_rr, u_int16 auth_rr, u_int16 addi_rr);
-EC_API_EXTERN int send_mdns_reply(u_int16 dport, struct ip_addr *sip, struct ip_addr *tip, u_int8 *tmac, u_int16 id, u_int8 *data, size_t datalen, u_int16 anws_rr, u_int16 auth_rr, u_int16 addi_rr);
+EC_API_EXTERN int send_mdns_reply(struct iface_env *iface, u_int16 dport, struct ip_addr *sip, struct ip_addr *tip, u_int8 *tmac, u_int16 id, u_int8 *data, size_t datalen, u_int16 anws_rr, u_int16 auth_rr, u_int16 addi_rr);
 EC_API_EXTERN int send_tcp(struct ip_addr *sip, struct ip_addr *tip, u_int16 sport, u_int16 dport, u_int32 seq, u_int32 ack, u_int8 flags, u_int8 *payload, size_t length);
 EC_API_EXTERN int send_udp(struct ip_addr *sip, struct ip_addr *tip, u_int8 *tmac, u_int16 sport, u_int16 dport, u_int8 *payload, size_t length);
 EC_API_EXTERN int send_tcp_ether(u_int8 *dmac, struct ip_addr *sip, struct ip_addr *tip, u_int16 sport, u_int16 dport, u_int32 seq, u_int32 ack, u_int8 flags);

--- a/plug-ins/dns_spoof/dns_spoof.c
+++ b/plug-ins/dns_spoof/dns_spoof.c
@@ -391,6 +391,7 @@ static void dns_spoof(struct packet_object *po)
 {
    struct dns_header *dns;
    struct rr_entry *rr;
+   struct iface_env *iface;
    u_char *data, *end, *dns_reply;
    char name[NS_MAXDNAME];
    int name_len, dns_len, dns_off, n_answ, n_auth, n_addi;
@@ -450,6 +451,9 @@ static void dns_spoof(struct packet_object *po)
       /* Do not forward query */
       po->flags |= PO_DROPPED; 
 
+      /* set incoming interface as outgoing interface for reply */
+      iface = po->flags & PO_FROMIFACE ? GBL_IFACE : GBL_BRIDGE;
+
       /* allocate memory for the dns reply */
       SAFE_CALLOC(dns_reply, dns_len, sizeof(u_int8));
 
@@ -506,7 +510,7 @@ static void dns_spoof(struct packet_object *po)
       }
 
       /* send the reply */
-      send_dns_reply(po->L4.src, &po->L3.dst, &po->L3.src, po->L2.src,
+      send_dns_reply(iface, po->L4.src, &po->L3.dst, &po->L3.src, po->L2.src,
                   ntohs(dns->id), dns_reply, dns_len, n_answ, n_auth, n_addi);
 
       /* spoofed DNS reply sent - free memory */

--- a/src/ec_send.c
+++ b/src/ec_send.c
@@ -1138,7 +1138,7 @@ int send_mdns_reply(u_int16 dport, struct ip_addr *sip, struct ip_addr *tip, u_i
 /*
  * send a dns reply
  */
-int send_dns_reply(u_int16 dport, struct ip_addr *sip, struct ip_addr *tip, u_int8 *tmac, u_int16 id, u_int8 *data, size_t datalen, u_int16 anws_rr, u_int16 auth_rr, u_int16 addi_rr)
+int send_dns_reply(struct iface_env *iface, u_int16 dport, struct ip_addr *sip, struct ip_addr *tip, u_int8 *tmac, u_int16 id, u_int8 *data, size_t datalen, u_int16 anws_rr, u_int16 auth_rr, u_int16 addi_rr)
 {
    libnet_ptag_t t;
    int c, proto, ethertype;
@@ -1147,8 +1147,8 @@ int send_dns_reply(u_int16 dport, struct ip_addr *sip, struct ip_addr *tip, u_in
    proto = ntohs(sip->addr_type);
  
    /* if not lnet warn the developer ;) */
-   BUG_IF(GBL_IFACE->lnet == 0);
-   l = GBL_IFACE->lnet;
+   BUG_IF(iface->lnet == 0);
+   l = iface->lnet;
   
    SEND_LOCK;
 

--- a/src/ec_send.c
+++ b/src/ec_send.c
@@ -1023,7 +1023,7 @@ int send_dhcp_reply(struct ip_addr *sip, struct ip_addr *tip, u_int8 *tmac, u_in
 /*
  * send a mdns reply
  */
-int send_mdns_reply(u_int16 dport, struct ip_addr *sip, struct ip_addr *tip, u_int8 *tmac, u_int16 id, u_int8 *data, size_t datalen, u_int16 anws_rr, u_int16 auth_rr, u_int16 addi_rr)
+int send_mdns_reply(struct iface_env *iface, u_int16 dport, struct ip_addr *sip, struct ip_addr *tip, u_int8 *tmac, u_int16 id, u_int8 *data, size_t datalen, u_int16 anws_rr, u_int16 auth_rr, u_int16 addi_rr)
 {
    libnet_ptag_t t;
    int c, proto, ethertype;
@@ -1031,8 +1031,8 @@ int send_mdns_reply(u_int16 dport, struct ip_addr *sip, struct ip_addr *tip, u_i
    proto = ntohs(sip->addr_type);
 
    /* if not lnet warn the developer ;) */
-   BUG_IF(GBL_IFACE->lnet == 0);
-   l = GBL_IFACE->lnet;
+   BUG_IF(iface->lnet == 0);
+   l = iface->lnet;
   
    SEND_LOCK;
 


### PR DESCRIPTION
This pull request addresses issue #774 as the send function does not properly take the dual interface situation into account in bridged sniffing mode.