### PR TITLE
Fix further clang warnings

### DIFF
--- a/plug-ins/sslstrip/sslstrip.c
+++ b/plug-ins/sslstrip/sslstrip.c
@@ -1352,7 +1352,7 @@ static void http_parse_packet(struct http_connection *connection, int direction,
 
    switch(ip_addr_is_local(&PACKET->L3.src, NULL)) {
       case E_SUCCESS:
-         PACKET->PASSIVE.flags &= ~FP_HOST_NONLOCAL;
+         PACKET->PASSIVE.flags &= ~(FP_HOST_NONLOCAL);
          PACKET->PASSIVE.flags |= FP_HOST_LOCAL;
          break;
       case -E_NOTFOUND:

--- a/src/ec_profiles.c
+++ b/src/ec_profiles.c
@@ -648,7 +648,7 @@ void * profile_print(int mode, void *list, char **desc, size_t len)
       
       ip_addr_ntoa(&h->L3_addr, tmp);
       snprintf(*desc, len, "%c %15s   %s", (found) ? '*' : ' ', 
-            tmp, (h->hostname) ? h->hostname : "" );
+            tmp, h->hostname);
 
 #ifdef WITH_GEOIP
       /* determine current string length */

--- a/src/ec_sslwrap.c
+++ b/src/ec_sslwrap.c
@@ -267,7 +267,7 @@ EC_THREAD_FUNC(sslw_start)
    struct sockaddr_in6 *sa6;
 #endif
    u_int len = sizeof(client_ss);
-   int fd, nfds, i = 0;
+   int fd = 0, nfds = 0, i = 0;
 
    /* variable not used */
    (void) EC_THREAD_PARAM;
@@ -1005,7 +1005,7 @@ static void sslw_parse_packet(struct accepted_entry *ae, u_int32 direction, stru
    /* calculate if the dest is local or not */
    switch (ip_addr_is_local(&PACKET->L3.src, NULL)) {
       case E_SUCCESS:
-         PACKET->PASSIVE.flags &= ~FP_HOST_NONLOCAL;
+         PACKET->PASSIVE.flags &= ~(FP_HOST_NONLOCAL);
          PACKET->PASSIVE.flags |= FP_HOST_LOCAL;
          break;
       case -E_NOTFOUND:

--- a/src/interfaces/text/ec_text_profile.c
+++ b/src/interfaces/text/ec_text_profile.c
@@ -165,7 +165,7 @@ static void detail_select(void)
    
    /* go thru the list and print a profile for each host */
    TAILQ_FOREACH(h, &GBL_PROFILES, next) {
-      fprintf(stdout, "%2d) %15s   %s\n", ++i, ip_addr_ntoa(&h->L3_addr, tmp), (h->hostname) ? h->hostname : "");
+      fprintf(stdout, "%2d) %15s   %s\n", ++i, ip_addr_ntoa(&h->L3_addr, tmp), h->hostname);
    }
       
    /* there aren't any profiles */

--- a/src/protocols/ec_ip.c
+++ b/src/protocols/ec_ip.c
@@ -192,7 +192,7 @@ FUNC_DECODER(decode_ip)
    /* calculate if the dest is local or not */
    switch (ip_addr_is_local(&PACKET->L3.src, NULL)) {
       case E_SUCCESS:
-         PACKET->PASSIVE.flags &= ~FP_HOST_NONLOCAL;
+         PACKET->PASSIVE.flags &= ~(FP_HOST_NONLOCAL);
          PACKET->PASSIVE.flags |= FP_HOST_LOCAL;
          break;
       case -E_NOTFOUND:

--- a/src/protocols/ec_ip6.c
+++ b/src/protocols/ec_ip6.c
@@ -135,7 +135,7 @@ FUNC_DECODER(decode_ip6)
    /* calculate if the dest is local or not */
    switch (ip_addr_is_local(&PACKET->L3.src, NULL)) {
       case E_SUCCESS:
-         PACKET->PASSIVE.flags &= ~FP_HOST_NONLOCAL;
+         PACKET->PASSIVE.flags &= ~(FP_HOST_NONLOCAL);
          PACKET->PASSIVE.flags |= FP_HOST_LOCAL;
          break;
       case -E_NOTFOUND:

--- a/src/protocols/ec_udp.c
+++ b/src/protocols/ec_udp.c
@@ -111,7 +111,7 @@ FUNC_DECODER(decode_udp)
           *
           * if the source is the ettercap host, don't display the message 
           */
-         if (!ip_addr_is_ours(&PACKET->L3.src) == E_FOUND)
+         if (ip_addr_is_ours(&PACKET->L3.src) != E_FOUND)
             return NULL;
 #endif
          if (GBL_CONF->checksum_warning)


### PR DESCRIPTION
This PR is meant to be a continuation of #664, basically fixing flaws reported through warnings from clang compiler.

The following commits fix the following warnings:
4c5a44d :
```
/Users/m106891/dev/ettercap/src/protocols/ec_udp.c:114:14: warning: logical not is only applied to the left hand side of this
      comparison [-Wlogical-not-parentheses]
         if (!ip_addr_is_ours(&PACKET->L3.src) == E_FOUND)
             ^                                 ~~
/Users/m106891/dev/ettercap/src/protocols/ec_udp.c:114:14: note: add parentheses after the '!' to evaluate the comparison first
         if (!ip_addr_is_ours(&PACKET->L3.src) == E_FOUND)
             ^
              (                                          )
/Users/m106891/dev/ettercap/src/protocols/ec_udp.c:114:14: note: add parentheses around left hand side expression to silence this
      warning
         if (!ip_addr_is_ours(&PACKET->L3.src) == E_FOUND)
             ^
             (                                )
/Users/m106891/dev/ettercap/src/protocols/ec_udp.c:114:48: warning: comparison of constant 'E_FOUND' (128) with boolean expression
      is always false [-Wtautological-constant-out-of-range-compare]
         if (!ip_addr_is_ours(&PACKET->L3.src) == E_FOUND)
             ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^  ~~~~~~~
2 warnings generated.
```

b26bd4d:
```
/Users/m106891/dev/ettercap/plug-ins/sslstrip/sslstrip.c:1355:36: warning: shifting a negative signed value is undefined
      [-Wshift-negative-value]
         PACKET->PASSIVE.flags &= ~FP_HOST_NONLOCAL;
                                  ~^~~~~~~~~~~~~~~~
/Users/m106891/dev/ettercap/include/ec_fingerprint.h:61:35: note: expanded from macro 'FP_HOST_NONLOCAL'
      #define FP_HOST_NONLOCAL   1<<1
                                  ^
1 warning generated.
```
and
```
/Users/m106891/dev/ettercap/src/ec_sslwrap.c:289:15: warning: variable 'nfds' is uninitialized when used here [-Wuninitialized]
      poll_fd[nfds].fd = le->fd;
              ^~~~
/Users/m106891/dev/ettercap/src/ec_sslwrap.c:270:16: note: initialize the variable 'nfds' to silence this warning
   int fd, nfds, i = 0;
               ^
```

a803f6a
```
/Users/m106891/dev/ettercap/src/interfaces/text/ec_text_profile.c:168:84: warning: address of array 'h->hostname' will always
      evaluate to 'true' [-Wpointer-bool-conversion]
      fprintf(stdout, "%2d) %15s   %s\n", ++i, ip_addr_ntoa(&h->L3_addr, tmp), (h->hostname) ? h->hostname : "");
                                                                                ~~~^~~~~~~~  ~
1 warning generated.
```


ff0994b :
```
/Users/m106891/dev/ettercap/src/dissectors/ec_ssh.c:467:74: warning: incompatible integer to pointer conversion passing 'u_int32'
      (aka 'unsigned int') to parameter of type 'RSA *' (aka 'struct rsa_st *') [-Wint-conversion]
                  (*index_ssl)->myserverkey = (RSA *)RSA_generate_key_ex(server_mod, server_exp, NULL, NULL);
                                                                         ^~~~~~~~~~
/usr/local/opt/openssl/include/openssl/rsa.h:331:30: note: passing argument to parameter 'rsa' here
int RSA_generate_key_ex(RSA *rsa, int bits, BIGNUM *e, BN_GENCB *cb);
                             ^
/Users/m106891/dev/ettercap/src/dissectors/ec_ssh.c:467:47: warning: cast to 'RSA *' (aka 'struct rsa_st *') from smaller integer
      type 'int' [-Wint-to-pointer-cast]
                  (*index_ssl)->myserverkey = (RSA *)RSA_generate_key_ex(server_mod, server_exp, NULL, NULL);
                                              ^
2 warnings generated.
```

The PR has been developed on FreeBSD, tested and tuned on MacOSX and also tested on Linux of course.

Additionally I've raised issue 2552 on _openssl_ repository since the man page for the `RSA_generate_key_ex()` function wasn't complete which had a effect for this PR.