### PR TITLE
Fix #792 and #789

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,7 @@ if(NOT DISABLE_RPATH)
   set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
   set(CMAKE_MACOSX_RPATH 1)
 endif(NOT DISABLE_RPATH)
-set(CMAKE_C_FLAGS_DEBUG "-O0 -ggdb3 -DDEBUG -Wall -Wno-pointer-sign -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Wextra -Wredundant-decls" CACHE STRING "" FORCE)
+set(CMAKE_C_FLAGS_DEBUG "-O0 -ggdb3 -DDEBUG -Wall -Wno-pointer-sign -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Wextra -Wredundant-decls -fsanitize=address -fno-omit-frame-pointer" CACHE STRING "" FORCE)
 set(CMAKE_C_FLAGS_RELEASE "-O2 -w -D_FORTIFY_SOURCE=2" CACHE STRING "" FORCE)
 
 if(OS_DARWIN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,7 +126,27 @@ if(NOT DISABLE_RPATH)
   set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
   set(CMAKE_MACOSX_RPATH 1)
 endif(NOT DISABLE_RPATH)
-set(CMAKE_C_FLAGS_DEBUG "-O0 -ggdb3 -DDEBUG -Wall -Wno-pointer-sign -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Wextra -Wredundant-decls -fsanitize=address -fno-omit-frame-pointer" CACHE STRING "" FORCE)
+
+# set general build flags for debug build-type
+set(CMAKE_C_FLAGS_DEBUG "-O0 -ggdb3 -DDEBUG -Wall -Wno-pointer-sign -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Wextra -Wredundant-decls" CACHE STRING "" FORCE)
+# append ASAN build flags if compiler version has support
+if ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+   if (CMAKE_C_COMPILER_VERSION VERSION_GREATER 4.8)
+      set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer" CACHE STRING "" FORCE)
+      message("Building with ASAN support (GNU compiler)")
+   else (CMAKE_C_COMPILER_VERSION VERSION_GREATER 4.8)
+      message("Building without ASAN support (GNU compiler)")
+   endif (CMAKE_C_COMPILER_VERSION VERSION_GREATER 4.8)
+elseif ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
+   if (CMAKE_C_COMPILER_VERSION VERSION_GREATER 3.1)
+      set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address -fno-omit-frame-pointer" CACHE STRING "" FORCE)
+      message("Building with ASAN support (Clang compiler)")
+   elseif (CMAKE_C_COMPILER_VERSION VERSION_GREATER 3.1)
+      message("Building without ASAN support (Clang compiler)")
+   endif (CMAKE_C_COMPILER_VERSION VERSION_GREATER 3.1)
+endif ("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
+
+# set build flags for release build-type
 set(CMAKE_C_FLAGS_RELEASE "-O2 -w -D_FORTIFY_SOURCE=2" CACHE STRING "" FORCE)
 
 if(OS_DARWIN)

--- a/include/ec_strings.h
+++ b/include/ec_strings.h
@@ -43,7 +43,7 @@
 
 EC_API_EXTERN int match_pattern(const char *s, const char *pattern);
 EC_API_EXTERN int base64_decode(char *bufplain, const char *bufcoded);
-EC_API_EXTERN int strescape(char *dst, char *src);
+EC_API_EXTERN int strescape(char *dst, char *src, size_t len);
 EC_API_EXTERN int str_replace(char **text, const char *s, const char *d);   
 EC_API_EXTERN size_t strlen_utf8(const char *s);
 EC_API_EXTERN char * ec_strtok(char *s, const char *delim, char **ptrptr);

--- a/src/ec_encryption.c
+++ b/src/ec_encryption.c
@@ -218,7 +218,7 @@ int set_wep_key(char *string)
 
    if (type == 's') {
       /* escape the string and check its length */
-      if (strescape((char *)tmp_wkey, p) != (int)tmp_wkey_len)
+      if (strescape((char *)tmp_wkey, p, strlen(tmp_wkey)+1) != (int)tmp_wkey_len)
     	  SEMIFATAL_ERROR("Specified WEP key length does not match the given string");
    } else if (type == 'p') {
       /* create the key from the passphrase */

--- a/src/interfaces/curses/ec_curses_view_connections.c
+++ b/src/interfaces/curses/ec_curses_view_connections.c
@@ -614,7 +614,7 @@ static void inject_user(void)
    size_t len;
 
    /* escape the sequnces in the buffer */
-   len = strescape((char*)injectbuf, (char*)injectbuf);
+   len = strescape((char*)injectbuf, (char*)injectbuf, strlen(injectbuf)+1);
    
    /* check where to inject */
    if (wdg_c1->flags & WDG_OBJ_FOCUSED) {

--- a/src/interfaces/gtk/ec_gtk_view_connections.c
+++ b/src/interfaces/gtk/ec_gtk_view_connections.c
@@ -1627,7 +1627,7 @@ static void gtkui_inject_user(int side)
    size_t len;
     
    /* escape the sequnces in the buffer */
-   len = strescape(injectbuf, injectbuf);
+   len = strescape(injectbuf, injectbuf, strlen(injectbuf)+1);
 
    /* check where to inject */
    if (side == 1 || side == 2) {

--- a/utils/etterfilter/ef_encode.c
+++ b/utils/etterfilter/ef_encode.c
@@ -136,7 +136,8 @@ int encode_const(char *string, struct filter_op *fop)
       fop->op.test.string = (u_char*)strdup(string + 1);
          
       /* escape it in the structure */
-      fop->op.test.slen = strescape((char*)fop->op.test.string, (char*)fop->op.test.string);
+      fop->op.test.slen = strescape((char*)fop->op.test.string, 
+            (char*)fop->op.test.string, strlen(fop->op.test.string)+1);
      
       return E_SUCCESS;
       
@@ -184,7 +185,8 @@ int encode_function(char *string, struct filter_op *fop)
             fop->opcode = FOP_FUNC;
             fop->op.func.op = FFUNC_SEARCH;
             fop->op.func.string = (u_char*)strdup(dec_args[1]);
-            fop->op.func.slen = strescape((char*)fop->op.func.string, (char*)fop->op.func.string);
+            fop->op.func.slen = strescape((char*)fop->op.func.string, 
+                  (char*)fop->op.func.string, strlen(fop->op.func.string)+1);
             ret = E_SUCCESS;
          } else
             SCRIPT_ERROR("Unknown offset %s ", dec_args[0]);
@@ -202,7 +204,8 @@ int encode_function(char *string, struct filter_op *fop)
             fop->opcode = FOP_FUNC;
             fop->op.func.op = FFUNC_REGEX;
             fop->op.func.string = (u_char*)strdup(dec_args[1]);
-            fop->op.func.slen = strescape((char*)fop->op.func.string, (char*)fop->op.func.string);
+            fop->op.func.slen = strescape((char*)fop->op.func.string, 
+                  (char*)fop->op.func.string, strlen(fop->op.func.string)+1);
             ret = E_SUCCESS;
          } else
             SCRIPT_ERROR("Unknown offset %s ", dec_args[0]);
@@ -272,9 +275,11 @@ int encode_function(char *string, struct filter_op *fop)
          /* replace always operate at DATA level */
          fop->op.func.level = 5;
          fop->op.func.string = (u_char*)strdup(dec_args[0]);
-         fop->op.func.slen = strescape((char*)fop->op.func.string, (char*)fop->op.func.string);
+         fop->op.func.slen = strescape((char*)fop->op.func.string, 
+               (char*)fop->op.func.string, strlen(fop->op.func.string)+1);
          fop->op.func.replace = (u_char*)strdup(dec_args[1]);
-         fop->op.func.rlen = strescape((char*)fop->op.func.replace, (char*)fop->op.func.replace);
+         fop->op.func.rlen = strescape((char*)fop->op.func.replace, 
+               (char*)fop->op.func.replace, strlen(fop->op.func.replace)+1);
          ret = E_SUCCESS;
       } else
          SCRIPT_ERROR("Wrong number of arguments for function \"%s\" ", name);
@@ -328,7 +333,8 @@ int encode_function(char *string, struct filter_op *fop)
       if (nargs == 1) {
          fop->op.func.op = FFUNC_MSG;
          fop->op.func.string = (u_char*)strdup(dec_args[0]);
-         fop->op.func.slen = strescape((char*)fop->op.func.string, (char*)fop->op.func.string);
+         fop->op.func.slen = strescape((char*)fop->op.func.string, 
+               (char*)fop->op.func.string, strlen(fop->op.func.string)+1);
          ret = E_SUCCESS;
       } else
          SCRIPT_ERROR("Wrong number of arguments for function \"%s\" ", name);


### PR DESCRIPTION
This PR is meant to fix the heap buffer over- or underflow conditions introduced by **strescape()**.
See #789 and #792.
This resolves also CVE-2017-8366.