### PR TITLE
Fix #829 - index offset flaw

### DIFF
--- a/utils/etterfilter/ef_output.c
+++ b/utils/etterfilter/ef_output.c
@@ -76,7 +76,7 @@ int write_output(void)
    write(fd, data, fh.code - fh.data);
    
    /* write the instructions */
-   for (i = 0; i <= ninst; i++) {
+   for (i = 0; i < ninst; i++) {
       print_progress_bar(&fop[i]);
       write(fd, &fop[i], sizeof(struct filter_op));
    }


### PR DESCRIPTION
actually the reproducer works also with a filter code:
```
msg("test");
```
due to index offset comparsion flaw.
Last iteration printing the progressbar steped one `sizeof(struct filter_op)` too far.

This pull request should fix issue #829 