### PR TITLE
Remove the dependency on ghostscript when building the PDF docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ addons:
       - check
       - cmake
       - flex
-      - ghostscript
+      - groff
       - libbsd-dev
       - libcurl4-openssl-dev
       - libgtk2.0-dev
@@ -138,7 +138,7 @@ matrix:
       env: BUILD_ARGS="-DENABLE_GTK=Off -DENABLE_CURSES=Off"
 
 before_install:
-    - if [ ${TRAVIS_OS_NAME} = "osx" ]; then brew update; brew install check curl; brew install ghostscript gtk+ gtk+3; brew install libidn libnet; brew install luajit openssl pcre rtmpdump geoip; fi
+    - if [ ${TRAVIS_OS_NAME} = "osx" ]; then brew update; brew install check curl; brew install groff gtk+ gtk+3; brew install libidn libnet; brew install luajit openssl pcre rtmpdump geoip; fi
 before_script:
     - if [ ${TRAVIS_OS_NAME} = "osx" ]; then export BUILD_ARGS="$BUILD_ARGS -DOPENSSL_ROOT_DIR=`brew --prefix openssl`";fi
 

--- a/man/CMakeLists.txt
+++ b/man/CMakeLists.txt
@@ -1,8 +1,17 @@
 # Add man page custom target
 if(ENABLE_PDF_DOCS)
-  find_program(GROFF_EXECUTABLE NAMES groff)
-  find_program(PS2PDF_EXECUTABLE NAMES ps2pdf)
-  set(PDF_FILES)
+        find_program(GROFF_EXECUTABLE NAMES groff)
+        set(PDF_FILES)
+
+# Check if groff supports PDF generation
+        execute_process(COMMAND ${GROFF_EXECUTABLE} -Tpdf -V
+        RESULT_VARIABLE GROFF_EXIT
+        ERROR_VARIABLE GROFF_ERROR
+        OUTPUT_QUIET)
+
+        if(NOT ${GROFF_EXIT} STREQUAL 0)
+          message(FATAL_ERROR "groff (at ${GROFF_EXECUTABLE}) does not seem to support PDF generation (${GROFF_EXIT}).\ngroff failed with output:\n${GROFF_ERROR}\nConsider upgrading the groff installation.\nUsers of Debian-based distributions must also install the full groff package.")
+        endif()
 endif()
 
 set (MAN_NAMES ettercap.8 etterfilter.8 etterlog.8 etter.conf.5)
@@ -25,20 +34,12 @@ foreach (m IN LISTS MAN_NAMES)
         list(APPEND MAN_FILES ${mf})
 
         if(ENABLE_PDF_DOCS)
-          set(ps ${CMAKE_BINARY_DIR}/man/${m}.ps)
           set(pdf ${CMAKE_BINARY_DIR}/man/${m}.pdf)
 
-          add_custom_command(OUTPUT ${mf}.ps
-          COMMAND ${GROFF_EXECUTABLE} -mandoc -Tps ${mf} > ${ps}
+          add_custom_command(OUTPUT ${mf}.pdf
+          COMMAND ${GROFF_EXECUTABLE} -mandoc -Tpdf ${mf} > ${pdf}
           WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-          COMMENT "Building manpage ${mf}"
-          VERBATIM)
-
-          add_custom_command(OUTPUT ${pdf}
-          COMMAND ${PS2PDF_EXECUTABLE} ${ps} ${pdf}
-          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}
-          DEPENDS ${mf}.ps
-          COMMENT "Creating PDF for ${ps}"
+          COMMENT "Creating PDF for ${mf}"
           VERBATIM)
           list(APPEND PDF_FILES ${pdf})
           install(FILES ${pdf} DESTINATION ${INSTALL_DATADIR}/ettercap/doc)


### PR DESCRIPTION
This PR _attempts_ to remove the dependency on ghostscript when building the PDF docs.
Groff can do the conversion by itself.
I think the ghostscript package is around 18 megabytes on ubuntu. On windows ghostscript is even bigger.
All PDF docs combined are less 250 kilobytes.
It's not very efficient to get such a big package to output such tiny files.

By the way: travis may error not because this doesn't work, but because there is something wrong with the groff package on precise pangolin. It's limited (or there is a bug or something). So try it on your local machine.