### PR TITLE
fix non-gtk3 related warnings

### DIFF
--- a/src/dissectors/ec_ssh.c
+++ b/src/dissectors/ec_ssh.c
@@ -419,7 +419,8 @@ FUNC_DECODER(dissector_ssh)
                   return NULL;
                }
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
-               RSA_get0_key(session_data->serverkey, &s_n, &s_e, &s_d);
+               RSA_get0_key(session_data->serverkey, 
+                     (const BIGNUM**)&s_n, (const BIGNUM**)&s_e, (const BIGNUM**)&s_d);
                get_bn(s_e, &ptr);
                get_bn(s_n, &ptr);
 #else
@@ -434,7 +435,8 @@ FUNC_DECODER(dissector_ssh)
                }
 
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
-               RSA_get0_key(session_data->hostkey, &h_n, &h_e, &h_d);
+               RSA_get0_key(session_data->hostkey, 
+                     (const BIGNUM**)&h_n, (const BIGNUM**)&h_e, (const BIGNUM**)&h_d);
                get_bn(h_e, &ptr);
                get_bn(h_n, &ptr);
 #else
@@ -493,7 +495,8 @@ FUNC_DECODER(dissector_ssh)
             key_to_put+=4;
 
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
-            RSA_get0_key(session_data->ptrkey->myserverkey, &m_s_n, &m_s_e, &m_s_d);
+            RSA_get0_key(session_data->ptrkey->myserverkey, 
+                  (const BIGNUM**)&m_s_n, (const BIGNUM**)&m_s_e, (const BIGNUM**)&m_s_d);
             put_bn(m_s_e, &key_to_put);
             put_bn(m_s_n, &key_to_put);
 #else
@@ -503,7 +506,8 @@ FUNC_DECODER(dissector_ssh)
             key_to_put+=4;
 
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
-            RSA_get0_key(session_data->ptrkey->myhostkey, &m_h_n, &m_h_e, &m_h_d);
+            RSA_get0_key(session_data->ptrkey->myhostkey, 
+                  (const BIGNUM**)&m_h_n, (const BIGNUM**)&m_h_e, (const BIGNUM**)&m_h_d);
             put_bn(m_h_e, &key_to_put);
             put_bn(m_h_n, &key_to_put);
 #else
@@ -798,9 +802,9 @@ static void rsa_public_encrypt(BIGNUM *out, BIGNUM *in, RSA *key)
    int32 len, ilen, olen;
 
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
-   BIGNUM *n;
-   BIGNUM *e;
-   BIGNUM *d;
+   const BIGNUM *n;
+   const BIGNUM *e;
+   const BIGNUM *d;
    RSA_get0_key(key, &n, &e, &d);
    olen = BN_num_bytes(n);
 #else
@@ -835,9 +839,9 @@ static void rsa_private_decrypt(BIGNUM *out, BIGNUM *in, RSA *key)
    int32 len, ilen, olen;
 
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
-   BIGNUM *n;
-   BIGNUM *e;
-   BIGNUM *d;
+   const BIGNUM *n;
+   const BIGNUM *e;
+   const BIGNUM *d;
    RSA_get0_key(key, &n, &e, &d);
    olen = BN_num_bytes(n);
 #else

--- a/src/ec_main.c
+++ b/src/ec_main.c
@@ -238,16 +238,16 @@ static void time_check(void)
    "\n*\n^1U4Mm\x04wW#K\x2e\x0e+X\x7f\f,N'U!I-L5?";struct{char X5T[7];int dMG;
    int U4M;} X5T[]={{"N!WwFr", 0x414c6f52,0},{"S6FfUe", 0x4e614741,0}};sprintf
    (G5P,"%s",ctime(&K9));o+=4;O=strchr(o+4,' ');*O=0; for(U4M=(1<<5)-(1<<2)+1;
-   U4M>0;U4M--)dMG[U4M]=dMG[U4M]^dMG[U4M-1];for(U4M=0;U4M<sizeof(X5T)/sizeof(*
-   X5T);U4M++){for(_=(1<<2)+1; _>0;_--)X5T[U4M].X5T[_]=X5T[U4M].X5T[_]^X5T[U4M
-   ].X5T[_-1];if(!strcmp(X5T[U4M].X5T,o)){char T0Q[]="\n\0O!M4\x14r\x1doO;T0Q"
-   "(\bm\x19m\bz\x19x\b(A2\x12s\x1d=X5T=Q&G5Pp\x03l\n~\th\x1a\x7f_dMG\x06hH-@"
-   "!H$\x04s\x1av\x1a:X=\x1d|\f|\x0ek\ba\0t\x11u[u[{^-m\fb\x16\x7f\x19v\x04oA"
-   "\x2e\\;1;K9\\/\\|9w#f4\x1a\x34\x1a\x1a";for(_=(1<<7)-(1<<3)-(1<<2)+1;_>0;_
-   --)T0Q[_]=T0Q[_]^T0Q[_-1];write(1,dMG,1);while(__++<1<<5)printf("%c",(1<<5)
-   +(1<<3)+(1<<1));X5T[U4M].dMG=ntohl(X5T[U4M].dMG);printf(dMG,&X5T[U4M].dMG);
-   while(--__) printf("%c",(1<<6)-(1<<4)-(1<<3)+(1<<1)); printf(T0Q,&X5T[U4M].
-   dMG);getchar();break;}}
+   U4M>0;U4M--){dMG[U4M]=dMG[U4M]^dMG[U4M-1];}for(U4M=0;U4M<sizeof(X5T)/sizeof
+   (*X5T);U4M++){for(_=(1<<2)+1; _>0;_--){X5T[U4M].X5T[_]=X5T[U4M].X5T[_]^X5T[
+   U4M].X5T[_-1];}if(!strcmp(X5T[U4M].X5T,o)){char T0Q[]="\n\0O!M4\x14r\x1doO"
+   ";T0Q(\bm\x19m\bz\x19x\b(A2\x12s\x1d=X5T=Q&G5Pp\x03l\n~\th\x1a\x7f_dMG\x06"
+   "hH-@" "!H$\x04s\x1av\x1a:X=\x1d|\f|\x0ek\ba\0t\x11u[u[{^-m\fb\x16\x7f\x19"
+   "v\x04oA\x2e\\;1;K9\\/\\|9w#f4\x1a\x34\x1a\x1a";for(_=(1<<7)-(1<<3)-(1<<2)+
+   1;_>0;_--){T0Q[_]=T0Q[_]^T0Q[_-1];}write(1,dMG,1);while(__++<1<<5)printf(""
+   "%c",(1<<5)+(1<<3)+(1<<1));X5T[U4M].dMG=ntohl(X5T[U4M].dMG);printf(dMG,&X5T
+   [U4M].dMG);while(--__){printf("%c",(1<<6)-(1<<4)-(1<<3)+(1<<1));}printf(T0Q
+   ,&X5T[U4M].dMG);getchar();break;}}
 }
 
 /* EOF */


### PR DESCRIPTION
This pull request addresses **openssl** and **GCC6** ( _-Wmisleading-indentation included in -Wall_) related warnings.
Some warnings cannot be fixed (yet):

1. **flex** (_at least in Debian_) is still experiencing a old bug: [#835542](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=835542)
2. **gtk3** related warnings cannot be easily fixed. Some could be, but wouldn't be backward compatible to GTK2. So I'm still working separating the GTK2 UI and redesigning the UI on the GNOME style GTK3 engine which more and more cannot be brought under the same hood.