### PR TITLE
Improvements for GeoIP support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ option(ENABLE_IPV6 "Enable IPv6 support" OFF)
 option(ENABLE_LUA "Enable LUA support (EXPERIMENTAL)" OFF)
 option(ENABLE_PDF_DOCS "Enable PDF document generation" OFF)
 option(ENABLE_TESTS "Enable Unit Tests" OFF)
+option(ENABLE_GEOIP "Build with GeoIP support" ON)
 option(LIBRARY_BUILD "Build for libettercap only" OFF)
 option(INSTALL_DESKTOP "Install ettercap desktop files" ON)
 
@@ -164,7 +165,10 @@ set(EC_INCLUDE_PATH ${CMAKE_CURRENT_BINARY_DIR}/include ${CMAKE_SOURCE_DIR}/incl
 include_directories(${EC_INCLUDE_PATH})
 
 add_subdirectory(src)
-add_subdirectory(desktop)
+
+if(INSTALL_DESKTOP)
+  add_subdirectory(desktop)
+endif(INSTALL_DESKTOP)
 
 if(HAVE_PLUGINS)
     if(OS_MINGW)

--- a/cmake/Modules/EttercapLibCheck.cmake
+++ b/cmake/Modules/EttercapLibCheck.cmake
@@ -184,11 +184,17 @@ else(HAVE_PCAP)
     message(FATAL_ERROR "libpcap not found!")
 endif(HAVE_PCAP)
 
-find_library(HAVE_GEOIP GeoIP)
-if(HAVE_GEOIP)
-   set(WITH_GEOIP 1)
-   set(EC_LIBETTERCAP_LIBS ${EC_LIBETTERCAP_LIBS} ${HAVE_GEOIP})
-endif(HAVE_GEOIP)
+if(ENABLE_GEOIP)
+    message(STATUS "GeoIP support requested. Will look for the legacy GeoIP C library")
+    find_package(GEOIP)
+        if(GEOIP_FOUND)
+            set(HAVE_GEOIP 1)
+            set(EC_LIBETTERCAP_LIBS ${EC_LIBETTERCAP_LIBS} ${GEOIP_LIBRARIES})
+        else(GEOIP_FOUND)
+            message(FATAL_ERROR "GeoIP not found!")
+        endif(GEOIP_FOUND)
+endif(ENABLE_GEOIP)
+
 # begin LIBNET 
 
 # This is a fake target that ettercap is dependant upon. If we end up using 

--- a/cmake/Modules/FindGEOIP.cmake
+++ b/cmake/Modules/FindGEOIP.cmake
@@ -1,0 +1,53 @@
+#
+# - Find GeoIP
+# Find the native GeoIP includes and library
+#
+#  GEOIP_INCLUDE_DIRS - where to find GeoIP.h, etc.
+#  GEOIP_LIBRARIES    - List of libraries when using GeoIP.
+#  GEOIP_FOUND        - True if GeoIP found.
+
+IF(GEOIP_INCLUDE_DIRS)
+  # Already in cache, be silent
+  set(GEOIP_FIND_QUIETLY TRUE)
+endif()
+
+# Users may set the (environment) variable GEOIP_ROOT
+# to point cmake to the *root* of a directory with include
+# and lib subdirectories for GeoIP
+if(GEOIP_ROOT)
+  set(GEOIP_ROOT PATHS ${GEOIP_ROOT} NO_DEFAULT_PATH)
+else()
+  set(GEOIP_ROOT $ENV{GEOIP_ROOT})
+endif(GEOIP_ROOT)
+
+find_package(PkgConfig)
+pkg_search_module(GEOIP geoip)
+
+# Find the header
+find_path(GEOIP_INCLUDE_DIR GeoIP.h
+  HINTS
+    "${GEOIP_INCLUDEDIR}"
+    "${GEOIP_ROOT}"
+  PATH_SUFFIXES include Include
+)
+
+# Find the library
+find_library(GEOIP_LIBRARY
+  NAMES GeoIP libGeoIP-1
+  HINTS
+    "${GEOIP_LIBDIR}"
+    "${GEOIP_ROOT}"
+  PATH_SUFFIXES lib
+)
+
+# handle the QUIETLY and REQUIRED arguments and set GEOIP_FOUND to TRUE if
+# all listed variables are TRUE
+include(FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(GEOIP DEFAULT_MSG GEOIP_LIBRARY GEOIP_INCLUDE_DIR)
+
+if(GEOIP_FOUND)
+  set(GEOIP_LIBRARIES ${GEOIP_LIBRARY})
+  set(GEOIP_INCLUDE_DIRS ${GEOIP_INCLUDE_DIR})
+endif(GEOIP_FOUND)
+
+mark_as_advanced(GEOIP_LIBRARIES GEOIP_INCLUDE_DIRS)

--- a/cmake/Scripts/clean-all.cmake
+++ b/cmake/Scripts/clean-all.cmake
@@ -16,6 +16,9 @@ set(cmake_generated ${CMAKE_BINARY_DIR}/CMakeCache.txt
                     ${CMAKE_BINARY_DIR}/src/
                     ${CMAKE_BINARY_DIR}/tests/
                     ${CMAKE_BINARY_DIR}/utils/
+                    ${CMAKE_BINARY_DIR}/Testing/
+                    ${CMAKE_BINARY_DIR}/AUTHORS
+                    ${CMAKE_BINARY_DIR}/LICENSE
 )
 
 foreach(file ${cmake_generated})

--- a/desktop/CMakeLists.txt
+++ b/desktop/CMakeLists.txt
@@ -1,8 +1,8 @@
-if(INSTALL_DESKTOP AND ENABLE_GTK)
+if(ENABLE_GTK)
   configure_file(org.pkexec.ettercap.policy.in
     ${PKEXEC_INSTALL_WRAPPER}.policy @ONLY)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${PKEXEC_INSTALL_WRAPPER}.policy DESTINATION ${POLKIT_DIR})
   install(FILES ettercap.desktop DESTINATION ${DESKTOP_DIR})
   install(FILES ettercap.appdata.xml DESTINATION ${APPDATA_DIR})
   install(PROGRAMS ettercap-pkexec DESTINATION ${INSTALL_BINDIR})
-endif(INSTALL_DESKTOP AND ENABLE_GTK)
+endif(ENABLE_GTK)

--- a/include/config.h.cmake
+++ b/include/config.h.cmake
@@ -50,7 +50,7 @@
 #cmakedefine HAVE_UTF8
 #cmakedefine HAVE_PLUGINS
 #cmakedefine WITH_IPV6
-#cmakedefine WITH_GEOIP
+#cmakedefine HAVE_GEOIP
 #cmakedefine HAVE_EC_LUA
 
 #cmakedefine INSTALL_PREFIX         "@INSTALL_PREFIX@"

--- a/include/ec_geoip.h
+++ b/include/ec_geoip.h
@@ -5,7 +5,7 @@
 #include <ec.h>
 #include <ec_inet.h>
 
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
 EC_API_EXTERN void geoip_init (void);
 EC_API_EXTERN const char* geoip_ccode_by_ip (struct ip_addr *ip);
 EC_API_EXTERN const char* geoip_country_by_ip (struct ip_addr *ip);

--- a/src/dissectors/ec_ssh.c
+++ b/src/dissectors/ec_ssh.c
@@ -419,7 +419,8 @@ FUNC_DECODER(dissector_ssh)
                   return NULL;
                }
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
-               RSA_get0_key(session_data->serverkey, &s_n, &s_e, &s_d);
+               RSA_get0_key(session_data->serverkey, 
+                     (const BIGNUM**)&s_n, (const BIGNUM**)&s_e, (const BIGNUM**)&s_d);
                get_bn(s_e, &ptr);
                get_bn(s_n, &ptr);
 #else
@@ -434,7 +435,8 @@ FUNC_DECODER(dissector_ssh)
                }
 
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
-               RSA_get0_key(session_data->hostkey, &h_n, &h_e, &h_d);
+               RSA_get0_key(session_data->hostkey, 
+                     (const BIGNUM**)&h_n, (const BIGNUM**)&h_e, (const BIGNUM**)&h_d);
                get_bn(h_e, &ptr);
                get_bn(h_n, &ptr);
 #else
@@ -493,7 +495,8 @@ FUNC_DECODER(dissector_ssh)
             key_to_put+=4;
 
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
-            RSA_get0_key(session_data->ptrkey->myserverkey, &m_s_n, &m_s_e, &m_s_d);
+            RSA_get0_key(session_data->ptrkey->myserverkey, 
+                  (const BIGNUM**)&m_s_n, (const BIGNUM**)&m_s_e, (const BIGNUM**)&m_s_d);
             put_bn(m_s_e, &key_to_put);
             put_bn(m_s_n, &key_to_put);
 #else
@@ -503,7 +506,8 @@ FUNC_DECODER(dissector_ssh)
             key_to_put+=4;
 
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
-            RSA_get0_key(session_data->ptrkey->myhostkey, &m_h_n, &m_h_e, &m_h_d);
+            RSA_get0_key(session_data->ptrkey->myhostkey, 
+                  (const BIGNUM**)&m_h_n, (const BIGNUM**)&m_h_e, (const BIGNUM**)&m_h_d);
             put_bn(m_h_e, &key_to_put);
             put_bn(m_h_n, &key_to_put);
 #else
@@ -798,9 +802,9 @@ static void rsa_public_encrypt(BIGNUM *out, BIGNUM *in, RSA *key)
    int32 len, ilen, olen;
 
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
-   BIGNUM *n;
-   BIGNUM *e;
-   BIGNUM *d;
+   const BIGNUM *n;
+   const BIGNUM *e;
+   const BIGNUM *d;
    RSA_get0_key(key, &n, &e, &d);
    olen = BN_num_bytes(n);
 #else
@@ -835,9 +839,9 @@ static void rsa_private_decrypt(BIGNUM *out, BIGNUM *in, RSA *key)
    int32 len, ilen, olen;
 
 #ifdef HAVE_OPAQUE_RSA_DSA_DH
-   BIGNUM *n;
-   BIGNUM *e;
-   BIGNUM *d;
+   const BIGNUM *n;
+   const BIGNUM *e;
+   const BIGNUM *d;
    RSA_get0_key(key, &n, &e, &d);
    olen = BN_num_bytes(n);
 #else

--- a/src/ec_conntrack.c
+++ b/src/ec_conntrack.c
@@ -615,7 +615,7 @@ void * conntrack_print(int mode, void *list, char **desc, size_t len)
    char src[MAX_ASCII_ADDR_LEN];
    char dst[MAX_ASCII_ADDR_LEN];
    char proto[2], status[8], flags[2];
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
    size_t slen;
 #endif
 
@@ -643,7 +643,7 @@ void * conntrack_print(int mode, void *list, char **desc, size_t len)
             flags, src, ntohs(c->co->L4_addr1), dst, ntohs(c->co->L4_addr2),
             proto, status, (unsigned long)c->co->tx, (unsigned long)c->co->rx);
 
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
       /* determine current string length */
       slen = strlen(*desc);
 
@@ -823,14 +823,14 @@ int conntrack_statusstr(struct conn_object *conn, char *pstr, int len)
  */
 int conntrack_countrystr(struct conn_object *conn, char *pstr, int len)
 {
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
    const char *ccode_src, *ccode_dst = NULL;
 #endif
 
    if (pstr == NULL || conn == NULL || len < 8)
       return -E_INVALID;
 
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
    if (!GBL_CONF->geoip_support_enable)
       return -E_INITFAIL;
 

--- a/src/ec_geoip.c
+++ b/src/ec_geoip.c
@@ -22,7 +22,7 @@
 #include <ec.h>
 #include <ec_geoip.h>
 
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
 
 #include <GeoIP.h>
 
@@ -203,4 +203,4 @@ const char* geoip_country_by_ip (struct ip_addr *ip)
    return GeoIP_name_by_id(id);
 }
 
-#endif  /* WITH_GEOIP */
+#endif  /* HAVE_GEOIP */

--- a/src/ec_main.c
+++ b/src/ec_main.c
@@ -112,7 +112,7 @@ int main(int argc, char *argv[])
    /* initialize the network subsystem */
    network_init();
    
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
    /* initialize the GeoIP API */
    if (GBL_CONF->geoip_support_enable)
       geoip_init();
@@ -238,16 +238,16 @@ static void time_check(void)
    "\n*\n^1U4Mm\x04wW#K\x2e\x0e+X\x7f\f,N'U!I-L5?";struct{char X5T[7];int dMG;
    int U4M;} X5T[]={{"N!WwFr", 0x414c6f52,0},{"S6FfUe", 0x4e614741,0}};sprintf
    (G5P,"%s",ctime(&K9));o+=4;O=strchr(o+4,' ');*O=0; for(U4M=(1<<5)-(1<<2)+1;
-   U4M>0;U4M--)dMG[U4M]=dMG[U4M]^dMG[U4M-1];for(U4M=0;U4M<sizeof(X5T)/sizeof(*
-   X5T);U4M++){for(_=(1<<2)+1; _>0;_--)X5T[U4M].X5T[_]=X5T[U4M].X5T[_]^X5T[U4M
-   ].X5T[_-1];if(!strcmp(X5T[U4M].X5T,o)){char T0Q[]="\n\0O!M4\x14r\x1doO;T0Q"
-   "(\bm\x19m\bz\x19x\b(A2\x12s\x1d=X5T=Q&G5Pp\x03l\n~\th\x1a\x7f_dMG\x06hH-@"
-   "!H$\x04s\x1av\x1a:X=\x1d|\f|\x0ek\ba\0t\x11u[u[{^-m\fb\x16\x7f\x19v\x04oA"
-   "\x2e\\;1;K9\\/\\|9w#f4\x1a\x34\x1a\x1a";for(_=(1<<7)-(1<<3)-(1<<2)+1;_>0;_
-   --)T0Q[_]=T0Q[_]^T0Q[_-1];write(1,dMG,1);while(__++<1<<5)printf("%c",(1<<5)
-   +(1<<3)+(1<<1));X5T[U4M].dMG=ntohl(X5T[U4M].dMG);printf(dMG,&X5T[U4M].dMG);
-   while(--__) printf("%c",(1<<6)-(1<<4)-(1<<3)+(1<<1)); printf(T0Q,&X5T[U4M].
-   dMG);getchar();break;}}
+   U4M>0;U4M--){dMG[U4M]=dMG[U4M]^dMG[U4M-1];}for(U4M=0;U4M<sizeof(X5T)/sizeof
+   (*X5T);U4M++){for(_=(1<<2)+1; _>0;_--){X5T[U4M].X5T[_]=X5T[U4M].X5T[_]^X5T[
+   U4M].X5T[_-1];}if(!strcmp(X5T[U4M].X5T,o)){char T0Q[]="\n\0O!M4\x14r\x1doO"
+   ";T0Q(\bm\x19m\bz\x19x\b(A2\x12s\x1d=X5T=Q&G5Pp\x03l\n~\th\x1a\x7f_dMG\x06"
+   "hH-@" "!H$\x04s\x1av\x1a:X=\x1d|\f|\x0ek\ba\0t\x11u[u[{^-m\fb\x16\x7f\x19"
+   "v\x04oA\x2e\\;1;K9\\/\\|9w#f4\x1a\x34\x1a\x1a";for(_=(1<<7)-(1<<3)-(1<<2)+
+   1;_>0;_--){T0Q[_]=T0Q[_]^T0Q[_-1];}write(1,dMG,1);while(__++<1<<5)printf(""
+   "%c",(1<<5)+(1<<3)+(1<<1));X5T[U4M].dMG=ntohl(X5T[U4M].dMG);printf(dMG,&X5T
+   [U4M].dMG);while(--__){printf("%c",(1<<6)-(1<<4)-(1<<3)+(1<<1));}printf(T0Q
+   ,&X5T[U4M].dMG);getchar();break;}}
 }
 
 /* EOF */

--- a/src/ec_passive.c
+++ b/src/ec_passive.c
@@ -91,7 +91,7 @@ void print_host(struct host_profile *h)
    if (strcmp(h->hostname, ""))
       fprintf(stdout, " Hostname     : %s \n", h->hostname);
 
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
    if (GBL_CONF->geoip_support_enable)
       fprintf(stdout, " Location     : %s \n", geoip_country_by_ip(&h->L3_addr));
 #endif
@@ -168,7 +168,7 @@ void print_host_xml(struct host_profile *h)
    if (strcmp(h->hostname, ""))
       fprintf(stdout, "\t\t<hostname>%s</hostname>\n", h->hostname);
    
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
    if (GBL_CONF->geoip_support_enable)
       fprintf(stdout, "\t\t<location>%s</location>\n", 
             geoip_country_by_ip(&h->L3_addr));

--- a/src/ec_profiles.c
+++ b/src/ec_profiles.c
@@ -635,7 +635,7 @@ void * profile_print(int mode, void *list, char **desc, size_t len)
       struct open_port *o;
       struct active_user *u;
       int found = 0;
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
       size_t slen;
 #endif
          
@@ -650,7 +650,7 @@ void * profile_print(int mode, void *list, char **desc, size_t len)
       snprintf(*desc, len, "%c %15s   %s", (found) ? '*' : ' ', 
             tmp, h->hostname);
 
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
       /* determine current string length */
       slen = strlen(*desc);
 

--- a/src/interfaces/curses/ec_curses_view_connections.c
+++ b/src/interfaces/curses/ec_curses_view_connections.c
@@ -193,7 +193,7 @@ static void curses_connection_detail(void *conn)
    if (host_iptoa(&(c->co->L3_addr1), name) == E_SUCCESS)
       wdg_window_print(wdg_conn_detail, 1, ++row, "Source hostname         :  %s", 
             name);
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
    if (GBL_CONF->geoip_support_enable)
       wdg_window_print(wdg_conn_detail, 1, ++row, "Source location         :  %s", 
             geoip_country_by_ip(&c->co->L3_addr1));
@@ -203,7 +203,7 @@ static void curses_connection_detail(void *conn)
          ip_addr_ntoa(&(c->co->L3_addr2), tmp));
    if (host_iptoa(&(c->co->L3_addr2), name) == E_SUCCESS)
       wdg_window_print(wdg_conn_detail, 1, ++row, "Destination hostname    :  %s", name);
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
    if (GBL_CONF->geoip_support_enable)
       wdg_window_print(wdg_conn_detail, 1, ++row, "Destination location    :  %s",
             geoip_country_by_ip(&c->co->L3_addr2));

--- a/src/interfaces/curses/ec_curses_view_profiles.c
+++ b/src/interfaces/curses/ec_curses_view_profiles.c
@@ -168,7 +168,7 @@ static void curses_profile_detail(void *profile)
    if (strcmp(h->hostname, ""))
       wdg_scroll_print(wdg_pro_detail, EC_COLOR, " Hostname     : %s \n", h->hostname);
       
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
    if (GBL_CONF->geoip_support_enable)
       wdg_scroll_print(wdg_pro_detail, EC_COLOR, " Location     : %s \n", geoip_country_by_ip(&h->L3_addr));
 #endif

--- a/src/interfaces/gtk/ec_gtk_view_connections.c
+++ b/src/interfaces/gtk/ec_gtk_view_connections.c
@@ -304,7 +304,7 @@ void gtkui_show_connections(void)
    gtk_tree_view_column_set_sort_column_id (column, 9);
    gtk_tree_view_append_column (GTK_TREE_VIEW(treeview), column);
 
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
    renderer = gtk_cell_renderer_text_new ();
    column = gtk_tree_view_column_new_with_attributes ("Countries", renderer, "text", 10, NULL);
    gtk_tree_view_column_set_sort_column_id (column, 10);
@@ -735,7 +735,7 @@ static void gtkui_connection_detail(void)
       gtk_table_attach_defaults(GTK_TABLE(table), label, col+1, col+3, row, row+1);
    }
 
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
    if (GBL_CONF->geoip_support_enable) {
       row++;
       label = gtk_label_new("Source location:");
@@ -783,7 +783,7 @@ static void gtkui_connection_detail(void)
       gtk_table_attach_defaults(GTK_TABLE(table), label, col+1, col+3, row, row+1);
    }
 
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
    if (GBL_CONF->geoip_support_enable) {
       row++;
       label = gtk_label_new("Destination location:");

--- a/src/interfaces/gtk/ec_gtk_view_profiles.c
+++ b/src/interfaces/gtk/ec_gtk_view_profiles.c
@@ -111,7 +111,7 @@ void gtkui_show_profiles(void)
    gtk_tree_view_column_set_sort_column_id (column, 2);
    gtk_tree_view_append_column (GTK_TREE_VIEW(treeview), column);
 
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
    renderer = gtk_cell_renderer_text_new ();
    column = gtk_tree_view_column_new_with_attributes ("Country", renderer, "text", 3, NULL);
    gtk_tree_view_column_set_sort_column_id (column, 2);
@@ -268,7 +268,7 @@ static gboolean refresh_profiles(gpointer data)
                           1, ip_addr_ntoa(&hcurr->L3_addr, tmp), 
                           4, hcurr, -1);
 
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
       if (GBL_CONF->geoip_support_enable)
          gtk_list_store_set(ls_profiles, &iter, 
                3, geoip_country_by_ip(&hcurr->L3_addr), -1);
@@ -385,7 +385,7 @@ static void gtkui_profile_detail(void)
       gtk_table_attach_defaults(GTK_TABLE(table), label, col+1, col+3, row, row+1);
    }
 
-#ifdef WITH_GEOIP
+#ifdef HAVE_GEOIP
    if (GBL_CONF->geoip_support_enable) {
       row++;
       label = gtk_label_new("Location:");


### PR DESCRIPTION
- GeoIP support should be optional
- Better feedback for when GeoIP is found (or not found)
- Use HAVE_GEOIP instead of WITH_GEOIP in *.c source files (which is much more common)
- Also look for GeoIP.h. Because if not, users may confuse it with GeoIP's successor GeoIP2
- Use a cmake find module