### PR TITLE
Fix issue #865 - Regex compilation prevents sslstrip plugin to load

### DIFF
--- a/plug-ins/sslstrip/sslstrip.c
+++ b/plug-ins/sslstrip/sslstrip.c
@@ -245,7 +245,7 @@ static int sslstrip_init(void *dummy)
    err = regcomp(&find_cookie_re, COOKIE_PATTERN, REG_EXTENDED | REG_NEWLINE | REG_ICASE);
    if (err) {
       regerror(err, &find_cookie_re, errbuf, sizeof(errbuf));
-      USER_MSG("SSLStrip: plugin load failed: Could not compile find_cookie regex: %d\n", err);
+      USER_MSG("SSLStrip: plugin load failed: Could not compile find_cookie regex: %s (%d)\n", errbuf, err);
       pcre_free(https_url_pcre);
       http_remove_redirect(bind_port);
       return PLUGIN_FINISHED;

--- a/plug-ins/sslstrip/sslstrip.c
+++ b/plug-ins/sslstrip/sslstrip.c
@@ -70,9 +70,9 @@
 
 //#define URL_PATTERN "(href=|src=|url\\(|action=)?[\"']?(https)://([^ \r\\)/\"'>\\)]*)/?([^ \\)\"'>\\)\r]*)"
 //#define URL_PATTERN "(href=|src=|url\\(|action=)?[\"']?(https)(\\%3A|\\%3a|:)//([^ \r\\)/\"'>\\)]*)/?([^ \\)\"'>\\)\r]*)"
-#define URL_PATTERN "(https://[\\w\\d:#@%/;$()~_?\\+-=\\\\.&]*)"
+#define URL_PATTERN "(https://[\\w\\d:#@%/;$()~_?\\+=\\\\.&-]*)"
 //#define COOKIE_PATTERN "Set-Cookie: (.*?;)(.?Secure;|.?Secure)(.*?)\r\n"
-#define COOKIE_PATTERN "Set-Cookie: ([ \\w\\d:#@%/;$()~_?\\+-=\\\\.&]+); ?Secure"
+#define COOKIE_PATTERN "Set-Cookie: ([ \\w\\d:#@%/;$()~_?\\+=\\\\.&-]+); ?Secure"
 
 
 #define REQUEST_TIMEOUT 120 /* If a request has not been used in 120 seconds, remove it from list */


### PR DESCRIPTION
This PR fixes an "invalid range end" regex issue.
In addition the error message is annotated with the string representation of the acutal error.