### PR TITLE
Fix #793 - fix alignment of ettercap filters - update changelog

### DIFF
--- a/src/ec_filter.c
+++ b/src/ec_filter.c
@@ -1085,7 +1085,13 @@ int filter_load_file(const char *filename, struct filter_list **list, uint8_t en
 
    /* sanity checks */
    if (fh.magic != htons(EC_FILTER_MAGIC))
-      FATAL_MSG("Bad magic in filter file\nMake sure to compile the filter with etterfilter");
+      FATAL_MSG("Bad magic in filter file\n"
+            "Make sure to compile the filter with a current version of etterfilter");
+
+   /* check pointer alignment */
+   if (fh.code % 8)
+      FATAL_MSG("Bad instruction pointer alignment\n"
+            "Make sure to compile the filter with a current version of etterfilter");
   
    /* which version has compiled the filter ? */
    if (strcmp(fh.version, EC_VERSION))


### PR DESCRIPTION
This fixes issue #793.
The main issue is, that the instructions are not (if not by accident) aligned on the address-bus width boundary.
Fixing the issue is two-fold:
 1. check byte-alignment when reading filters
 2. compiling filters with aligned instructions

Unfortunately this implicitly leads to invalidate (nearly) all pre-compiled filters. They need to get recompiled from the filter-source to get a aligned filter. But this shouldn't be a big deal, since **ettercap** checks the version of the filter anyway.
 
This PR aligns the instructions on 8-byte boundary even though on 32-bit systems, 4-byte alignment would be sufficient.
However in order to maintain filters compiled on a 32-bit system able to run on a 64-bit system I stick to 8-byte since it's automatically a 4-byte alignment.