### PR TITLE
Fix crashes when some external APIs fail

### DIFF
--- a/plug-ins/sslstrip/sslstrip.c
+++ b/plug-ins/sslstrip/sslstrip.c
@@ -771,7 +771,7 @@ static int http_get_peer(struct http_connection *connection)
    switch (ntohs(connection->ip[HTTP_CLIENT].addr_type)) {
       case AF_INET:
          if (getsockopt (connection->fd, SOL_IP, SO_ORIGINAL_DST, (struct sockaddr*)&ss, &ss_len) == -1) {
-            DEBUG_MSG("getsockopt failed: %s", strerror(errno));
+            WARN_MSG("getsockopt failed: %s", strerror(errno));
             return -E_INVALID;
          }
          sa4 = (struct sockaddr_in *)&ss;
@@ -780,7 +780,7 @@ static int http_get_peer(struct http_connection *connection)
 #if defined WITH_IPV6 && defined HAVE_IP6T_SO_ORIGINAL_DST
       case AF_INET6:
          if (getsockopt (connection->fd, IPPROTO_IPV6, IP6T_SO_ORIGINAL_DST, (struct sockaddr*)&ss, &ss_len) == -1) {
-            DEBUG_MSG("getsockopt failed: %s", strerror(errno));
+            WARN_MSG("getsockopt failed: %s", strerror(errno));
             return -E_INVALID;
          }
          sa6 = (struct sockaddr_in6 *)&ss;

--- a/plug-ins/sslstrip/sslstrip.c
+++ b/plug-ins/sslstrip/sslstrip.c
@@ -770,13 +770,19 @@ static int http_get_peer(struct http_connection *connection)
    socklen_t ss_len = sizeof(struct sockaddr_storage);
    switch (ntohs(connection->ip[HTTP_CLIENT].addr_type)) {
       case AF_INET:
-         getsockopt (connection->fd, SOL_IP, SO_ORIGINAL_DST, (struct sockaddr*)&ss, &ss_len);
+         if (getsockopt (connection->fd, SOL_IP, SO_ORIGINAL_DST, (struct sockaddr*)&ss, &ss_len) == -1) {
+            DEBUG_MSG("getsockopt failed: %s", strerror(errno));
+            return -E_INVALID;
+         }
          sa4 = (struct sockaddr_in *)&ss;
          ip_addr_init(&(connection->ip[HTTP_SERVER]), AF_INET, (u_char *)&(sa4->sin_addr.s_addr));
          break;
 #if defined WITH_IPV6 && defined HAVE_IP6T_SO_ORIGINAL_DST
       case AF_INET6:
-         getsockopt (connection->fd, IPPROTO_IPV6, IP6T_SO_ORIGINAL_DST, (struct sockaddr*)&ss, &ss_len);
+         if (getsockopt (connection->fd, IPPROTO_IPV6, IP6T_SO_ORIGINAL_DST, (struct sockaddr*)&ss, &ss_len) == -1) {
+            DEBUG_MSG("getsockopt failed: %s", strerror(errno));
+            return -E_INVALID;
+         }
          sa6 = (struct sockaddr_in6 *)&ss;
          ip_addr_init(&(connection->ip[HTTP_SERVER]), AF_INET6, (u_char *)&(sa6->sin6_addr.s6_addr));
          break;

--- a/src/ec_sslwrap.c
+++ b/src/ec_sslwrap.c
@@ -817,7 +817,7 @@ static int sslw_get_peer(struct accepted_entry *ae)
    switch (ntohs(ae->ip[SSL_CLIENT].addr_type)) {
       case AF_INET:
          if (getsockopt(ae->fd[SSL_CLIENT], SOL_IP, SO_ORIGINAL_DST, (struct sockaddr*)&ss, &ss_len) == -1) {
-            FATAL_ERROR("getsockopt failed");
+            WARN_MSG("getsockopt failed: %s", strerror(errno));
             return -E_INVALID;
          }
          sa4 = (struct sockaddr_in *)&ss;
@@ -826,7 +826,7 @@ static int sslw_get_peer(struct accepted_entry *ae)
 #if defined WITH_IPV6 && defined HAVE_IP6T_SO_ORIGINAL_DST
       case AF_INET6:
          if (getsockopt(ae->fd[SSL_CLIENT], IPPROTO_IPV6, IP6T_SO_ORIGINAL_DST, (struct sockaddr*)&ss, &ss_len) == -1) {
-            FATAL_ERROR("getsockopt failed");
+            WARN_MSG("getsockopt failed: %s", strerror(errno));
             return -E_INVALID;
          }
          sa6 = (struct sockaddr_in6 *)&ss;

--- a/src/ec_sslwrap.c
+++ b/src/ec_sslwrap.c
@@ -552,7 +552,7 @@ static int sslw_remove_redirect(u_int16 sport, u_int16 dport)
                return -E_INVALID;
       }
    }
-getsockopt
+
    return E_SUCCESS;
 }
 

--- a/src/ec_sslwrap.c
+++ b/src/ec_sslwrap.c
@@ -552,7 +552,7 @@ static int sslw_remove_redirect(u_int16 sport, u_int16 dport)
                return -E_INVALID;
       }
    }
-
+getsockopt
    return E_SUCCESS;
 }
 
@@ -816,13 +816,19 @@ static int sslw_get_peer(struct accepted_entry *ae)
 
    switch (ntohs(ae->ip[SSL_CLIENT].addr_type)) {
       case AF_INET:
-         getsockopt(ae->fd[SSL_CLIENT], SOL_IP, SO_ORIGINAL_DST, (struct sockaddr*)&ss, &ss_len);
+         if (getsockopt(ae->fd[SSL_CLIENT], SOL_IP, SO_ORIGINAL_DST, (struct sockaddr*)&ss, &ss_len) == -1) {
+            FATAL_ERROR("getsockopt failed");
+            return -E_INVALID;
+         }
          sa4 = (struct sockaddr_in *)&ss;
          ip_addr_init(&(ae->ip[SSL_SERVER]), AF_INET, (u_char *)&(sa4->sin_addr.s_addr));
          break;
 #if defined WITH_IPV6 && defined HAVE_IP6T_SO_ORIGINAL_DST
       case AF_INET6:
-         getsockopt(ae->fd[SSL_CLIENT], IPPROTO_IPV6, IP6T_SO_ORIGINAL_DST, (struct sockaddr*)&ss, &ss_len);
+         if (getsockopt(ae->fd[SSL_CLIENT], IPPROTO_IPV6, IP6T_SO_ORIGINAL_DST, (struct sockaddr*)&ss, &ss_len) == -1) {
+            FATAL_ERROR("getsockopt failed");
+            return -E_INVALID;
+         }
          sa6 = (struct sockaddr_in6 *)&ss;
          ip_addr_init(&(ae->ip[SSL_SERVER]), AF_INET6, (u_char *)&(sa6->sin6_addr.s6_addr));
          break;

--- a/src/interfaces/curses/widgets/wdg_file.c
+++ b/src/interfaces/curses/widgets/wdg_file.c
@@ -124,7 +124,7 @@ static int wdg_file_destroy(struct wdg_object *wo)
    
    /* restore the initial working directory */
    if (chdir(ww->initpath) == -1)
-       perror("chdir failed");
+       WARN_MSG("chdir failed: %s", strerror(errno));
 
    WDG_SAFE_FREE(wo->extend);
 
@@ -396,7 +396,7 @@ static int wdg_file_driver(struct wdg_object *wo, int key, struct wdg_mouse_even
       /* if it is a directory, change to it */
       if (S_ISDIR(buf.st_mode)) {
          if (chdir(item_name(current_item(ww->m))) == -1)
-             perror("chdir failed");
+             WARN_MSG("chdir failed: %s", strerror(errno));
          return -WDG_E_NOTHANDLED;
       } else {
          /* invoke the callback and return */

--- a/src/interfaces/curses/widgets/wdg_file.c
+++ b/src/interfaces/curses/widgets/wdg_file.c
@@ -123,7 +123,8 @@ static int wdg_file_destroy(struct wdg_object *wo)
    delwin(ww->win);
    
    /* restore the initial working directory */
-   chdir(ww->initpath);
+   if (chdir(ww->initpath))
+       perror("chdir failed");
 
    WDG_SAFE_FREE(wo->extend);
 
@@ -394,7 +395,8 @@ static int wdg_file_driver(struct wdg_object *wo, int key, struct wdg_mouse_even
       stat(item_name(current_item(ww->m)), &buf);
       /* if it is a directory, change to it */
       if (S_ISDIR(buf.st_mode)) {
-         chdir(item_name(current_item(ww->m)));
+         if (chdir(item_name(current_item(ww->m))))
+             perror("chdir failed");
          return -WDG_E_NOTHANDLED;
       } else {
          /* invoke the callback and return */

--- a/src/interfaces/curses/widgets/wdg_file.c
+++ b/src/interfaces/curses/widgets/wdg_file.c
@@ -123,7 +123,7 @@ static int wdg_file_destroy(struct wdg_object *wo)
    delwin(ww->win);
    
    /* restore the initial working directory */
-   if (chdir(ww->initpath))
+   if (chdir(ww->initpath) == -1)
        perror("chdir failed");
 
    WDG_SAFE_FREE(wo->extend);
@@ -395,7 +395,7 @@ static int wdg_file_driver(struct wdg_object *wo, int key, struct wdg_mouse_even
       stat(item_name(current_item(ww->m)), &buf);
       /* if it is a directory, change to it */
       if (S_ISDIR(buf.st_mode)) {
-         if (chdir(item_name(current_item(ww->m))))
+         if (chdir(item_name(current_item(ww->m))) == -1)
              perror("chdir failed");
          return -WDG_E_NOTHANDLED;
       } else {


### PR DESCRIPTION
Hi,

I'm a PhD student. I analyzed the ettercap source code and found some potential API bugs that may cause crashes. These crashes are mainly caused by insufficient error handling of API functions like chdir or getsockopt.

I think it's unsafe to assume the library function would be correct. It would be better if we could handle the error properly.

Best,
Zhouyang