### PR TITLE
Fix format string bug in etterlog --filter

### DIFF
--- a/utils/etterlog/el_ec_compat.c
+++ b/utils/etterlog/el_ec_compat.c
@@ -57,16 +57,6 @@ void ui_error(const char *fmt, ...)
    fprintf(stderr, "\n");
 }
 
-void ui_fatal_error(const char *fmt, ...)
-{
-   va_list ap;
-   va_start(ap, fmt);
-   vfprintf (stderr, fmt, ap);
-   va_end(ap);
-   fprintf(stderr, "\n");
-   exit(-1);
-}
-
 void ui_cleanup(void) { }
 
 /* EOF */


### PR DESCRIPTION
A format string bug exists within etterlog:

$ etterlog --filter %p

etterlog 0.8.2 copyright 2001-2015 Ettercap Development Team

TARGET (0x5557eca62b6a) contains invalid chars !



Looking at the code, I saw two ui_fatal_error() functions. One utilized va_args, the other didn't. I did not see any usages of the va_args-enabled ui_fatal_error() function elsewhere in the code.

fatal_error() within ec_error.c calls ui_fatal_error() without format strings, triggering this bug.