### PR TITLE
Fix packetbuffer racecondition

### DIFF
--- a/include/ec_globals.h
+++ b/include/ec_globals.h
@@ -121,7 +121,6 @@ struct program_env {
 /* global pcap structure */
 struct pcap_env {
    pcap_if_t     *ifs;
-   char          *buffer;        /* buffer to be used to handle all the packets */
    u_int8         align;         /* alignment needed on sparc 4*n - sizeof(media_hdr) */
    char           promisc;
    char          *filter;        /* pcap filter */

--- a/include/ec_network.h
+++ b/include/ec_network.h
@@ -27,6 +27,9 @@ struct iface_env {
 
    pcap_t* pcap;
    libnet_t* lnet;
+
+   u_char* pbuf; /* buffer to be used to handle the packet on the arriving interface*/
+
 };
 
 

--- a/src/ec_decode.c
+++ b/src/ec_decode.c
@@ -128,16 +128,16 @@ void ec_decode(u_char *param, const struct pcap_pkthdr *pkthdr, const u_char *pk
    }
    
    /* 
-    * copy the packet in a "safe" buffer 
+    * copy the packet in a "dedicated" buffer
     * we don't want other packets after the end of the packet (as in BPF)
     *
     * also keep the buffer aligned !
     * the alignment is set by the media decoder.
     */
-   memcpy(EC_GBL_PCAP->buffer + EC_GBL_PCAP->align, pkt, pkthdr->caplen);
+   memcpy(iface->pbuf + EC_GBL_PCAP->align, pkt, pkthdr->caplen);
    
    /* extract data and datalen from pcap packet */
-   data = (u_char *)EC_GBL_PCAP->buffer + EC_GBL_PCAP->align;
+   data = (u_char *)iface->pbuf + EC_GBL_PCAP->align;
    datalen = pkthdr->caplen;
 
    /* 


### PR DESCRIPTION
This pull request is motivated by troubleshooting issue #772.
It is meant to fix #772.
However other issues may also be fixed by this pulll request.

**_Symptom:_**
When running in Bridged mode, Ettercap throws the following error message and in consequence stops packet forwarding:
```
ERROR : 90, Message too long
[/home/koeppea/dev/ettercap/src/ec_send.c:send_to_iface:152]

 libnet_write 37494 (-1): libnet_write_link(): only -1 bytes written (Message too long)
```
This issue becomes more probable to occur when ettercap is "under pressure" in forwarding (e.g. bulk transfer).

Another observation in an environment with managed upstream switches is, that MAC addresses appear to flap bet ween Ettercap's port and the actual port. Also Spanning-Tree BPDUs seem to get reflected back by Ettercap leading to BPDU-guard to trigger.

**_Background:_**
This issue only occurs when having more than 1 capture thread, which is the case in bridged mode.
Threads have own stacks but share the heap. The buffer where the captured packet content is copied into, is initially allocated in the HEAP, since it's variable sized.
If now the thread of the IFACE dives into the protocol stack - assume it arrived in the IPv6 protocol decoder due to the read `proto` value of the Ethernet protocol decoder - the BRIDGE thread overrides the content of the buffer since a new packet has been capture on the BRIDGE interface. Now the IPv6 decoder takes the header value for the payload length (which has been overridden by the second thread in the meantime with something else) and updates the _len_ attribute of the packet object. This results `libnet_write()` to fail or sending packet content on a interface, that is not destined to that interface.

**_Approach_**
Instead using thread locks as the classical approach for shared HEAP buffer, I decided not to slow down ettercap's throughput by two concurring threads waiting for each other.
Instead I decided to use dedicated packet buffer allocations per interface, since Ettercap is creating one capture thread per interface.

**_Test Results_**
First test results make the error message not appear. It seems to me, that the throughput is much faster. No errors on the upstream managed switch.

So it may be the case that this pull request may not fix #772 only.