### PR TITLE
Allow NDP and ARP poisoning without any optional parameters

### DIFF
--- a/src/interfaces/curses/ec_curses_mitm.c
+++ b/src/interfaces/curses/ec_curses_mitm.c
@@ -60,11 +60,12 @@ struct wdg_menu menu_mitm[] = { {"Mitm",                'M', "", NULL},
 static void curses_arp_poisoning(void)
 {
    char *method = "arp:";
+   char *default_param = "remote";
    size_t len = strlen(method);
    
    DEBUG_MSG("curses_arp_poisoning");
 
-   strncpy(params, method, len);
+   snprintf(params, PARAMS_LEN, "%s%s", method, default_param);
 
    curses_input("Parameters :", params + len, PARAMS_LEN - len - 1, curses_start_mitm);
 }
@@ -109,11 +110,12 @@ static void curses_dhcp_spoofing(void)
 static void curses_ndp_poisoning(void)
 {
    char *method = "ndp:";
+   char *default_param = "remote";
    size_t len = strlen(method);
 
    DEBUG_MSG("curses_ndp_poisoning");
 
-   strncpy(params, method, len);
+   snprintf(params, PARAMS_LEN, "%s%s", method, default_param);
 
    curses_input("Parameters :", params + len, PARAMS_LEN - len - 1, curses_start_mitm);
 }

--- a/src/interfaces/gtk/ec_gtk_mitm.c
+++ b/src/interfaces/gtk/ec_gtk_mitm.c
@@ -40,7 +40,6 @@ void gtkui_arp_poisoning(void)
    GtkWidget *dialog, *vbox, *hbox, *image, *button1, *button2, *frame, *content_area;
    gint response = 0;
    gboolean remote = FALSE;
-   gboolean oneway = FALSE;
 
    DEBUG_MSG("gtk_arp_poisoning");
 //   not needed, the \0 is already appended from snprintf
@@ -90,22 +89,17 @@ void gtkui_arp_poisoning(void)
       const char *s_remote = "", *comma = "", *s_oneway = "";
 
       if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON (button1))) {
-	s_remote="remote";
+        s_remote="remote";
         remote = TRUE;
       }
 
       if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON (button2))) {
          if(remote)
-		comma = ",";
+            comma = ",";
 
-	 s_oneway = "oneway";	
-         oneway = TRUE;
+         s_oneway = "oneway";
       } 
 
-      if(!remote && !oneway) {
-         ui_error("You must select at least one ARP mode");
-         return;
-      }
       snprintf(params, PARAMS_LEN+1, "arp:%s%s%s", s_remote, comma, s_oneway);
       gtkui_start_mitm();
    }
@@ -254,7 +248,7 @@ void gtkui_port_stealing(void)
       if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON (button2))) {
          if(remote)
               comma = ",";
-	 tree = "tree";
+         tree = "tree";
       }
   
       snprintf(params, PARAMS_LEN+1, "port:%s%s%s", s_remote, comma, tree); 
@@ -362,7 +356,6 @@ void gtkui_ndp_poisoning(void)
    GtkWidget *dialog, *vbox, *hbox, *image, *button1, *button2, *frame, *content_area;
    gint response = 0;
    gboolean remote = FALSE;
-   gboolean oneway = FALSE;
 
    DEBUG_MSG("gtk_ndp_poisoning");
 //   not needed, the \0 is already appended from snprintf
@@ -421,13 +414,8 @@ void gtkui_ndp_poisoning(void)
             comma = ",";
 
          s_oneway = "oneway";
-         oneway = TRUE;
       } 
 
-      if(!remote && !oneway) {
-         ui_error("You must select at least one NDP mode");
-         return;
-      }
       snprintf(params, PARAMS_LEN+1, "ndp:%s%s%s", 
             s_remote, comma, s_oneway);
       gtkui_start_mitm();

--- a/src/interfaces/gtk/ec_gtk_mitm.c
+++ b/src/interfaces/gtk/ec_gtk_mitm.c
@@ -76,6 +76,7 @@ void gtkui_arp_poisoning(void)
    gtk_widget_show(vbox);
 
    button1 = gtk_check_button_new_with_label("Sniff remote connections.");
+   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON (button1), TRUE);
    gtk_box_pack_start(GTK_BOX (vbox), button1, FALSE, FALSE, 0);
    gtk_widget_show(button1);
 
@@ -392,6 +393,7 @@ void gtkui_ndp_poisoning(void)
    gtk_widget_show(vbox);
 
    button1 = gtk_check_button_new_with_label("Sniff remote connections.");
+   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON (button1), TRUE);
    gtk_box_pack_start(GTK_BOX (vbox), button1, FALSE, FALSE, 0);
    gtk_widget_show(button1);
 

--- a/src/interfaces/gtk3/ec_gtk3_mitm.c
+++ b/src/interfaces/gtk3/ec_gtk3_mitm.c
@@ -40,7 +40,6 @@ void gtkui_arp_poisoning(GSimpleAction *action, GVariant *value, gpointer data)
    GtkWidget *dialog, *vbox, *hbox, *image, *button1, *button2, *frame, *content_area;
    gint response = 0;
    gboolean remote = FALSE;
-   gboolean oneway = FALSE;
 
    (void) action;
    (void) value;
@@ -94,22 +93,16 @@ void gtkui_arp_poisoning(GSimpleAction *action, GVariant *value, gpointer data)
       const char *s_remote = "", *comma = "", *s_oneway = "";
 
       if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON (button1))) {
-	s_remote="remote";
+        s_remote="remote";
         remote = TRUE;
       }
 
       if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON (button2))) {
          if(remote)
-		comma = ",";
-
-	 s_oneway = "oneway";	
-         oneway = TRUE;
+           comma = ",";
+         s_oneway = "oneway";
       } 
 
-      if(!remote && !oneway) {
-         ui_error("You must select at least one ARP mode");
-         return;
-      }
       snprintf(params, PARAMS_LEN+1, "arp:%s%s%s", s_remote, comma, s_oneway);
       gtkui_start_mitm();
    }
@@ -266,8 +259,8 @@ void gtkui_port_stealing(GSimpleAction *action, GVariant *value, gpointer data)
    
       if(gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON (button2))) {
          if(remote)
-              comma = ",";
-	 tree = "tree";
+            comma = ",";
+         tree = "tree";
       }
   
       snprintf(params, PARAMS_LEN+1, "port:%s%s%s", s_remote, comma, tree); 
@@ -379,7 +372,6 @@ void gtkui_ndp_poisoning(GSimpleAction *action, GVariant *value, gpointer data)
    GtkWidget *dialog, *vbox, *hbox, *image, *button1, *button2, *frame, *content_area;
    gint response = 0;
    gboolean remote = FALSE;
-   gboolean oneway = FALSE;
 
    (void) action;
    (void) value;
@@ -442,13 +434,8 @@ void gtkui_ndp_poisoning(GSimpleAction *action, GVariant *value, gpointer data)
             comma = ",";
 
          s_oneway = "oneway";
-         oneway = TRUE;
       } 
 
-      if(!remote && !oneway) {
-         ui_error("You must select at least one NDP mode");
-         return;
-      }
       snprintf(params, PARAMS_LEN+1, "ndp:%s%s%s", 
             s_remote, comma, s_oneway);
       gtkui_start_mitm();

--- a/src/interfaces/gtk3/ec_gtk3_mitm.c
+++ b/src/interfaces/gtk3/ec_gtk3_mitm.c
@@ -80,6 +80,7 @@ void gtkui_arp_poisoning(GSimpleAction *action, GVariant *value, gpointer data)
    gtk_widget_show(vbox);
 
    button1 = gtk_check_button_new_with_label("Sniff remote connections.");
+   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON (button1), TRUE);
    gtk_box_pack_start(GTK_BOX (vbox), button1, FALSE, FALSE, 0);
    gtk_widget_show(button1);
 
@@ -412,6 +413,7 @@ void gtkui_ndp_poisoning(GSimpleAction *action, GVariant *value, gpointer data)
    gtk_widget_show(vbox);
 
    button1 = gtk_check_button_new_with_label("Sniff remote connections.");
+   gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON (button1), TRUE);
    gtk_box_pack_start(GTK_BOX (vbox), button1, FALSE, FALSE, 0);
    gtk_widget_show(button1);
 

--- a/src/mitm/ec_ip6nd_poison.c
+++ b/src/mitm/ec_ip6nd_poison.c
@@ -74,8 +74,6 @@ static int ndp_poison_start(char *args)
          else
             SEMIFATAL_ERROR("NDP poisoning: incorrect arguments.\n");
       }
-   } else {
-      SEMIFATAL_ERROR("NDP poisoning: missing arguments.\n");
    }
 
    /* we need the host list */


### PR DESCRIPTION
According to the man page both parameters for the NDP MITM attack are
optional:
```
ndp ([remote],[oneway])
```

But ettercap aborted with the following error message:
```
$ sudo ettercap -Tq6i eth0 -M ndp /// ///
[...]
FATAL: NDP poisoning: missing arguments.
$ echo $?
255
```

With this patch the NDP MITM attack without any parameters works as
expected.