### PR TITLE
Activate TLS support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,7 @@ addons:
       - libssl-dev
       - libgtk-3-dev
       - libgeoip-dev
+    update: true
 
 env:
   # Default build. Release.

--- a/src/ec_sslwrap.c
+++ b/src/ec_sslwrap.c
@@ -1150,8 +1150,8 @@ static void sslw_init(void)
    SSL_library_init();
 
    /* Create the two global CTX */
-   ssl_ctx_client = SSL_CTX_new(SSLv23_server_method());
-   ssl_ctx_server = SSL_CTX_new(SSLv23_client_method());
+   ssl_ctx_client = SSL_CTX_new(TLS_server_method());
+   ssl_ctx_server = SSL_CTX_new(TLS_client_method());
 
    ON_ERROR(ssl_ctx_client, NULL, "Could not create client SSL CTX");
    ON_ERROR(ssl_ctx_server, NULL, "Could not create server SSL CTX");


### PR DESCRIPTION
The way the OpenSSL context is being initialized is limited to SSLv2 and v3.
I think there is no rationale necessary to adjust this to the most common TLS versions nowadays.....