### PR TITLE
Fix new warnings due to new gcc version

### DIFF
--- a/src/dissectors/ec_bgp.c
+++ b/src/dissectors/ec_bgp.c
@@ -179,7 +179,7 @@ FUNC_DECODER(dissector_bgp)
          
          /* Get authentication data */
          if (length > 1) {
-            snprintf(PACKET->DISSECTOR.pass, 4, "Hex(");
+            snprintf(PACKET->DISSECTOR.pass, 5, "Hex(");
             str_ptr = PACKET->DISSECTOR.pass + strlen(PACKET->DISSECTOR.pass);
 
             for (j = 0; j < (length-1); j++) {

--- a/src/dissectors/ec_smb.c
+++ b/src/dissectors/ec_smb.c
@@ -253,7 +253,7 @@ FUNC_DECODER(dissector_smb)
                if (pwlen > 1) 
                   memcpy(session_data->response1, Blob, sizeof(session_data->response1) - 1);
                else
-                  snprintf((char*)session_data->response1, 7, "(empty)");
+                  snprintf((char*)session_data->response1, 8, "(empty)");
 
                IF_IN_PCK(Blob, PACKET)		  	 
                   Blob = GetUser(Blob+pwlen+unilen, session_data->user, 200);
@@ -336,7 +336,7 @@ FUNC_DECODER(dissector_smb)
                     memcmp(session_data->response1, "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00", 24) ) {
                     memset(session_data->response1, 0, 24);
                     memset(session_data->response2, 0, 24);
-                    strncpy((char*)session_data->user, "(empty)", 7);
+                    strncpy((char*)session_data->user, "(empty)", 8);
                     session_data->domain[0]=0;		    		    
                }
 	       

--- a/src/dissectors/ec_vnc.c
+++ b/src/dissectors/ec_vnc.c
@@ -240,7 +240,7 @@ FUNC_DECODER(dissector_vnc)
                SAFE_CALLOC(PACKET->DISSECTOR.pass, 256, sizeof(char));
 
                /* Dump Challenge and Response */
-               snprintf(PACKET->DISSECTOR.pass, 10, "Challenge:");
+               snprintf(PACKET->DISSECTOR.pass, 11, "Challenge:");
                str_ptr = (u_char*)PACKET->DISSECTOR.pass + strlen(PACKET->DISSECTOR.pass);
 
                for (index = 0; index < 16; index++)

--- a/src/ec_fingerprint.c
+++ b/src/ec_fingerprint.c
@@ -134,7 +134,7 @@ int fingerprint_search(const char *f, char *dst)
   
    //Do not process if length is invalid
    if (!strcmp(f, "") || strlen(f) != FINGER_LEN) {
-      strncpy(dst, "UNKNOWN", 7);
+      strncpy(dst, "UNKNOWN", 8);
       return E_SUCCESS;
    }
    
@@ -220,41 +220,41 @@ void fingerprint_push(char *finger, int param, int value)
    switch (param) {
       case FINGER_WINDOW:
          snprintf(tmp, sizeof(tmp), "%04X", value);
-         strncpy(finger + FINGER_WINDOW, tmp, 4);
+         strncpy(finger + FINGER_WINDOW, tmp, 5);
          break;
       case FINGER_MSS:
          snprintf(tmp, sizeof(tmp), "%04X", value);
-         strncpy(finger + FINGER_MSS, tmp, 4);
+         strncpy(finger + FINGER_MSS, tmp, 5);
          break;
       case FINGER_TTL:
          snprintf(tmp, sizeof(tmp), "%02X", TTL_PREDICTOR(value));
-         strncpy(finger + FINGER_TTL, tmp, 2);
+         strncpy(finger + FINGER_TTL, tmp, 3);
          break;
       case FINGER_WS:
          snprintf(tmp, sizeof(tmp), "%02X", value);
-         strncpy(finger + FINGER_WS, tmp, 2);
+         strncpy(finger + FINGER_WS, tmp, 3);
          break;
       case FINGER_SACK:
          snprintf(tmp, sizeof(tmp), "%d", value);
-         strncpy(finger + FINGER_SACK, tmp, 1);
+         strncpy(finger + FINGER_SACK, tmp, 2);
          break;
       case FINGER_NOP:
          snprintf(tmp, sizeof(tmp), "%d", value);
-         strncpy(finger + FINGER_NOP, tmp, 1);
+         strncpy(finger + FINGER_NOP, tmp, 2);
          break;
       case FINGER_DF:
          snprintf(tmp, sizeof(tmp), "%d", value);
-         strncpy(finger + FINGER_DF, tmp, 1);
+         strncpy(finger + FINGER_DF, tmp, 2);
          break;
       case FINGER_TIMESTAMP:
          snprintf(tmp, sizeof(tmp), "%d", value);
-         strncpy(finger + FINGER_TIMESTAMP, tmp, 1);
+         strncpy(finger + FINGER_TIMESTAMP, tmp, 2);
          break;
       case FINGER_TCPFLAG:
          if (value == 1)
-            strncpy(finger + FINGER_TCPFLAG, "A", 1);
+            strncpy(finger + FINGER_TCPFLAG, "A", 2);
          else
-            strncpy(finger + FINGER_TCPFLAG, "S", 1);
+            strncpy(finger + FINGER_TCPFLAG, "S", 2);
          break;
       case FINGER_LT:
          /*
@@ -264,7 +264,7 @@ void fingerprint_push(char *finger, int param, int value)
           */
          lt_old = strtoul(finger + FINGER_LT, NULL, 16);
          snprintf(tmp, sizeof(tmp), "%02X", value + lt_old);
-         strncpy(finger + FINGER_LT, tmp, 2);
+         strncpy(finger + FINGER_LT, tmp, 3);
          break;                                 
    }
 }

--- a/src/ec_inet.c
+++ b/src/ec_inet.c
@@ -224,7 +224,7 @@ inet_ntop4(const u_char *src, char *dst, size_t size)
    char str[IP_ASCII_ADDR_LEN];
    int n;
    
-	n = snprintf(str, IP_ASCII_ADDR_LEN, "%u.%u.%u.%u", src[0], src[1], src[2], src[3]);
+   n = snprintf(str, IP_ASCII_ADDR_LEN, "%u.%u.%u.%u", src[0], src[1], src[2], src[3]);
    
    str[n] = '\0';
  
@@ -236,90 +236,90 @@ inet_ntop4(const u_char *src, char *dst, size_t size)
 const char *
 inet_ntop6(const u_char *src, char *dst, size_t size)
 {
-	/*
-	 * Note that int32_t and int16_t need only be "at least" large enough
-	 * to contain a value of the specified size.  On some systems, like
-	 * Crays, there is no such thing as an integer variable with 16 bits.
-	 * Keep this in mind if you think this function should have been coded
-	 * to use pointer overlays.  All the world's not a VAX.
-	 */
-	char tmp[IP6_ASCII_ADDR_LEN], *tp;
-	struct { int base, len; } best, cur;
-	u_int words[NS_IN6ADDRSZ / NS_INT16SZ];
-	int i;
+   /*
+    * Note that int32_t and int16_t need only be "at least" large enough
+    * to contain a value of the specified size.  On some systems, like
+    * Crays, there is no such thing as an integer variable with 16 bits.
+    * Keep this in mind if you think this function should have been coded
+    * to use pointer overlays.  All the world's not a VAX.
+    */
+   char tmp[IP6_ASCII_ADDR_LEN], *tp;
+   struct { int base, len; } best, cur;
+   u_int words[NS_IN6ADDRSZ / NS_INT16SZ];
+   int i;
 
-	best.len = 0;
-	cur.len = 0;
+   best.len = 0;
+   cur.len = 0;
 
-	/*
-	 * Preprocess:
-	 *	Copy the input (bytewise) array into a wordwise array.
-	 *	Find the longest run of 0x00's in src[] for :: shorthanding.
-	 */
-	memset(words, '\0', sizeof words);
-	for (i = 0; i < NS_IN6ADDRSZ; i += 2)
-		words[i / 2] = (src[i] << 8) | src[i + 1];
-	best.base = -1;
-	cur.base = -1;
-	for (i = 0; i < (NS_IN6ADDRSZ / NS_INT16SZ); i++) {
-		if (words[i] == 0) {
-			if (cur.base == -1)
-				cur.base = i, cur.len = 1;
-			else
-				cur.len++;
-		} else {
-			if (cur.base != -1) {
-				if (best.base == -1 || cur.len > best.len)
-					best = cur;
-				cur.base = -1;
-			}
-		}
-	}
-	if (cur.base != -1) {
-		if (best.base == -1 || cur.len > best.len)
-			best = cur;
-	}
-	if (best.base != -1 && best.len < 2)
-		best.base = -1;
+   /*
+    * Preprocess:
+    *   Copy the input (bytewise) array into a wordwise array.
+    *   Find the longest run of 0x00's in src[] for :: shorthanding.
+    */
+   memset(words, '\0', sizeof words);
+   for (i = 0; i < NS_IN6ADDRSZ; i += 2)
+      words[i / 2] = (src[i] << 8) | src[i + 1];
+   best.base = -1;
+   cur.base = -1;
+   for (i = 0; i < (NS_IN6ADDRSZ / NS_INT16SZ); i++) {
+      if (words[i] == 0) {
+         if (cur.base == -1)
+            cur.base = i, cur.len = 1;
+         else
+            cur.len++;
+      } else {
+         if (cur.base != -1) {
+            if (best.base == -1 || cur.len > best.len)
+               best = cur;
+            cur.base = -1;
+         }
+      }
+   }
+   if (cur.base != -1) {
+      if (best.base == -1 || cur.len > best.len)
+         best = cur;
+   }
+   if (best.base != -1 && best.len < 2)
+      best.base = -1;
 
-	/*
-	 * Format the result.
-	 */
-	tp = tmp;
-	for (i = 0; i < (NS_IN6ADDRSZ / NS_INT16SZ); i++) {
-		/* Are we inside the best run of 0x00's? */
-		if (best.base != -1 && i >= best.base &&
-		    i < (best.base + best.len)) {
-			if (i == best.base)
-				*tp++ = ':';
-			continue;
-		}
-		/* Are we following an initial run of 0x00s or any real hex? */
-		if (i != 0)
-			*tp++ = ':';
-		/* Is this address an encapsulated IPv4? */
-		if (i == 6 && best.base == 0 &&
-		    (best.len == 6 || (best.len == 5 && words[5] == 0xffff))) {
-			if (inet_ntop4(src+12, tp, IP_ASCII_ADDR_LEN) != 0)
-				return (NULL);
-			tp += strlen(tp);
-			break;
-		}
-		tp += sprintf(tp, "%x", words[i]);
-	}
-	/* Was it a trailing run of 0x00's? */
-	if (best.base != -1 && (best.base + best.len) == 
-	    (NS_IN6ADDRSZ / NS_INT16SZ))
-		*tp++ = ':';
-	*tp++ = '\0';
+   /*
+    * Format the result.
+    */
+   tp = tmp;
+   for (i = 0; i < (NS_IN6ADDRSZ / NS_INT16SZ); i++) {
+      /* Are we inside the best run of 0x00's? */
+      if (best.base != -1 && i >= best.base &&
+          i < (best.base + best.len)) {
+         if (i == best.base)
+            *tp++ = ':';
+         continue;
+      }
+      /* Are we following an initial run of 0x00s or any real hex? */
+      if (i != 0)
+         *tp++ = ':';
+      /* Is this address an encapsulated IPv4? */
+      if (i == 6 && best.base == 0 &&
+          (best.len == 6 || (best.len == 5 && words[5] == 0xffff))) {
+         if (inet_ntop4(src+12, tp, IP_ASCII_ADDR_LEN) != 0)
+            return (NULL);
+         tp += strlen(tp);
+         break;
+      }
+      tp += sprintf(tp, "%x", words[i]);
+   }
+   /* Was it a trailing run of 0x00's? */
+   if (best.base != -1 && (best.base + best.len) == 
+       (NS_IN6ADDRSZ / NS_INT16SZ))
+      *tp++ = ':';
+   *tp++ = '\0';
 
-  	/*
-	 * Check for overflow, copy, and we're done.
-	 */
-	if ((size_t)(tp - tmp) > size) {
-		__set_errno (ENOSPC);
-		return (NULL);
-	}
+     /*
+    * Check for overflow, copy, and we're done.
+    */
+   if ((size_t)(tp - tmp) > size) {
+      __set_errno (ENOSPC);
+      return (NULL);
+   }
 
    strncpy(dst, tmp, size);
    
@@ -357,7 +357,7 @@ char *mac_addr_ntoa(u_char *mac, char *dst)
    char str[ETH_ASCII_ADDR_LEN];
    int n;
    
-	n = snprintf(str, ETH_ASCII_ADDR_LEN, "%02X:%02X:%02X:%02X:%02X:%02X", 
+   n = snprintf(str, ETH_ASCII_ADDR_LEN, "%02X:%02X:%02X:%02X:%02X:%02X", 
          mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
    
    str[n] = '\0';
@@ -455,7 +455,7 @@ int ip_addr_is_multicast(struct ip_addr *ip)
       default:
          return -E_INVALID;
    }
-	return 0;
+   return 0;
 }
 
 /*
@@ -464,36 +464,38 @@ int ip_addr_is_multicast(struct ip_addr *ip)
  */
 int ip_addr_is_broadcast(struct ip_addr *sa)
 {
-	struct ip_addr *nw;
-	struct ip_addr *nm;
+   struct ip_addr *nw;
+   struct ip_addr *nm;
 
-	u_int32* address;
-	u_int32* netmask;
-	u_int32* network;
-	u_int32 broadcast;
+   u_int32* address;
+   u_int32* netmask;
+   u_int32* network;
+   u_int32 broadcast;
 
-	switch(ntohs(sa->addr_type)) {
-		case AF_INET:
+   switch(ntohs(sa->addr_type)) {
+      case AF_INET:
          if(!EC_GBL_IFACE->has_ipv4)
             return -E_INVALID;
-			nm = &EC_GBL_IFACE->netmask;
-			nw = &EC_GBL_IFACE->network;
-		
+         nm = &EC_GBL_IFACE->netmask;
+         nw = &EC_GBL_IFACE->network;
+
          /* 255.255.255.255 is definitely broadcast */
          if(!memcmp(sa->addr, "\xff\xff\xff\xff", IP_ADDR_LEN))
             return E_SUCCESS;
 
-			address = sa->addr32;
-			netmask = nm->addr32;
-			network = nw->addr32;
+         address = sa->addr32;
+         netmask = nm->addr32;
+         network = nw->addr32;
 
-			broadcast = (*network) | ~(*netmask);
+         broadcast = (*network) | ~(*netmask);
 
-			if (broadcast == *address)
-				return E_SUCCESS;
-		case AF_INET6:
-			if(!EC_GBL_IFACE->has_ipv6)
-				return -E_INVALID;
+         if (broadcast == *address)
+            return E_SUCCESS;
+
+         break;
+      case AF_INET6:
+         if(!EC_GBL_IFACE->has_ipv6)
+            return -E_INVALID;
 
          /* IPv6 has no such thing as a broadcast address. The closest
           * equivalent is the multicast address ff02::1. Packets sent to that
@@ -502,10 +504,10 @@ int ip_addr_is_broadcast(struct ip_addr *sa)
          if(!memcmp(sa->addr, IP6_ALL_NODES, IP6_ADDR_LEN))
             return E_SUCCESS;
          
-			break;
-	}
+         break;
+   }
 
-	return -E_NOTFOUND;
+   return -E_NOTFOUND;
 }
 
 /*

--- a/src/ec_log.c
+++ b/src/ec_log.c
@@ -115,6 +115,7 @@ int set_loglevel(int level, char *filename)
          hook_add(HOOK_DISPATCHER, &log_packet);
 
          /* no break here, loglevel is incremental */
+         __attribute__((fallthrough));
          
       case LOG_INFO:
          if (EC_GBL_OPTIONS->compress) {

--- a/src/ec_log.c
+++ b/src/ec_log.c
@@ -115,7 +115,7 @@ int set_loglevel(int level, char *filename)
          hook_add(HOOK_DISPATCHER, &log_packet);
 
          /* no break here, loglevel is incremental */
-         __attribute__((fallthrough));
+         /* fall through */
          
       case LOG_INFO:
          if (EC_GBL_OPTIONS->compress) {

--- a/src/ec_parser.c
+++ b/src/ec_parser.c
@@ -343,7 +343,7 @@ void parse_options(int argc, char **argv)
          case 'Q':
                   set_superquiet();
                   /* no break, quiet must be enabled */
-                  __attribute__((fallthrough));
+                  /* fall through */
          case 'q':
 		  set_quiet();
                   break;

--- a/src/ec_parser.c
+++ b/src/ec_parser.c
@@ -343,6 +343,7 @@ void parse_options(int argc, char **argv)
          case 'Q':
                   set_superquiet();
                   /* no break, quiet must be enabled */
+                  __attribute__((fallthrough));
          case 'q':
 		  set_quiet();
                   break;

--- a/src/interfaces/curses/ec_curses_hosts.c
+++ b/src/interfaces/curses/ec_curses_hosts.c
@@ -267,7 +267,7 @@ static void curses_create_hosts_array(void)
    char name[MAX_HOSTNAME_LEN];
    size_t nhosts;
 
-#define MAX_DESC_LEN 70
+#define MAX_DESC_LEN MAX_ASCII_ADDR_LEN*2 + MAX_HOSTNAME_LEN + 4
    
    DEBUG_MSG("curses_create_hosts_array");
    

--- a/src/interfaces/curses/ec_curses_targets.c
+++ b/src/interfaces/curses/ec_curses_targets.c
@@ -103,7 +103,7 @@ static void curses_select_protocol(void)
    /* this will contain 'all', 'tcp' or 'udp' */
    if (!EC_GBL_OPTIONS->proto) {
       SAFE_CALLOC(EC_GBL_OPTIONS->proto, 4, sizeof(char));
-      strncpy(EC_GBL_OPTIONS->proto, "all", 3);
+      strncpy(EC_GBL_OPTIONS->proto, "all", 4);
    }
 
    curses_input("Protocol :", EC_GBL_OPTIONS->proto, 3, set_protocol);

--- a/src/interfaces/curses/widgets/wdg_file.c
+++ b/src/interfaces/curses/widgets/wdg_file.c
@@ -482,8 +482,8 @@ static void wdg_file_menu_create(struct wdg_object *wo)
           * transform the current dir into the root.
           * useful to exit from a path whose parent is not readable 
           */
-         if (!strcmp(ww->namelist[i]->d_name, ".")) {
-            strncpy(ww->namelist[i]->d_name, "/", 1);
+         if (*ww->namelist[i]->d_name == '.') {
+            *ww->namelist[i]->d_name = '/';
             ww->nitems++;
             WDG_SAFE_REALLOC(ww->items, ww->nitems * sizeof(ITEM *));
             ww->items[ww->nitems - 1] = new_item(ww->namelist[i]->d_name, "root");

--- a/src/interfaces/gtk3/ec_gtk3_conf.c
+++ b/src/interfaces/gtk3/ec_gtk3_conf.c
@@ -78,8 +78,7 @@ void gtkui_conf_read(void) {
      if(!p)
          continue;
       *p = '\0';
-      snprintf(name, sizeof(name), "%s", line);
-      strlcpy(name, line, sizeof(name) - 1);
+      strlcpy(name, line, sizeof(name));
       g_strstrip(name);
       value = atoi(p + 1);
       gtkui_conf_set(name, value);

--- a/src/interfaces/gtk3/ec_gtk3_hosts.c
+++ b/src/interfaces/gtk3/ec_gtk3_hosts.c
@@ -463,8 +463,7 @@ void gtkui_button_callback(GtkWidget *widget, gpointer data)
       }
 
       /* free the list of selections */
-      g_list_foreach (list,(GFunc) gtk_tree_path_free, NULL);
-      g_list_free (list);
+      g_list_free_full(list, (GDestroyNotify)gtk_tree_path_free);
    }
 }
 

--- a/src/interfaces/gtk3/ec_gtk3_targets.c
+++ b/src/interfaces/gtk3/ec_gtk3_targets.c
@@ -96,7 +96,7 @@ void gtkui_select_protocol(GSimpleAction *action, GVariant *value, gpointer data
    /* this will contain 'all', 'tcp' or 'udp' */
    if (!EC_GBL_OPTIONS->proto) {
       SAFE_CALLOC(EC_GBL_OPTIONS->proto, 4, sizeof(char));
-      strncpy(EC_GBL_OPTIONS->proto, "all", 3);
+      strncpy(EC_GBL_OPTIONS->proto, "all", 4);
    }
 
    /* create dialog for selecting the protocol */
@@ -688,8 +688,7 @@ static void gtkui_delete_targets(GtkWidget *widget, gpointer data) {
    
    /* free the list of selections */
    if(list) {
-      g_list_foreach (list,(GFunc) gtk_tree_path_free, NULL);
-      g_list_free (list);
+      g_list_free_full(list, (GDestroyNotify)gtk_tree_path_free);
    }
 }
 

--- a/src/interfaces/gtk3/ec_gtk3_view.c
+++ b/src/interfaces/gtk3/ec_gtk3_view.c
@@ -474,11 +474,11 @@ void gtkui_vis_method(GSimpleAction *action, GVariant *value, gpointer data)
       memset(vmethod, 0, VLEN);
 
       switch(active) {
-         case 6: strncpy(vmethod, "hex", 3); break;
-         case 5: strncpy(vmethod, "ascii", 5); break; 
-         case 4: strncpy(vmethod, "text", 4); break;
-         case 3: strncpy(vmethod, "ebcdic", 6); break;
-         case 2: strncpy(vmethod, "html", 4); break;
+         case 6: strncpy(vmethod, "hex", 4); break;
+         case 5: strncpy(vmethod, "ascii", 6); break; 
+         case 4: strncpy(vmethod, "text", 5); break;
+         case 3: strncpy(vmethod, "ebcdic", 7); break;
+         case 2: strncpy(vmethod, "html", 5); break;
          case 1: /* utf8 */
             /* copy first word from encoding choice */
             gtk_combo_box_get_active_iter(GTK_COMBO_BOX(lang_combo), &iter);
@@ -487,11 +487,12 @@ void gtkui_vis_method(GSimpleAction *action, GVariant *value, gpointer data)
             i=sscanf(selected_lang, "%[^ ]", encoding);
             BUG_IF(i!=1);
             if(strlen(encoding) > 0) {
-               strncpy(vmethod, "utf8", 4);
+               strncpy(vmethod, "utf8", 5);
                set_utf8_encoding(encoding);
                break;
             }
-         default: strncpy(vmethod, "ascii", 5);
+            __attribute__((fallthrough));
+         default: strncpy(vmethod, "ascii", 6);
       }
 
       set_format(vmethod);

--- a/src/interfaces/gtk3/ec_gtk3_view.c
+++ b/src/interfaces/gtk3/ec_gtk3_view.c
@@ -491,7 +491,7 @@ void gtkui_vis_method(GSimpleAction *action, GVariant *value, gpointer data)
                set_utf8_encoding(encoding);
                break;
             }
-            __attribute__((fallthrough));
+            /* fall through */
          default: strncpy(vmethod, "ascii", 6);
       }
 

--- a/src/interfaces/text/ec_text_display.c
+++ b/src/interfaces/text/ec_text_display.c
@@ -118,10 +118,10 @@ static void display_headers(struct packet_object *po)
    /* determine the proto */
    switch(po->L4.proto) {
       case NL_TYPE_TCP:
-         strncpy(proto, "TCP", 3);
+         strncpy(proto, "TCP", 4);
          break;
       case NL_TYPE_UDP:
-         strncpy(proto, "UDP", 3);
+         strncpy(proto, "UDP", 4);
          break;
    }
    

--- a/src/os/ec_linux.c
+++ b/src/os/ec_linux.c
@@ -283,6 +283,7 @@ void disable_interface_offload(void)
 			_exit(-E_INVALID);
 		case -1:
 			safe_free_mem(param, &param_length, command);
+         break;
 		default:
 			safe_free_mem(param, &param_length, command);
 			wait(&ret_val);

--- a/src/protocols/ec_icmp.c
+++ b/src/protocols/ec_icmp.c
@@ -111,6 +111,7 @@ FUNC_DECODER(decode_icmp)
                PACKET->PASSIVE.flags |= FP_ROUTER;
                break;
          }
+         break;
       case ICMP_REDIRECT:
       case ICMP_TIME_EXCEEDED:
          PACKET->PASSIVE.flags |= FP_ROUTER;


### PR DESCRIPTION
Since GCC7, some things trigger warnings which wasn't the case before.
Fixing the code avoiding these warnings while retaining the functionality.
Additionally the intendiation has been harmonized in `ec_inet.c`.
