### PR TITLE
Fix #937 - Build failure in ec_stdint.h/wdg.c on Alpine with GCC 8.3

### DIFF
--- a/src/interfaces/curses/widgets/wdg.h
+++ b/src/interfaces/curses/widgets/wdg.h
@@ -14,7 +14,7 @@
    #include <windows.h>
 #endif
 
-#ifdef OS_DARWIN
+#if defined(OS_DARWIN) || defined(OS_LINUX)
    #include <sys/types.h>
 #endif
 


### PR DESCRIPTION
Minor tweak to imports in `wdg.h` to unconditionally include `sys/types.h` on Linux.

Fixes #937