### PR TITLE
remove deprecated redirect commands

### DIFF
--- a/share/etter.conf.v4
+++ b/share/etter.conf.v4
@@ -170,11 +170,6 @@ geoip_data_file_v6 = "/usr/local/share/GeoIP/GeoIPv6.dat"
 #     Linux 
 #---------------
 
-# if you use ipchains:
-   #redir_command_on = "ipchains -A input -i %iface -p tcp -s %source -d %destination %port -j REDIRECT %rport"
-   #redir_command_off = "ipchains -D input -i %iface -p tcp -s %source -d %destination %port -j REDIRECT %rport"
-
-# if you use iptables:
    #redir_command_on = "iptables -t nat -A PREROUTING -i %iface -p tcp -s %source -d %destination --dport %port -j REDIRECT --to-port %rport"
    #redir_command_off = "iptables -t nat -D PREROUTING -i %iface -p tcp -s %source -d %destination --dport %port -j REDIRECT --to-port %rport"
 
@@ -182,11 +177,6 @@ geoip_data_file_v6 = "/usr/local/share/GeoIP/GeoIPv6.dat"
 #    Mac Os X
 #---------------
 
-# if you use ipfw:
-   #redir_command_on = "ipfw -q add set %set fwd 127.0.0.1,%rport tcp from %source to %destination %port in via %iface"
-   #redir_command_off = "ipfw -q delete set %set"
-
-# if you use BSD PF:
    #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from %source to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
    #redir_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet .+ %source to %destination port = %port' | pfctl -f - 2> /dev/null"
 

--- a/share/etter.conf.v6
+++ b/share/etter.conf.v6
@@ -176,11 +176,6 @@ geoip_data_file_v6 = "/usr/local/share/GeoIP/GeoIPv6.dat"
 #     Linux 
 #---------------
 
-# if you use ipchains:
-   #redir_command_on = "ipchains -A input -i %iface -p tcp -s %source -d %destination %port -j REDIRECT %rport"
-   #redir_command_off = "ipchains -D input -i %iface -p tcp -s %source -d %destination %port -j REDIRECT %rport"
-
-# if you use iptables:
    #redir_command_on = "iptables -t nat -A PREROUTING -i %iface -p tcp -s %source -d %destination --dport %port -j REDIRECT --to-port %rport"
    #redir_command_off = "iptables -t nat -D PREROUTING -i %iface -p tcp -s %source -d %destination --dport %port -j REDIRECT --to-port %rport"
 
@@ -192,11 +187,6 @@ geoip_data_file_v6 = "/usr/local/share/GeoIP/GeoIPv6.dat"
 #    Mac Os X
 #---------------
 
-# if you use ipfw:
-   #redir_command_on = "ipfw -q add set %set fwd 127.0.0.1,%rport tcp from %source to %destination %port in via %iface"
-   #redir_command_off = "ipfw -q delete set %set"
-
-# if you use BSD PF:
    #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from %source to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
    #redir_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet .+ %source to %destination port = %port' | pfctl -f - 2> /dev/null"
 


### PR DESCRIPTION
Finally get rid of deprecated traffic redirect commands for MacOSX and Linux.
Solves #611 