### PR TITLE
Fix #922 segmentation fault when parsing NTLM/HTTP handshake

### DIFF
--- a/src/dissectors/ec_http.c
+++ b/src/dissectors/ec_http.c
@@ -501,7 +501,7 @@ static int Parse_NTLM_Auth(char *ptr, char *from_here, struct packet_object *po)
           */  
          if (conn_status->c_status == NTLM_WAIT_RESPONSE) {
             /* Fill the user and passwords */
-            response_struct  = (tSmbNtlmAuthResponse *) to_decode;
+            response_struct  = (tSmbNtlmAuthResponse *) decoded;
             po->DISSECTOR.user = strdup(GetUnicodeString(response_struct, uUser));
             SAFE_CALLOC(po->DISSECTOR.pass, strlen(po->DISSECTOR.user) + 150, sizeof(char));
             snprintf(po->DISSECTOR.pass, strlen(po->DISSECTOR.user) + 150, "(NTLM) %s:\"\":\"\":", po->DISSECTOR.user);


### PR DESCRIPTION
This pull request fixes a segmentation fault when parsing a complete NTLM HTTP handshake.
This has been uncovered with the help of debug data provided in issue #922 .

The basic issue is that the NTLM data in the HTTP header is Base64 encoded.
If the message Type of the Base64 decoded NTLM Header is 3 which seem to stand for NTLM Auth Response, the whole header is falsely interpreted from the Base64 **un**decoded data.
This led to crap values in the auth response structure.
Crap value in the offset member caused the byte pointer to be forwarded way too far within the `unicodeToString()` function effectively causing the memory corruption.
