### PR TITLE
fix crash if one redirect command is not enabled

### DIFF
--- a/src/ec_redirect.c
+++ b/src/ec_redirect.c
@@ -113,6 +113,12 @@ int ec_redirect(ec_redir_act_t action, char *name, ec_redir_proto_t proto,
             }
          }
          command = commands[EC_REDIR_COMMAND_INSERT];
+         if (command == NULL) {
+            DEBUG_MSG("ec_redirect(): redirect insert command for %s desired "
+                  "but not set in etter.conf - skipping...",
+                  proto == EC_REDIR_PROTO_IPV4 ? "IPv4" : "IPv6");
+            return -E_NOTHANDLED;
+         }
          break;
       case EC_REDIR_ACTION_REMOVE:
          /* check if entry is still present */
@@ -123,6 +129,12 @@ int ec_redirect(ec_redir_act_t action, char *name, ec_redir_proto_t proto,
                 sport == re->from_port && dport == re->to_port) {
                /* entry present - ready to be removed */
                command = commands[EC_REDIR_COMMAND_REMOVE];
+               if (command == NULL) {
+                  DEBUG_MSG("ec_redirect(): redirect insert command for %s "
+                        "desired but not set in etter.conf - skipping...",
+                        proto == EC_REDIR_PROTO_IPV4 ? "IPv4" : "IPv6");
+                  return -E_NOTHANDLED;
+               }
                break;
             }
          }

--- a/src/interfaces/gtk/ec_gtk.c
+++ b/src/interfaces/gtk/ec_gtk.c
@@ -150,7 +150,8 @@ static void gtkui_fatal_error_wrap(const char *msg) {
 
    char *copy = strdup(msg);
    if (msg) {
-      g_idle_add(gtkui_fatal_error_shim, copy);
+      gtkui_fatal_error_shim(copy);
+      //g_idle_add(gtkui_fatal_error_shim, copy);
    } else {
       FATAL_ERROR("out of memory");
    }

--- a/src/interfaces/gtk3/ec_gtk3.c
+++ b/src/interfaces/gtk3/ec_gtk3.c
@@ -155,7 +155,8 @@ static void gtkui_fatal_error_wrap(const char *msg) {
 
    char *copy = strdup(msg);
    if (msg) {
-      g_idle_add(gtkui_fatal_error_shim, copy);
+      gtkui_fatal_error_shim(copy);
+      //g_idle_add(gtkui_fatal_error_shim, copy);
    } else {
       FATAL_ERROR("out of memory");
    }


### PR DESCRIPTION
As revealed in #962, this pull-request aims to fix the crash at startup when Ettercap has been build with IPv6 support and enabled then redirect commands in etter.conf only for IPv4.

For GTK based UI it doesn't put the rendering of the fatal error into the background. This way the user has the chance to see error message on the CLI as Ettercap is otherwise faster shut down than the UI would have to to render the error message in the UI.