### PR TITLE
include user message output in debug logfile

### DIFF
--- a/src/ec_ui.c
+++ b/src/ec_ui.c
@@ -212,6 +212,11 @@ void ui_msg(const char *fmt, ...)
       fprintf(EC_GBL_OPTIONS->msg_fd, "%s", msg->message);
       fflush(EC_GBL_OPTIONS->msg_fd);
    }
+
+#ifdef DEBUG
+   /* include user messages in debug log file */
+   DEBUG_MSG("USER_MSG(): %s", msg->message);
+#endif
    
    /* 
     * MUST use the mutex.


### PR DESCRIPTION
This pull requests aims to improve the troubleshooting by including the output on the messages pane via `USER_MSG()` into the debug logfile if Ettercap has been build in Debug mode.

This way it's easier to put the rest of the logfile into the context what actually happened visible for the user.