### PR TITLE
Autostart CLI provided plugins on graphical UI

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,13 @@ Legend:
          !! bug fixed
 
 =========================================
+0.8.4-XXXXXXXXX    00000000
+    + CLI provided plugins are now also autostarted in graphical UI
+
+
+
+
+
 0.8.3-Bertillon    20190701
    !! Fix binary comparsion and assignment in etterfilter
    !! Fixed packetbuffer racecond. in BRIDGE mode (e.g. Message too long)

--- a/man/ettercap.8.in
+++ b/man/ettercap.8.in
@@ -714,6 +714,12 @@ More detailed info about plugins and about how to write your own are found in
 the man page ettercap_plugins(8)
 
 .TP
+\fB\-\-plugin-list <PLUGIN1>[,<PLUGIN2>,...]\fR
+Instead of providing multiple occurances of \-P plugin, \-\-plugin-list can be
+used followed by a comma sepaparated list without any spaces.
+(e.g. ./ettercap \-\-plugin-list plugin1,plugin2).
+
+.TP
 \fB\-F\fR, \fB\-\-filter <FILE>\fR
 Load the filter from the file <FILE>. The filter must be compiled with
 etterfilter(8). The utility will compile the filter script and produce an

--- a/src/ec_parser.c
+++ b/src/ec_parser.c
@@ -232,201 +232,204 @@ void parse_options(int argc, char **argv)
       switch (c) {
 
          case 'M':
-		  set_mitm(optarg);
-                  break;
+            set_mitm(optarg);
+            break;
                   
          case 'o':
-		  set_onlymitm();
-                  //select_text_interface();
-                  break;
+            set_onlymitm();
+            //select_text_interface();
+            break;
 
          case 'b':
-		  set_broadcast();
-		  break;
+            set_broadcast();
+            break;
                   
          case 'B':
-		  set_iface_bridge(optarg);
-                  break;
+            set_iface_bridge(optarg);
+            break;
                   
          case 'p':
-		  set_promisc();
-                  break;
+            set_promisc();
+            break;
 #ifndef JUST_LIBRARY 
          case 'T':
-                  select_text_interface();
-                  break;
+            select_text_interface();
+            break;
                   
          case 'C':
-                  select_curses_interface();
-                  break;
+            select_curses_interface();
+            break;
 
          case 'G':
-                  select_gtk_interface();
-                  break;
+            select_gtk_interface();
+            break;
 
                   
          case 'D':
-                  select_daemon_interface();
-                  break;
+            select_daemon_interface();
+            break;
 #endif
                   
          case 'R':
-		  set_reversed();
-                  break;
+            set_reversed();
+            break;
                   
          case 't':
-		  set_proto(optarg);
-                  break;
+            set_proto(optarg);
+            break;
                   
          case 'P':
-		  set_plugin(optarg);
-                  break;
+            set_plugin(optarg);
+            break;
                   
          case 'i':
-  set_iface(optarg);
-                  break;
+            set_iface(optarg);
+            break;
                   
          case 'I':
-                  /* this option is only useful in the text interface */
-          set_lifaces();
-  select_text_interface();
-                  break;
+            /* this option is only useful in the text interface */
+            set_lifaces();
+            select_text_interface();
+            break;
 
          case 'Y':
-                  set_secondary(optarg);
-                  break;
+            set_secondary(optarg);
+            break;
          
          case 'n':
-                  set_netmask(optarg);
-                  break;
+            set_netmask(optarg);
+            break;
 
          case 'A':
-                  set_address(optarg);
-                  break;
+            set_address(optarg);
+            break;
                   
          case 'r':
-                  set_read_pcap(optarg);
-                  break;
+            set_read_pcap(optarg);
+            break;
                  
          case 'w':
-		  set_write_pcap(optarg);
-                  break;
+            set_write_pcap(optarg);
+            break;
                   
          case 'f':
-		  set_pcap_filter(optarg);
-                  break;
+            set_pcap_filter(optarg);
+            break;
                   
          case 'F':
-		  set_filter(opt_end, optarg);
-                  break;
+            set_filter(opt_end, optarg);
+            break;
                   
          case 'L':
-		  set_loglevel_packet(optarg);
-		  break;
+            set_loglevel_packet(optarg);
+            break;
 
          case 'l':
-		  set_loglevel_info(optarg);
-                  break;
+            set_loglevel_info(optarg);
+            break;
 
          case 'm':
-	          set_loglevel_true(optarg);
-                  break;
+            set_loglevel_true(optarg);
+            break;
                   
          case 'c':
-		  set_compress();
-                  break;
+            set_compress();
+            break;
 
          case 'e':
-                  opt_set_regex(optarg);
-                  break;
+            opt_set_regex(optarg);
+            break;
          
          case 'Q':
-                  set_superquiet();
-                  /* no break, quiet must be enabled */
-                  /* fall through */
+            set_superquiet();
+            /* no break, quiet must be enabled */
+            /* fall through */
          case 'q':
-		  set_quiet();
-                  break;
+            set_quiet();
+            break;
                   
          case 's':
-                  set_script(optarg);
-                  break;
+            set_script(optarg);
+            break;
                   
          case 'z':
-                  set_silent();
-                  break;
+            set_silent();
+            break;
                   
 #ifdef WITH_IPV6
          case '6':
-                  set_ip6scan();
-                  break;
+            set_ip6scan();
+            break;
 #endif
 
          case 'u':
-                  set_unoffensive();
-                  break;
+            set_unoffensive();
+            break;
 
          case 'S':
-                  disable_sslmitm();
-                  break;
+            disable_sslmitm();
+            break;
  
          case 'd':
-                  set_resolve();
-                  break;
+            set_resolve();
+            break;
                   
          case 'j':
-                  set_load_hosts(optarg);
-                  break;
+            set_load_hosts(optarg);
+            break;
                   
          case 'k':
-	          set_save_hosts(optarg);
-                  break;
+            set_save_hosts(optarg);
+            break;
                   
          case 'V':
-                  opt_set_format(optarg);
-                  break;
+            opt_set_format(optarg);
+            break;
                   
          case 'E':
-                  set_ext_headers();
-                  break;
+            set_ext_headers();
+            break;
                   
          case 'W':
-                  set_wifi_key(optarg);
-                  break;
+            set_wifi_key(optarg);
+            break;
                   
          case 'a':
-                  set_conf_file(optarg);
-                  break;
+            set_conf_file(optarg);
+            break;
          
          case 'h':
-                  ec_usage();
-                  break;
+            ec_usage();
+            break;
 
          case 'v':
-                  printf("%s %s\n", EC_GBL_PROGRAM, EC_GBL_VERSION);
-                  clean_exit(0);
-                  break;
+            printf("%s %s\n", EC_GBL_PROGRAM, EC_GBL_VERSION);
+            clean_exit(0);
+            break;
 
         /* Certificate and private key options */
          case 0:
-		if (!strcmp(long_options[option_index].name, "certificate")) {
-			EC_GBL_OPTIONS->ssl_cert = strdup(optarg);	
-		} else if (!strcmp(long_options[option_index].name, "private-key")) {
-			EC_GBL_OPTIONS->ssl_pkey = strdup(optarg);
+            if (!strcmp(long_options[option_index].name, "certificate")) {
+               EC_GBL_OPTIONS->ssl_cert = strdup(optarg);   
+            }
+            else if (!strcmp(long_options[option_index].name, "private-key")) {
+               EC_GBL_OPTIONS->ssl_pkey = strdup(optarg);
 #ifdef HAVE_EC_LUA
-                } else if (!strcmp(long_options[option_index].name,"lua-args")) {
-                    ec_lua_cli_add_args(strdup(optarg));
-                } 
-                else if (!strcmp(long_options[option_index].name,"lua-script")) {
-                    ec_lua_cli_add_script(strdup(optarg));
-        break;
+            }
+            else if (!strcmp(long_options[option_index].name,"lua-args")) {
+               ec_lua_cli_add_args(strdup(optarg));
+            } 
+            else if (!strcmp(long_options[option_index].name,"lua-script")) {
+               ec_lua_cli_add_script(strdup(optarg));
+               break;
 #endif
-		} else {
-			fprintf(stdout, "\nTry `%s --help' for more options.\n\n", EC_GBL_PROGRAM);
-			clean_exit(-1);
-		}
+            }
+            else {
+               fprintf(stdout, "\nTry `%s --help' for more options.\n\n", EC_GBL_PROGRAM);
+               clean_exit(-1);
+            }
 
-		break;
+            break;
 
          case ':': // missing parameter
             fprintf(stdout, "\nTry `%s --help' for more options.\n\n", EC_GBL_PROGRAM);

--- a/src/ec_parser.c
+++ b/src/ec_parser.c
@@ -113,7 +113,8 @@ void ec_usage(void)
    fprintf(stdout, "  -Y, --secondary <ifaces>    list of secondary network interfaces\n");
    fprintf(stdout, "  -n, --netmask <netmask>     force this <netmask> on iface\n");
    fprintf(stdout, "  -A, --address <address>     force this local <address> on iface\n");
-   fprintf(stdout, "  -P, --plugin <plugin>       launch this <plugin>\n");
+   fprintf(stdout, "  -P, --plugin <plugin>       launch this <plugin> - multiple occurance allowed\n");
+   fprintf(stdout, "      --plugin-list <plugin1>,[<plugin2>,...]       comma-separated list of plugins\n");
    fprintf(stdout, "  -F, --filter <file>         load the filter <file> (content filter)\n");
    fprintf(stdout, "  -z, --silent                do not perform the initial ARP scan\n");
 #ifdef WITH_IPV6
@@ -155,6 +156,7 @@ void parse_options(int argc, char **argv)
       { "proto", required_argument, NULL, 't' },
       
       { "plugin", required_argument, NULL, 'P' },
+      { "plugin-list", required_argument, NULL, 0 },
       
       { "filter", required_argument, NULL, 'F' },
 #ifdef HAVE_EC_LUA
@@ -423,6 +425,9 @@ void parse_options(int argc, char **argv)
                ec_lua_cli_add_script(strdup(optarg));
                break;
 #endif
+            }
+            else if (!strcmp(long_options[option_index].name, "plugin-list")) {
+               set_plugin_list(strdup(optarg));
             }
             else {
                fprintf(stdout, "\nTry `%s --help' for more options.\n\n", EC_GBL_PROGRAM);

--- a/src/ec_set.c
+++ b/src/ec_set.c
@@ -74,18 +74,41 @@ void set_reversed(void)
 
 void set_plugin(char *name)
 {
-    struct plugin_list *plugin;
+    struct plugin_list *plugin, *tmp;
 
     if(!strcasecmp(name, "list")) {
         plugin_list();
         clean_exit(0);
     }
 
+    /* check if plugin name is a duplicate */
+    LIST_FOREACH_SAFE(plugin, &EC_GBL_OPTIONS->plugins, next, tmp)
+       if (!strcmp(plugin->name, name))
+             return;
+
     SAFE_CALLOC(plugin, 1, sizeof(struct plugin_list));
     plugin->name = strdup(name);
     plugin->exists = true;
     LIST_INSERT_HEAD(&EC_GBL_OPTIONS->plugins, plugin, next);
 
+}
+
+void set_plugin_list(char *list)
+{
+   char *tmp, *p, *plugin;
+
+   p = list;
+
+   while((plugin = ec_strtok(p, ",", &tmp))) {
+      if (plugin) {
+         set_plugin(plugin);
+         p = NULL;
+      }
+      else
+         break;
+   }
+
+   SAFE_FREE(list);
 }
 
 void set_proto(char *proto)

--- a/src/interfaces/curses/ec_curses.c
+++ b/src/interfaces/curses/ec_curses.c
@@ -345,12 +345,14 @@ void curses_interface(void)
 {
    DEBUG_MSG("curses_interface");
    
+   /* if we have to activate a plugin */
+   curses_autostart_plugins();
+
    /* which interface do we have to display ? */
    if (EC_GBL_OPTIONS->read)
       curses_sniff_offline();
    else
       curses_sniff_live();
-   
 
    /* destroy the previously allocated object */
    wdg_destroy_object(&sysmsg_win);

--- a/src/interfaces/curses/ec_curses.h
+++ b/src/interfaces/curses/ec_curses.h
@@ -17,6 +17,7 @@ extern void curses_sniff_offline(void);
 extern void curses_sniff_live(void);
 void curses_hosts_update(void);
 void curses_plugins_update(void);
+void curses_autostart_plugins(void);
 
 /* menus */
 extern struct wdg_menu menu_filters[]; 

--- a/src/interfaces/gtk/ec_gtk.c
+++ b/src/interfaces/gtk/ec_gtk.c
@@ -720,6 +720,9 @@ void gtkui_start(void)
       gtkui_sniff_offline();
    else
       gtkui_sniff_live();
+
+   /* start plugins defined on CLI */
+   g_idle_add(gtkui_plugins_autostart, NULL);
    
    /* the main gui loop, once this exits the gui will be destroyed */
    gtk_main();

--- a/src/interfaces/gtk/ec_gtk.h
+++ b/src/interfaces/gtk/ec_gtk.h
@@ -136,6 +136,7 @@ extern void gtkui_stop_msg(void);
 extern void gtkui_plugin_mgmt(void);
 extern void gtkui_plugin_load(void);
 extern gboolean gtkui_refresh_plugin_list(gpointer data);
+extern gboolean gtkui_plugins_autostart(gpointer data);
 
 /* ec_gtk_view_connections.c */
 extern void gtkui_show_connections(void);

--- a/src/interfaces/gtk3/ec_gtk3.c
+++ b/src/interfaces/gtk3/ec_gtk3.c
@@ -928,6 +928,9 @@ void gtkui_start(void)
 
    /* create second instance of the UI application */
    etterapp = gtkui_setup(gtkui_create_menu, GINT_TO_POINTER(online));
+
+   /* start plugins defined on CLI */
+   g_idle_add(gtkui_plugins_autostart, NULL);
    
    /* the main gui loop, once this exits the gui will be destroyed */
    g_application_run(G_APPLICATION(etterapp), 0, NULL);

--- a/src/interfaces/gtk3/ec_gtk3.h
+++ b/src/interfaces/gtk3/ec_gtk3.h
@@ -157,6 +157,7 @@ extern void gtkui_stop_msg(GSimpleAction *action, GVariant *value, gpointer data
 extern void gtkui_plugin_mgmt(GSimpleAction *action, GVariant *value, gpointer data);
 extern void gtkui_plugin_load(GSimpleAction *action, GVariant *value, gpointer data);
 extern gboolean gtkui_refresh_plugin_list(gpointer data);
+extern gboolean gtkui_plugins_autostart(gpointer data);
 
 /* ec_gtk3_view_connections.c */
 extern void gtkui_show_connections(GSimpleAction *action, GVariant *value, gpointer data);

--- a/src/interfaces/gtk3/ec_gtk3_plugins.c
+++ b/src/interfaces/gtk3/ec_gtk3_plugins.c
@@ -33,9 +33,13 @@ static void gtkui_add_plugin(char active, struct plugin_ops *ops);
 static void gtkui_plug_destroy(void);
 static void gtkui_plugins_detach(GtkWidget *child);
 static void gtkui_plugins_attach(void);
-static void gtkui_select_plugin(void);
+static int  gtkui_select_plugin(gchar *plugin);
+static void gtkui_select_plugin_menu(GtkMenuItem *item, gpointer data);
+static void gtkui_select_plugin_treeview(GtkTreeView *treeview,
+      GtkTreePath *path, GtkTreeViewColumn *column, gpointer data);
 static void gtkui_create_plug_array(void);
-gboolean gtkui_plugin_context(GtkWidget *widget, GdkEventButton *event, gpointer data);
+gboolean gtkui_plugin_context(GtkWidget *widget, GdkEventButton *event,
+   gpointer data);
 
 /* globals */
 
@@ -182,7 +186,8 @@ void gtkui_plugin_mgmt(GSimpleAction *action, GVariant *value, gpointer data)
 
    selection = gtk_tree_view_get_selection (GTK_TREE_VIEW (treeview));
    gtk_tree_selection_set_mode (selection, GTK_SELECTION_SINGLE);
-   g_signal_connect (G_OBJECT (treeview), "row_activated", G_CALLBACK (gtkui_select_plugin), NULL);
+   g_signal_connect (G_OBJECT (treeview), "row-activated",
+         G_CALLBACK(gtkui_select_plugin_treeview), NULL);
    
    renderer = gtk_cell_renderer_text_new ();
    column = gtk_tree_view_column_new_with_attributes (" ", renderer, "text", 0, NULL);
@@ -262,11 +267,13 @@ static void gtkui_create_plug_array(void)
    /* go thru the list of plugins */
    res = plugin_list_walk(PLP_MIN, PLP_MAX, &gtkui_add_plugin);
    if (res == -E_NOTFOUND) { 
-      blocked = g_signal_handlers_block_by_func (G_OBJECT (treeview), G_CALLBACK (gtkui_select_plugin), NULL);
+      blocked = g_signal_handlers_block_by_func(G_OBJECT(treeview),
+            G_CALLBACK(gtkui_select_plugin_treeview), NULL);
       gtk_list_store_append (ls_plugins, &iter);
       gtk_list_store_set (ls_plugins, &iter, 0, " ", 1, "No Plugins Loaded", -1);
    } else if(blocked > 0) {
-      g_signal_handlers_unblock_by_func (G_OBJECT (treeview), G_CALLBACK (gtkui_select_plugin), NULL);
+      g_signal_handlers_unblock_by_func(G_OBJECT(treeview),
+            G_CALLBACK(gtkui_select_plugin_treeview), NULL);
       blocked = 0;
    }
 }
@@ -291,23 +298,15 @@ static void gtkui_add_plugin(char active, struct plugin_ops *ops)
 }
 
 /*
- * callback function for a plugin 
+ * toggle state of a plugin
  */
-static void gtkui_select_plugin(void)
+static int gtkui_select_plugin(gchar *plugin)
 {
-   GtkTreeIter iter;
-   GtkTreeModel *model;
-   char *plugin = NULL;
-
-   model = GTK_TREE_MODEL (ls_plugins);
-
-   if (gtk_tree_selection_get_selected (GTK_TREE_SELECTION (selection), &model, &iter)) {
-      gtk_tree_model_get (model, &iter, 1, &plugin, -1);
-   } else
-      return; /* nothing is selected */
+   int ret;
 
    if(!plugin)
-      return; /* bad pointer from gtk_tree_model_get, shouldn't happen */
+      /* bad pointer from gtk_tree_model_get, shouldn't happen */
+      return -E_NOTHANDLED;
 
    /* print the message */
    if (plugin_is_activated(plugin) == 0)
@@ -323,12 +322,90 @@ static void gtkui_select_plugin(void)
     * and immediately return
     */
    if (plugin_is_activated(plugin) == 1)
-      plugin_fini(plugin);   
+      ret = plugin_fini(plugin);
    else
-      plugin_init(plugin);
+      ret = plugin_init(plugin);
         
    /* refresh the list to mark plugin active */
    gtkui_create_plug_array();
+
+   return ret;
+}
+
+/*
+ * callback when plugin is selected using the context menu
+ */
+static void gtkui_select_plugin_menu(GtkMenuItem *item, gpointer data)
+{
+   gchar *plugin;
+
+   (void) item;
+
+   plugin = data;
+
+   gtkui_select_plugin(plugin);
+
+}
+
+/*
+ * callback when plugin is double clicked in the treeview
+ */
+static void gtkui_select_plugin_treeview(GtkTreeView *treeview,
+      GtkTreePath *path, GtkTreeViewColumn *column, gpointer data)
+{
+   GtkTreeIter iter;
+   GtkTreeModel *model;
+   GtkTreeSelection *selection;
+   gchar *plugin;
+
+   (void) path;
+   (void) column;
+   (void) data;
+
+   model = gtk_tree_view_get_model(treeview);
+   selection = gtk_tree_view_get_selection(treeview);
+
+   if (gtk_tree_selection_get_selected(selection, &model, &iter)) {
+      gtk_tree_model_get (model, &iter, 1, &plugin, -1);
+   } else
+      return; /* nothing is selected */
+
+   gtkui_select_plugin(plugin);
+}
+
+/*
+ * check if plugins have been supplied on the CLI
+ * and try to start all provided plugins
+ */
+gboolean gtkui_plugins_autostart(gpointer data)
+{
+   struct plugin_list *plugin, *tmp;
+
+   (void) data;
+
+   DEBUG_MSG("gtkui_plugins_autostart()");
+
+   /* if plugins have been defined on the CLI */
+   if (!LIST_EMPTY(&EC_GBL_OPTIONS->plugins)) {
+      LIST_FOREACH_SAFE(plugin, &EC_GBL_OPTIONS->plugins, next, tmp) {
+         /* first check if the plugin exists */
+         if (search_plugin(plugin->name) != E_SUCCESS) {
+            plugin->exists = false;
+            USER_MSG("Sorry, plugin '%s' can not be found - skipping!\n\n",
+                  plugin->name);
+         }
+         else {
+            /* now we can try to start the plugin */
+            plugin->exists = true;
+            if (gtkui_select_plugin(plugin->name) != PLUGIN_RUNNING) {
+               USER_MSG("Plugin '%s' can not be started - skipping!\n\n",
+                     plugin->name);
+            }
+         }
+      }
+   }
+
+   return FALSE;
 }
 
 gboolean gtkui_refresh_plugin_list(gpointer data)
@@ -357,12 +434,6 @@ gboolean gtkui_plugin_context(GtkWidget *widget, GdkEventButton *event, gpointer
 
    model = GTK_TREE_MODEL(ls_plugins);
 
-   menu = gtk_menu_new();
-   item = gtk_menu_item_new();
-   gtk_menu_shell_append(GTK_MENU_SHELL(menu), item);
-   g_signal_connect(G_OBJECT(item), "activate", G_CALLBACK(gtkui_select_plugin), NULL);
-   gtk_widget_show(item);
-
 
    if (gtk_tree_selection_get_selected (GTK_TREE_SELECTION(selection), &model, &iter)) {
       gtk_tree_model_get (model, &iter, 1, &plugin, -1);
@@ -371,6 +442,14 @@ gboolean gtkui_plugin_context(GtkWidget *widget, GdkEventButton *event, gpointer
 
    if(!plugin)
       return FALSE; /* bad pointer from gtk_tree_model_get, shouldn't happen */
+   /* create context menu and bind event to menu item */
+   menu = gtk_menu_new();
+   item = gtk_menu_item_new();
+   gtk_menu_shell_append(GTK_MENU_SHELL(menu), item);
+   g_signal_connect(G_OBJECT(item), "activate",
+         G_CALLBACK(gtkui_select_plugin_menu), plugin);
+   gtk_widget_show(item);
+
 
    /* print the message */
    if (plugin_is_activated(plugin) == 0)


### PR DESCRIPTION
This pull-request is inspired by issue #962 to align the behavior when plugins are provided on the CLI using the  `-P` parameter.

Prior this pull-request only the text interface acts on provided plugins on the CLI.
The command like `ettercap -G -Pdns_spoof` does effectively nothing with the provided plugin and it remains deactivated.

With this pull request, all user interfaces treat the provided plugins and start them as soon as Ettercap's initial setup is succeeded.

This also improves troubleshooting plugin related problems since activation of the plugin is no longer depended on the user's interaction on the graphical user interface.