### PR TITLE
Fix PCAP

### DIFF
--- a/include/ec_capture.h
+++ b/include/ec_capture.h
@@ -11,6 +11,7 @@ EC_API_EXTERN EC_THREAD_FUNC(capture);
 
 EC_API_EXTERN int is_pcap_file(char *file, char *pcap_errbuf);
 EC_API_EXTERN void capture_getifs(void);
+EC_API_EXTERN char* capture_default_if(void);
 
 #define FUNC_ALIGNER(func) int func(void)
 #define FUNC_ALIGNER_PTR(func) int (*func)(void)

--- a/src/ec_capture.c
+++ b/src/ec_capture.c
@@ -168,6 +168,24 @@ void capture_getifs(void)
 }
 
 /*
+ * return default interface
+ */
+char* capture_default_if(void)
+{
+   /*
+    * as per deprecation message of pcap_lookupdev() the new way to determine
+    * the default interface, is to use the first interface detected by the call
+    * of pcap_findalldevs(). This is already determined in capture_getifs() and
+    * stored in EC_GBL_PCAP->ifs
+    */
+
+   if (EC_GBL_PCAP && EC_GBL_PCAP->ifs)
+      return EC_GBL_PCAP->ifs->name;
+
+   return NULL;
+}
+
+/*
  * check if the given file is a pcap file
  */
 int is_pcap_file(char *file, char *pcap_errbuf)

--- a/src/ec_network.c
+++ b/src/ec_network.c
@@ -51,7 +51,6 @@ static void l3_close(void);
 void network_init()
 {
    char *iface;
-   char perrbuf[PCAP_ERRBUF_SIZE];
 
    DEBUG_MSG("init_network");
 
@@ -61,7 +60,7 @@ void network_init()
       source_init(EC_GBL_OPTIONS->pcapfile_in, EC_GBL_IFACE, true, false);
       source_print(EC_GBL_IFACE);
    } else {
-      iface = EC_GBL_OPTIONS->iface ? EC_GBL_OPTIONS->iface : (EC_GBL_OPTIONS->iface = pcap_lookupdev(perrbuf));
+      iface = EC_GBL_OPTIONS->iface ? EC_GBL_OPTIONS->iface : (EC_GBL_OPTIONS->iface = capture_default_if());
       ON_ERROR(iface, NULL, "No suitable interface found...");
       source_init(iface, EC_GBL_IFACE, true, true);
       source_print(EC_GBL_IFACE);

--- a/src/ec_network.c
+++ b/src/ec_network.c
@@ -11,14 +11,14 @@
 #include <ifaddrs.h>
 #endif
 
-#if defined(OS_BSD_OPEN) || defined(OS_LINUX)
-   /* LINUX does not care about timeout */
+#if defined(OS_BSD_OPEN)
    /* OPENBSD needs 0 */
    #define PCAP_TIMEOUT 0
 #elif defined(OS_SOLARIS)
    /* SOLARIS needs > 1 */
    #define PCAP_TIMEOUT 10
 #else
+   /* LINUX needs > 0 */
    /* FREEBSD needs 1 */
    /* MACOSX  needs 1 */
    #define PCAP_TIMEOUT 1

--- a/src/interfaces/curses/ec_curses.c
+++ b/src/interfaces/curses/ec_curses.c
@@ -558,7 +558,6 @@ static void write_pcapfile(void)
  */
 static void curses_unified_sniff(void)
 {
-   char err[PCAP_ERRBUF_SIZE];
    
 #define IFACE_LEN  50
    
@@ -569,8 +568,8 @@ static void curses_unified_sniff(void)
       char *iface;
       
       SAFE_CALLOC(EC_GBL_OPTIONS->iface, IFACE_LEN, sizeof(char));
-      iface = pcap_lookupdev(err);
-      ON_ERROR(iface, NULL, "pcap_lookupdev: %s", err);
+      iface = capture_default_if();
+      ON_ERROR(iface, NULL, "No suitable interface found...");
 
       strncpy(EC_GBL_OPTIONS->iface, iface, IFACE_LEN - 1);
    }
@@ -585,20 +584,17 @@ static void curses_unified_sniff(void)
 static void curses_bridged_sniff(void)
 {
    wdg_t *in;
-   char err[PCAP_ERRBUF_SIZE];
+   char *iface;
    
    DEBUG_MSG("curses_bridged_sniff");
    
    /* if the user has not specified an interface, get the first one */
    if (EC_GBL_OPTIONS->iface == NULL) {
       SAFE_CALLOC(EC_GBL_OPTIONS->iface, IFACE_LEN, sizeof(char));
-   /* if ettercap is started with a non root account pcap_lookupdev(err) == NULL (Fedora bug 783675) */
-      if(pcap_lookupdev(err) != NULL)
-         strncpy(EC_GBL_OPTIONS->iface, pcap_lookupdev(err), IFACE_LEN - 1);
-   /* else
-	here we have to gracefully exit, since we don't have any available interface
-  */
-	
+
+      iface = capture_default_if();
+      ON_ERROR(iface, NULL, "No suitable interface found....");
+      strncpy(EC_GBL_OPTIONS->iface, iface, IFACE_LEN - 1);
    }
    
    SAFE_CALLOC(EC_GBL_OPTIONS->iface_bridge, IFACE_LEN, sizeof(char));

--- a/src/interfaces/gtk/ec_gtk.c
+++ b/src/interfaces/gtk/ec_gtk.c
@@ -1267,7 +1267,6 @@ static void gtkui_unified_sniff(void)
  */
 static void gtkui_unified_sniff_default(void) 
 {
-   char err[PCAP_ERRBUF_SIZE];
    
    DEBUG_MSG("gtkui_unified_sniff_default");
 
@@ -1276,8 +1275,8 @@ static void gtkui_unified_sniff_default(void)
       char *iface;
 
       SAFE_CALLOC(EC_GBL_OPTIONS->iface, IFACE_LEN, sizeof(char));
-      iface = pcap_lookupdev(err);
-      ON_ERROR(iface, NULL, "pcap_lookupdev: %s", err);
+      iface = capture_default_if();
+      ON_ERROR(iface, NULL, "No suitable interface found....");
    
       strncpy(EC_GBL_OPTIONS->iface, iface, IFACE_LEN - 1);
    }


### PR DESCRIPTION
Starting with **libpcap** version 1.9.1, some changes come in that affect Ettercap:
   1. `pcap_lookupdevice()` to determine the _default_ interface has become deprecated
   2. Setting `PCAP_TIMEOUT` to 0 on Linux (used with `pcap_open_live()`) causes a huge delay between the call of `pcap_loop()` and starting  to pass packets to the handler function `ec_decode()`. This has the effect, that the network scan results in a 0 host list because the scan wait's only 1 second until it cancels the capture thread.

This PR addresses both issues. Of course, behavior changes on other platforms still need to be confirmed. However this depends on the availability of the new **libpcap** version on these platforms.