### PR TITLE
Fix Installation of etter.dns and etter.mdns files

### DIFF
--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -43,6 +43,8 @@ endforeach()
 install(FILES
         ${CMAKE_CURRENT_BINARY_DIR}/${EC_CONFFILES}
         ${CMAKE_CURRENT_BINARY_DIR}/etter.conf
+        ${CMAKE_CURRENT_BINARY_DIR}/etter.dns
+        ${CMAKE_CURRENT_BINARY_DIR}/etter.mdns
         DESTINATION ${INSTALL_SYSCONFDIR}/ettercap)
 install(FILES
         ${CMAKE_CURRENT_BINARY_DIR}/${EC_DATAFILES}


### PR DESCRIPTION
This is related to #972 and fixes the proper installation of the corresponding `etter.dns` and `etter.mdns` files.