### PR TITLE
Fix Non-Intercept Forwarding

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,8 @@ Legend:
          !! bug fixed
 =========================================
 0.8.4-XXXXXXXXX    YYYYMMDD
+   !! Fix SSL protocol failure with older TLS client/server versions (min. TLS1.0)
+   !! Fix blackholing SSL packets when specific redirection is used
    !! Fix TLS 1.3 interception issues (replace fake certificate with proper key length)
    !! Fix segmentation fault when parsing HTTP NTLM handshake (fixes #922)
    !! Fix crash if one redirect command is not enabled
@@ -16,6 +18,7 @@ Legend:
     + Use server certificate sign algorithm to sign fake certificate defaulting to SHA256
     + CLI provided plugins are now also autostarted in graphical UI
     + Added --plugin-list CLI parameter
+    - Remove source IP specification from customizable SSL redirects
     - Remove of deprecated redirect commands from etter.conf
     - Remove Easter Egg (Sorry ALoR and NaGA)
 

--- a/include/ec_redirect.h
+++ b/include/ec_redirect.h
@@ -18,6 +18,10 @@ struct redir_entry {
    char                   *destination;
    u_int16                 from_port;
    u_int16                 to_port;
+   struct ip_addr          src_network;
+   struct ip_addr          src_netmask;
+   struct ip_addr          dst_network;
+   struct ip_addr          dst_netmask;
    LIST_ENTRY(redir_entry) next;
 };
 
@@ -34,6 +38,7 @@ EC_API_EXTERN int ec_redirect(ec_redir_act_t action, char *name,
       u_int16 sport, u_int16 dport);
 EC_API_EXTERN int ec_walk_redirects(void (*func)(struct redir_entry*));
 EC_API_EXTERN int ec_walk_redirect_services(void (*func)(struct serv_entry*));
+EC_API_EXTERN int ec_redirect_lookup(struct packet_object *po);
 EC_API_EXTERN void ec_redirect_cleanup(void);
 
 

--- a/include/ec_redirect.h
+++ b/include/ec_redirect.h
@@ -14,12 +14,10 @@ typedef enum {
 struct redir_entry {
    char                   *name;
    ec_redir_proto_t        proto;
-   char                   *source;
    char                   *destination;
    u_int16                 from_port;
    u_int16                 to_port;
-   struct ip_addr          src_network;
-   struct ip_addr          src_netmask;
+   u_int16                 orig_nport;
    struct ip_addr          dst_network;
    struct ip_addr          dst_netmask;
    LIST_ENTRY(redir_entry) next;
@@ -34,7 +32,7 @@ struct serv_entry {
 
 /* proto */
 EC_API_EXTERN int ec_redirect(ec_redir_act_t action, char *name,
-      ec_redir_proto_t proto, const char *source, const char *destination,
+      ec_redir_proto_t proto, const char *destination,
       u_int16 sport, u_int16 dport);
 EC_API_EXTERN int ec_walk_redirects(void (*func)(struct redir_entry*));
 EC_API_EXTERN int ec_walk_redirect_services(void (*func)(struct serv_entry*));

--- a/include/ec_utils.h
+++ b/include/ec_utils.h
@@ -10,5 +10,6 @@ EC_API_EXTERN void regain_privs_atexit(void);
 EC_API_EXTERN int base64encode(const char *inputbuf, char **outptr);
 EC_API_EXTERN int base64decode(const char *src, char **outptr);
 EC_API_EXTERN const char *ec_ctime(const struct timeval *tv);
+EC_API_EXTERN u_char *ec_plen_to_binary(size_t buflen, u_int16 plen);
 
 #endif

--- a/plug-ins/sslstrip/sslstrip.c
+++ b/plug-ins/sslstrip/sslstrip.c
@@ -235,10 +235,10 @@ static int sslstrip_init(void *dummy)
    if (!https_url_pcre) {
       USER_MSG("SSLStrip: plugin load failed: pcre_compile failed (offset: %d), %s\n", erroroffset, error);
       ec_redirect(EC_REDIR_ACTION_REMOVE, "http", EC_REDIR_PROTO_IPV4,
-            NULL, NULL, 80, bind_port);
+            NULL, 80, bind_port);
 #ifdef WITH_IPV6
       ec_redirect(EC_REDIR_ACTION_REMOVE, "http", EC_REDIR_PROTO_IPV6,
-            NULL, NULL, 80, bind_port);
+            NULL, 80, bind_port);
 #endif
 
       return PLUGIN_FINISHED;
@@ -250,10 +250,10 @@ static int sslstrip_init(void *dummy)
       USER_MSG("SSLStrip: plugin load failed: Could not compile find_cookie regex: %s (%d)\n", errbuf, err);
       pcre_free(https_url_pcre);
       ec_redirect(EC_REDIR_ACTION_REMOVE, "http" , EC_REDIR_PROTO_IPV4,
-            NULL, NULL, 80, bind_port);
+            NULL, 80, bind_port);
 #ifdef WITH_IPV6
       ec_redirect(EC_REDIR_ACTION_REMOVE, "http" , EC_REDIR_PROTO_IPV6,
-            NULL, NULL, 80, bind_port);
+            NULL, 80, bind_port);
 #endif
 
       return PLUGIN_FINISHED;
@@ -278,13 +278,13 @@ static int sslstrip_fini(void *dummy)
 
    DEBUG_MSG("SSLStrip: Removing redirect\n");
    if (ec_redirect(EC_REDIR_ACTION_REMOVE, "http", EC_REDIR_PROTO_IPV4,
-            NULL, NULL, 80, bind_port) != E_SUCCESS) {
+            NULL, 80, bind_port) != E_SUCCESS) {
       USER_MSG("SSLStrip: Unable to remove HTTP redirect, please do so "
             "manually.\n");
    }
 #ifdef WITH_IPV6
    if (ec_redirect(EC_REDIR_ACTION_REMOVE, "http", EC_REDIR_PROTO_IPV6,
-            NULL, NULL, 80, bind_port) != E_SUCCESS) {
+            NULL, 80, bind_port) != E_SUCCESS) {
       USER_MSG("SSLStrip: Unable to remove HTTP redirect, please do so "
             "manually.\n");
    }
@@ -1341,12 +1341,12 @@ static int http_bind_wrapper(void)
    USER_MSG("SSLStrip plugin: bind 80 on %d\n", bind_port);
    
    if (ec_redirect(EC_REDIR_ACTION_INSERT, "http", EC_REDIR_PROTO_IPV4,
-            NULL, NULL, 80, bind_port) != E_SUCCESS)
+            NULL, 80, bind_port) != E_SUCCESS)
       return -E_FATAL;
 
 #ifdef WITH_IPV6
    if (ec_redirect(EC_REDIR_ACTION_INSERT, "http", EC_REDIR_PROTO_IPV6,
-            NULL, NULL, 80, bind_port) != E_SUCCESS)
+            NULL, 80, bind_port) != E_SUCCESS)
       return -E_FATAL;
 #endif
 

--- a/share/etter.conf.v4
+++ b/share/etter.conf.v4
@@ -170,15 +170,15 @@ geoip_data_file_v6 = "/usr/local/share/GeoIP/GeoIPv6.dat"
 #     Linux 
 #---------------
 
-   #redir_command_on = "iptables -t nat -A PREROUTING -i %iface -p tcp -s %source -d %destination --dport %port -j REDIRECT --to-port %rport"
-   #redir_command_off = "iptables -t nat -D PREROUTING -i %iface -p tcp -s %source -d %destination --dport %port -j REDIRECT --to-port %rport"
+   #redir_command_on = "iptables -t nat -A PREROUTING -i %iface -p tcp -d %destination --dport %port -j REDIRECT --to-port %rport"
+   #redir_command_off = "iptables -t nat -D PREROUTING -i %iface -p tcp -d %destination --dport %port -j REDIRECT --to-port %rport"
 
 #---------------
 #    Mac Os X
 #---------------
 
-   #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from %source to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
-   #redir_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet .+ %source to %destination port = %port' | pfctl -f - 2> /dev/null"
+   #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
+   #redir_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet .+ any to %destination port = %port' | pfctl -f - 2> /dev/null"
 
 
 #---------------
@@ -194,8 +194,8 @@ geoip_data_file_v6 = "/usr/local/share/GeoIP/GeoIPv6.dat"
 # `pfctl -si | grep Status | awk '{print $2;}'`. If "Disabled", enable it with
 # `pfctl -e`.
 
-   #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from %source to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
-   #redir_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet .+ %source to %destination port = %port' | pfctl -f - 2> /dev/null"
+   #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
+   #redir_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet .+ any to %destination port = %port' | pfctl -f - 2> /dev/null"
 
 
 #---------------

--- a/share/etter.conf.v6
+++ b/share/etter.conf.v6
@@ -176,23 +176,23 @@ geoip_data_file_v6 = "/usr/local/share/GeoIP/GeoIPv6.dat"
 #     Linux 
 #---------------
 
-   #redir_command_on = "iptables -t nat -A PREROUTING -i %iface -p tcp -s %source -d %destination --dport %port -j REDIRECT --to-port %rport"
-   #redir_command_off = "iptables -t nat -D PREROUTING -i %iface -p tcp -s %source -d %destination --dport %port -j REDIRECT --to-port %rport"
+   #redir_command_on = "iptables -t nat -A PREROUTING -i %iface -p tcp -d %destination --dport %port -j REDIRECT --to-port %rport"
+   #redir_command_off = "iptables -t nat -D PREROUTING -i %iface -p tcp -d %destination --dport %port -j REDIRECT --to-port %rport"
 
 # pendant for IPv6 - Note that you need iptables v1.4.16 or newer to use IPv6 redirect
-   #redir6_command_on = "ip6tables -t nat -A PREROUTING -i %iface -p tcp -s %source -d %destination --dport %port -j REDIRECT --to-port %rport"
-   #redir6_command_off = "ip6tables -t nat -D PREROUTING -i %iface -p tcp -s %source -d %destination --dport %port -j REDIRECT --to-port %rport"
+   #redir6_command_on = "ip6tables -t nat -A PREROUTING -i %iface -p tcp -d %destination --dport %port -j REDIRECT --to-port %rport"
+   #redir6_command_off = "ip6tables -t nat -D PREROUTING -i %iface -p tcp -d %destination --dport %port -j REDIRECT --to-port %rport"
 
 #---------------
 #    Mac Os X
 #---------------
 
-   #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from %source to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
-   #redir_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet .+ %source to %destination port = %port' | pfctl -f - 2> /dev/null"
+   #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
+   #redir_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet .+ any to %destination port = %port' | pfctl -f - 2> /dev/null"
 
 # BSD PF for IPv6:
-   #redir6_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet6 proto tcp from %source to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
-   #redir6_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet6 .+ %source to %destination port = %port' | pfctl -f - 2> /dev/null"
+   #redir6_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet6 proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
+   #redir6_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet6 .+ any to %destination port = %port' | pfctl -f - 2> /dev/null"
 
 
 #---------------
@@ -207,12 +207,12 @@ geoip_data_file_v6 = "/usr/local/share/GeoIP/GeoIPv6.dat"
 # `pfctl -si | grep Status | awk '{print $2;}'`. If "Disabled", enable it with
 # `pfctl -e`.
 
-   #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from %source to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
-   #redir_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet .+ %source to %destination port = %port' | pfctl -f - 2> /dev/null"
+   #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
+   #redir_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet .+ any to %destination port = %port' | pfctl -f - 2> /dev/null"
 
 # pendant for IPv6
-   #redir6_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet6 proto tcp from %source to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
-   #redir6_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet6 .+ %source to %destination port = %port' | pfctl -f - 2> /dev/null"
+   #redir6_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet6 proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
+   #redir6_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet6 .+ any to %destination port = %port' | pfctl -f - 2> /dev/null"
 
 #---------------
 #   Open BSD

--- a/src/ec_sslwrap.c
+++ b/src/ec_sslwrap.c
@@ -413,18 +413,15 @@ static void sslw_hook_handled(struct packet_object *po)
  */
 static int sslw_is_ssl(struct packet_object *po)
 {
-   struct listen_entry *le;
-   
    /* If it's already coming from ssl wrapper 
     * or the connection is not TCP */ 
    if (po->flags & PO_FROMSSL || po->L4.proto != NL_TYPE_TCP) 
       return 0;
 
-   LIST_FOREACH(le, &listen_ports, next) {
-      if (ntohs(po->L4.dst) == le->sslw_port ||
-          ntohs(po->L4.src) == le->sslw_port)
-         return 1;
-   }
+   /* check if packet matches one of the registered redirects */
+   if (ec_redirect_lookup(po) == E_SUCCESS)
+      return 1;
+
    return 0;
 }
 

--- a/src/ec_sslwrap.c
+++ b/src/ec_sslwrap.c
@@ -53,6 +53,9 @@
 /* don't include kerberos. RH sux !! */
 #define OPENSSL_NO_KRB5 1
 #include <openssl/ssl.h>
+#ifdef DEBUG
+   #include <openssl/err.h>
+#endif
 
 #if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
 #define HAVE_OPAQUE_RSA_DSA_DH 1 /* since 1.1.0 -pre5 */
@@ -623,8 +626,14 @@ static int sslw_ssl_accept(SSL *ssl_sk)
 #endif
       
       /* there was an error...  but only if it's not just pending further progress */
-      if (ssl_err != SSL_ERROR_WANT_READ && ssl_err != SSL_ERROR_WANT_WRITE)
+      if (ssl_err != SSL_ERROR_WANT_READ && ssl_err != SSL_ERROR_WANT_WRITE) {
+#ifdef DEBUG
+         char error_msg[256], *error;
+         error = ERR_error_string(ERR_get_error(), error_msg);
+         DEBUG_MSG("sslw_ssl_accept(): SSL_accept() failed with '%s'", error);
+#endif
          return -E_INVALID;
+      }
       
       /* sleep a quirk of time... */
       ec_usleep(TSLEEP);

--- a/src/ec_sslwrap.c
+++ b/src/ec_sslwrap.c
@@ -206,7 +206,7 @@ void sslw_dissect_move(char *name, u_int16 port)
       if(!strcmp(name, le->name)) {
          DEBUG_MSG("sslw_dissect_move: %s [%u]", name, port);
          le->sslw_port = port;
-	 
+
       /* Move to zero means disable */
       if (port == 0) {
          LIST_REMOVE(le, next);
@@ -389,8 +389,8 @@ EC_THREAD_FUNC(sslw_start)
    }
 
    return NULL;
-   
-}	 
+
+}
 
 /* 
  * Filter SSL related packets and create NAT sessions.
@@ -403,7 +403,7 @@ static void sslw_hook_handled(struct packet_object *po)
    /* We have nothing to do with this packet */
    if (!sslw_is_ssl(po))
       return;
-     
+
    /* If it's an ssl packet don't forward */
    po->flags |= PO_DROPPED;
    
@@ -411,7 +411,7 @@ static void sslw_hook_handled(struct packet_object *po)
    if ( (po->flags & PO_FORWARDABLE) && 
         (po->L4.flags & TH_SYN) &&
         !(po->L4.flags & TH_ACK) ) {
-	
+
       sslw_create_session(&s, PACKET);
 
 #ifndef OS_LINUX
@@ -419,7 +419,7 @@ static void sslw_hook_handled(struct packet_object *po)
       memcpy(s->data, &po->L3.dst, sizeof(struct ip_addr));
       session_put(s);
 #else
-	SAFE_FREE(s); /* Just get rid of it */
+      SAFE_FREE(s); /* Just get rid of it */
 #endif
    } else /* Pass only the SYN for conntrack */
       po->flags |= PO_IGNORE;
@@ -527,7 +527,7 @@ static int sslw_sync_conn(struct accepted_entry *ae)
 {      
    if(sslw_get_peer(ae) != E_SUCCESS)
          return -E_INVALID;
-	 
+
    if(sslw_connect_server(ae) != E_SUCCESS)
          return -E_INVALID;
 
@@ -698,15 +698,15 @@ static int sslw_sync_ssl(struct accepted_entry *ae)
    }
 
    if (!EC_GBL_OPTIONS->ssl_cert) {
-   	/* Create the fake certificate based on actual certificate */
-   	ae->cert = sslw_create_selfsigned(server_cert);  
-   	X509_free(server_cert);
+      /* Create the fake certificate based on actual certificate */
+      ae->cert = sslw_create_selfsigned(server_cert);  
+      X509_free(server_cert);
 
-   	if (ae->cert == NULL)
-      		return -E_INVALID;
+      if (ae->cert == NULL)
+         return -E_INVALID;
 
       /* use faked certificate for further SSL client connection */
-   	SSL_use_certificate(ae->ssl[SSL_CLIENT], ae->cert);
+      SSL_use_certificate(ae->ssl[SSL_CLIENT], ae->cert);
 
    }
    
@@ -841,7 +841,7 @@ static int sslw_read_data(struct accepted_entry *ae, u_int32 direction, struct p
       /* XXX - Is it necessary? */
       if (len == 0)
          return -E_INVALID;
-	       
+
       if (ret_err == SSL_ERROR_WANT_READ || ret_err == SSL_ERROR_WANT_WRITE)
          return -E_NOTHANDLED;
       else
@@ -933,7 +933,7 @@ static int sslw_write_data(struct accepted_entry *ae, u_int32 direction, struct 
       /* XXX - Set a proper sleep time */
       if (not_written)
          ec_usleep(SEC2MICRO(1));
-	 	 
+
    } while (not_written);
          
    return E_SUCCESS;
@@ -1025,8 +1025,8 @@ static void sslw_initialize_po(struct packet_object *po, u_char *p_data)
       SAFE_CALLOC(po->DATA.data, 1, UINT16_MAX);
    } else {
       if (po->DATA.data != p_data) {
-      	  SAFE_FREE(po->DATA.data);
-          po->DATA.data = p_data;
+         SAFE_FREE(po->DATA.data);
+         po->DATA.data = p_data;
       }
    }
       
@@ -1153,29 +1153,38 @@ static void sslw_init(void)
 #endif
 
    if(EC_GBL_OPTIONS->ssl_pkey) {
-	/* Get our private key from the file specified from cmd-line */
-	DEBUG_MSG("Using custom private key %s", EC_GBL_OPTIONS->ssl_pkey);
-	if (SSL_CTX_use_PrivateKey_file(ssl_ctx_client, EC_GBL_OPTIONS->ssl_pkey, SSL_FILETYPE_PEM) == 0) {
-		FATAL_ERROR("Can't open \"%s\" file : %s", EC_GBL_OPTIONS->ssl_pkey, strerror(errno));
-	}
+      /* Get our private key from the file specified from cmd-line */
+      DEBUG_MSG("Using custom private key %s", EC_GBL_OPTIONS->ssl_pkey);
+      if (SSL_CTX_use_PrivateKey_file(ssl_ctx_client,
+               EC_GBL_OPTIONS->ssl_pkey, SSL_FILETYPE_PEM) == 0) {
+         FATAL_ERROR("Can't open \"%s\" file : %s",
+               EC_GBL_OPTIONS->ssl_pkey, strerror(errno));
+      }
 
-	if (EC_GBL_OPTIONS->ssl_cert) {
-		if (SSL_CTX_use_certificate_file(ssl_ctx_client, EC_GBL_OPTIONS->ssl_cert, SSL_FILETYPE_PEM) == 0) {
-			FATAL_ERROR("Can't open \"%s\" file : %s", EC_GBL_OPTIONS->ssl_cert, strerror(errno));
-		}
+      if (EC_GBL_OPTIONS->ssl_cert) {
+         if (SSL_CTX_use_certificate_file(ssl_ctx_client,
+                  EC_GBL_OPTIONS->ssl_cert, SSL_FILETYPE_PEM) == 0) {
+            FATAL_ERROR("Can't open \"%s\" file : %s",
+                  EC_GBL_OPTIONS->ssl_cert, strerror(errno));
+         }
 
-		if (!SSL_CTX_check_private_key(ssl_ctx_client)) {
-			FATAL_ERROR("Certificate \"%s\" does not match private key \"%s\"", EC_GBL_OPTIONS->ssl_cert, EC_GBL_OPTIONS->ssl_pkey);
-		}
-	}
+         if (!SSL_CTX_check_private_key(ssl_ctx_client)) {
+            FATAL_ERROR("Certificate \"%s\" does not match private key \"%s\"",
+                  EC_GBL_OPTIONS->ssl_cert, EC_GBL_OPTIONS->ssl_pkey);
+         }
+      }
    } else {
-   	/* Get our private key from our cert file */
-   	if (SSL_CTX_use_PrivateKey_file(ssl_ctx_client, INSTALL_DATADIR "/" PROGRAM "/" CERT_FILE, SSL_FILETYPE_PEM) == 0) {
-      		DEBUG_MSG("sslw -- SSL_CTX_use_PrivateKey_file -- trying ./share/%s",  CERT_FILE);
+      /* Get our private key from our cert file */
+      if (SSL_CTX_use_PrivateKey_file(ssl_ctx_client,
+               INSTALL_DATADIR"/"PROGRAM"/"CERT_FILE, SSL_FILETYPE_PEM) == 0) {
+            DEBUG_MSG("sslw -- SSL_CTX_use_PrivateKey_file -- trying ./share/%s",
+                  CERT_FILE);
 
-      		if (SSL_CTX_use_PrivateKey_file(ssl_ctx_client, "./share/" CERT_FILE, SSL_FILETYPE_PEM) == 0)
-         		FATAL_ERROR("Can't open \"./share/%s\" file : %s", CERT_FILE, strerror(errno));
-   	}
+            if (SSL_CTX_use_PrivateKey_file(ssl_ctx_client,
+                     "./share/" CERT_FILE, SSL_FILETYPE_PEM) == 0)
+               FATAL_ERROR("Can't open \"./share/%s\" file : %s",
+                     CERT_FILE, strerror(errno));
+      }
    }
 
    dummy_ssl = SSL_new(ssl_ctx_client);
@@ -1210,8 +1219,8 @@ EC_THREAD_FUNC(sslw_child)
       DEBUG_MSG("FAILED TO FIND PEER");
       SAFE_FREE(ae);
       ec_thread_exit();
-   }	    
-	    
+   }
+
    if ((ae->status & SSL_ENABLED) && 
       sslw_sync_ssl(ae) == -E_INVALID) {
       sslw_wipe_connection(ae);
@@ -1234,7 +1243,7 @@ EC_THREAD_FUNC(sslw_child)
 
          ret_val = sslw_read_data(ae, direction, &po);
          BREAK_ON_ERROR(ret_val,ae,po);
-	 
+
          /* if we have data to read */
          if (ret_val == E_SUCCESS) {
             data_read = 1;
@@ -1244,16 +1253,16 @@ EC_THREAD_FUNC(sslw_child)
 
             if (po.flags & PO_DROPPED)
                continue;
-	
+
             ret_val = sslw_write_data(ae, !direction, &po);
             BREAK_ON_ERROR(ret_val,ae,po);
-	    
+
             if ((po.flags & PO_SSLSTART) && !(ae->status & SSL_ENABLED)) {
                ae->status |= SSL_ENABLED; 
                ret_val = sslw_sync_ssl(ae);
                BREAK_ON_ERROR(ret_val,ae,po);
             }
-	    
+
             sslw_initialize_po(&po, po.DATA.data);
          }  
       }
@@ -1270,52 +1279,52 @@ EC_THREAD_FUNC(sslw_child)
 
 static int sslw_remove_sts(struct packet_object *po)
 {
-	u_char *ptr;
-	u_char *end;
-	u_char *h_end;
-	size_t len = po->DATA.len;
-	size_t slen = strlen("\r\nStrict-Transport-Security:");
+   u_char *ptr;
+   u_char *end;
+   u_char *h_end;
+   size_t len = po->DATA.len;
+   size_t slen = strlen("\r\nStrict-Transport-Security:");
 
-	if (!memmem(po->DATA.data, po->DATA.len, "\r\nStrict-Transport-Security:", slen)) {
-		return -E_NOTFOUND;
-	}
+   if (!memmem(po->DATA.data, po->DATA.len, "\r\nStrict-Transport-Security:", slen)) {
+      return -E_NOTFOUND;
+   }
 
-	ptr = po->DATA.data;
-	end = ptr + po->DATA.len;
+   ptr = po->DATA.data;
+   end = ptr + po->DATA.len;
 
-	len = end - ptr;
+   len = end - ptr;
 
-	ptr = (u_char*)memmem(ptr, len, "\r\nStrict-Transport-Security:", slen);
-	ptr += 2;
+   ptr = (u_char*)memmem(ptr, len, "\r\nStrict-Transport-Security:", slen);
+   ptr += 2;
 
-	h_end = (u_char*)memmem(ptr, len, "\r\n", 2);
-	h_end += 2;
+   h_end = (u_char*)memmem(ptr, len, "\r\n", 2);
+   h_end += 2;
 
-	size_t before_header = ptr - po->DATA.data;
-	size_t header_length = h_end - ptr;
-	size_t new_len = 0;
+   size_t before_header = ptr - po->DATA.data;
+   size_t header_length = h_end - ptr;
+   size_t new_len = 0;
 
-	u_char *new_html;
-	SAFE_CALLOC(new_html, len, sizeof(u_char));
+   u_char *new_html;
+   SAFE_CALLOC(new_html, len, sizeof(u_char));
 
-	BUG_IF(new_html == NULL);
+   BUG_IF(new_html == NULL);
 
-	memcpy(new_html, po->DATA.data, before_header);
-	new_len += before_header;
+   memcpy(new_html, po->DATA.data, before_header);
+   new_len += before_header;
 
-	memcpy(new_html+new_len, h_end, (len - header_length) - before_header);
-	new_len += (len - header_length) - before_header;
-
-
-	memset(po->DATA.data, '\0', po->DATA.len);
-
-	memcpy(po->DATA.data, new_html, new_len);
-	po->DATA.len = new_len;
-
-	po->flags |= PO_MODIFIED;
+   memcpy(new_html+new_len, h_end, (len - header_length) - before_header);
+   new_len += (len - header_length) - before_header;
 
 
-	return E_SUCCESS;
+   memset(po->DATA.data, '\0', po->DATA.len);
+
+   memcpy(po->DATA.data, new_html, new_len);
+   po->DATA.len = new_len;
+
+   po->flags |= PO_MODIFIED;
+
+
+   return E_SUCCESS;
 
 }
 

--- a/src/ec_sslwrap.c
+++ b/src/ec_sslwrap.c
@@ -488,13 +488,13 @@ static void sslw_bind_wrapper(void)
 #endif
 
       if (ec_redirect(EC_REDIR_ACTION_INSERT, le->name,
-               EC_REDIR_PROTO_IPV4, NULL, NULL,
+               EC_REDIR_PROTO_IPV4, NULL,
                le->sslw_port, le->redir_port) != E_SUCCESS)
         FATAL_ERROR("Can't insert firewall redirects");
 
 #ifdef WITH_IPV6
       if (ec_redirect(EC_REDIR_ACTION_INSERT, le->name,
-               EC_REDIR_PROTO_IPV6, NULL, NULL,
+               EC_REDIR_PROTO_IPV6, NULL,
                le->sslw_port, le->redir_port) != E_SUCCESS)
         FATAL_ERROR("Can't insert firewall redirects");
 #endif

--- a/src/ec_utils.c
+++ b/src/ec_utils.c
@@ -349,6 +349,37 @@ const char *ec_ctime(const struct timeval *tv)
   return (result);
 }
 
+/*
+ * convert a prefix length to a bit pattern buffer that can be freed
+ *  - expects the length of memory to allocate
+ *  - expects the prefix mask bit length
+ *  - returns a byte string pointer to the allocated memory containing
+ *    the bit mask corresponding to the prefix bit length
+ */
+u_char *ec_plen_to_binary(size_t buflen, u_int16 plen)
+{
+   size_t len;
+   u_char *buf, *p;
+   u_int32 i;
+
+   /* determine the network-host boundary byte */
+   len = plen % 8 ? plen / 8 + 1 : plen / 8;
+   BUG_IF(len > buflen);
+
+   /* allocate enough buffer */
+   SAFE_CALLOC(buf, buflen, sizeof(u_char));
+   p = buf;
+
+   for (i = 0; i < len; i++)
+      if (i == len-1)
+         *p++ = 0xff << (8-(plen-8*i));
+      else
+         *p++ = 0xff;
+
+   return buf;
+
+}
+
 
 /* EOF */
 

--- a/src/interfaces/curses/ec_curses_mitm.c
+++ b/src/interfaces/curses/ec_curses_mitm.c
@@ -77,7 +77,6 @@ static size_t n_redir = 0;
 static size_t n_serv  = 0;
 static char redir_proto[5] = "ipv4";
 static char redir_name[50] = "ftps";
-static char redir_source[MAX_ASCII_ADDR_LEN] = "0.0.0.0/0";
 static char redir_destination[MAX_ASCII_ADDR_LEN] = "0.0.0.0/0";
 
 
@@ -274,9 +273,7 @@ static void curses_sslredir_add(void *dummy)
    wdg_input_size(wdg_input, strlen("Destination: ") + 
          MAX_ASCII_ADDR_LEN, 6);
    wdg_input_add(wdg_input, 1, 1, "IP Version:  ", redir_proto, 5, 1);
-   wdg_input_add(wdg_input, 1, 2, "Source:      ", redir_source, 
-         MAX_ASCII_ADDR_LEN, 1);
-   wdg_input_add(wdg_input, 1, 3, "Destination: ", redir_destination, 
+   wdg_input_add(wdg_input, 1, 3, "Server IP: ", redir_destination, 
          MAX_ASCII_ADDR_LEN, 1);
    wdg_input_add(wdg_input, 1, 4, "Service:     ", redir_name, 10, 1);
 
@@ -354,13 +351,13 @@ static void curses_sslredir_add_rule(void)
 
    /* do the actual redirect insertion */
    ret = ec_redirect(EC_REDIR_ACTION_INSERT, se->name, proto,
-         redir_source, redir_destination, se->from_port, se->to_port);
+         redir_destination, se->from_port, se->to_port);
 
    /* inform user if redirect insertion wasn't successful */
    if (ret != E_SUCCESS) {
-      DEBUG_MSG("calling ec_redirect('%s', '%s', '%s', '%s', '%s', '%d', '%d'"
+      DEBUG_MSG("calling ec_redirect('%s', '%s', '%s', '%s', '%d', '%d'"
             " failed", "insert", se->name, redir_proto, 
-            redir_source, redir_destination, se->from_port, se->to_port);
+            redir_destination, se->from_port, se->to_port);
 
       INSTANT_USER_MSG("Inserting redirect for %s/%s failed!\n",
             redir_proto, redir_name);
@@ -386,14 +383,14 @@ static void curses_sslredir_del(void *dummy)
    /* remove the redirect */
    re = (struct redir_entry *)dummy;
    ret = ec_redirect(EC_REDIR_ACTION_REMOVE, re->name, re->proto,
-         re->source, re->destination, re->from_port, re->to_port);
+         re->destination, re->from_port, re->to_port);
 
 
    if (ret != E_SUCCESS) {
-      DEBUG_MSG("calling ec_redirect('%s', '%s', '%s', '%s', '%s', '%d', '%d'"
+      DEBUG_MSG("calling ec_redirect('%s', '%s', '%s', '%s', '%d', '%d'"
             " failed", "remove", re->name, 
             (re->proto == EC_REDIR_PROTO_IPV4 ? "ipv4" : "ipv6"),
-            re->source, re->destination, re->from_port, re->to_port);
+            re->destination, re->from_port, re->to_port);
 
       INSTANT_USER_MSG("Removing redirect for %s/%s failed!\n",
             (re->proto == EC_REDIR_PROTO_IPV4 ? "ipv4" : "ipv6"), re->name);
@@ -446,9 +443,8 @@ static void curses_sslredir_add_list(struct redir_entry *re)
          sizeof(char));
 
    snprintf(wdg_redirect_elements[n_redir].desc, MAX_DESC_LEN,
-         "%s %30s %30s %s", 
+         "%s %30s %s", 
          (re->proto == EC_REDIR_PROTO_IPV4 ? "ipv4" : "ipv6"),
-         re->source,
          re->destination,
          re->name);
 

--- a/src/interfaces/gtk/ec_gtk_conf.c
+++ b/src/interfaces/gtk/ec_gtk_conf.c
@@ -78,8 +78,7 @@ void gtkui_conf_read(void) {
      if(!p)
          continue;
       *p = '\0';
-      snprintf(name, sizeof(name), "%s", line);
-      strlcpy(name, line, sizeof(name) - 1);
+      strlcpy(name, line, sizeof(name));
       g_strstrip(name);
       value = atoi(p + 1);
       gtkui_conf_set(name, value);

--- a/src/interfaces/gtk/ec_gtk_targets.c
+++ b/src/interfaces/gtk/ec_gtk_targets.c
@@ -88,7 +88,7 @@ void gtkui_select_protocol(void)
    /* this will contain 'all', 'tcp' or 'udp' */
    if (!EC_GBL_OPTIONS->proto) {
       SAFE_CALLOC(EC_GBL_OPTIONS->proto, 4, sizeof(char));
-      strncpy(EC_GBL_OPTIONS->proto, "all", 3);
+      strncpy(EC_GBL_OPTIONS->proto, "all", 4);
    }
 
    /* create dialog for selecting the protocol */

--- a/src/interfaces/gtk/ec_gtk_view.c
+++ b/src/interfaces/gtk/ec_gtk_view.c
@@ -462,11 +462,11 @@ void gtkui_vis_method(void)
       memset(vmethod, 0, VLEN);
 
       switch(active) {
-         case 6: strncpy(vmethod, "hex", 3); break;
-         case 5: strncpy(vmethod, "ascii", 5); break; 
-         case 4: strncpy(vmethod, "text", 4); break;
-         case 3: strncpy(vmethod, "ebcdic", 6); break;
-         case 2: strncpy(vmethod, "html", 4); break;
+         case 6: strncpy(vmethod, "hex", 4); break;
+         case 5: strncpy(vmethod, "ascii", 6); break; 
+         case 4: strncpy(vmethod, "text", 5); break;
+         case 3: strncpy(vmethod, "ebcdic", 7); break;
+         case 2: strncpy(vmethod, "html", 5); break;
          case 1: /* utf8 */
             /* copy first word from encoding choice */
             gtk_combo_box_get_active_iter(GTK_COMBO_BOX(lang_combo), &iter);

--- a/src/interfaces/text/ec_text_redirect.c
+++ b/src/interfaces/text/ec_text_redirect.c
@@ -45,8 +45,8 @@ void text_redirect_print(void)
 
    /* print header */
    fprintf(stdout, "SSL Intercepts\n");
-   fprintf(stdout, " # proto %30s %30s service\n",
-         "source", "destination");
+   fprintf(stdout, " # IP Version %25s Service\n",
+         "Server IP");
 
    /* print rules */
    ec_walk_redirects(text_redirect_print_rule);
@@ -70,16 +70,16 @@ void text_redirect_del(int num)
    re = redirect_list[num - 1];
 
    ret = ec_redirect(EC_REDIR_ACTION_REMOVE, re->name, re->proto, 
-         re->source, re->destination, re->from_port, re->to_port);
+         re->destination, re->from_port, re->to_port);
 
    if (ret == E_SUCCESS)
       INSTANT_USER_MSG("Redirect removed successfully\n",
             (re->proto == EC_REDIR_PROTO_IPV4 ? "ipv4" : "ipv6"),
-            re->source, re->destination, re->name);
+            re->destination, re->name);
    else
       INSTANT_USER_MSG("Removing redirect [%s] %s -> %s:%s failed!\n",
             (re->proto == EC_REDIR_PROTO_IPV4 ? "ipv4" : "ipv6"),
-            re->source, re->destination, re->name);
+            re->destination, re->name);
 
 }
 
@@ -89,8 +89,8 @@ void text_redirect_del(int num)
 void text_redirect_add(void)
 {
    char ipver[20], service[20];
-   char sourcebuf[MAX_ASCII_ADDR_LEN], destinationbuf[MAX_ASCII_ADDR_LEN];
-   char *p, *source, *destination;
+   char destinationbuf[MAX_ASCII_ADDR_LEN];
+   char *p, *destination;
    int i, ret, found = 0, invalid = 0;
    ec_redir_proto_t proto;
 
@@ -107,13 +107,7 @@ void text_redirect_add(void)
    if ((p = strrchr(ipver, '\n')) != NULL)
       *p = 0;
    
-   fprintf(stdout, "Source [any]: ");
-   fgets(sourcebuf, MAX_ASCII_ADDR_LEN, stdin);
-   /* remove trailing line feed */
-   if ((p = strrchr(sourcebuf, '\n')) != NULL)
-      *p = 0;
-   
-   fprintf(stdout, "Destination [any]: ");
+   fprintf(stdout, "Server IP [any]: ");
    fgets(destinationbuf, MAX_ASCII_ADDR_LEN, stdin);
    /* remove trailing line feed */
    if ((p = strrchr(destinationbuf, '\n')) != NULL)
@@ -138,12 +132,7 @@ void text_redirect_add(void)
       invalid = 1;
    }
 
-   /* check user input for source and destination */
-   if (!strcmp(sourcebuf, "") || !strcasecmp(sourcebuf, "any"))
-      source = NULL;
-   else
-      source = sourcebuf;
-
+   /* check user input for server IP */
    if (!strcmp(destinationbuf, "") || !strcasecmp(destinationbuf, "any"))
       destination = NULL;
    else
@@ -171,7 +160,7 @@ void text_redirect_add(void)
    }
 
    ret = ec_redirect(EC_REDIR_ACTION_INSERT, service_list[i]->name,
-         proto, source, destination, service_list[i]->from_port,
+         proto, destination, service_list[i]->from_port,
          service_list[i]->to_port);
 
    if (ret == E_SUCCESS)
@@ -194,9 +183,9 @@ static void text_redirect_print_rule(struct redir_entry *re)
    n_redir++;
 
    /* print the rule */
-   fprintf(stdout, "%2d %5s %30s %30s %s\n", n_redir, 
+   fprintf(stdout, "%2d %5s %30s %s\n", n_redir, 
          (re->proto == EC_REDIR_PROTO_IPV4 ? "ipv4" : "ipv6"),
-         re->source, re->destination, re->name);
+         re->destination, re->name);
 
 }
 


### PR DESCRIPTION
Unfortunately the introduction of adjusting SSL interception at runtime had one blind spot that only becomes visible when one really makes use of the selective SSL redirection.

When SSL interception is enabled, Ettercap checks if a seen packet is part of SSL interception. Then it's flagged not to be forwarded by Ettercap as its terminated by the sockets Ettercap created for the connection. This check is solely based on source or destination port e.g. 443.

If you now try to limit the SSL interception with the new feature to let say 203.0.113.1 HTTPS, all traffic from and to this IP would be intercepted by Ettercap and the forwarding engine does not forward these packets. So far so good.

Under this constellation, all other packets on port 443 (HTTPS) will be dropped. They're not redirected to the Ettercap listener and they're still marked to be dropped because the port matched. This blackholes all other HTTPS traffic which is not the wanted behaviour of selective SSL interception and need correction.


This pull request addresses this issue. The check is being extended to also check if the source or destination IP lies within the IP specification done in the SSL interception dialog.

To reduce the per-packet processing overhead, I decided to remove the possibility to specify a source IP since I can't imagine there are any requirements or use-cases that would make use of it.

Sorry, the explanation was a little bit lengthy, but the issue is not trivial - at least to find and understand.
