### PR TITLE
etterlog causing seg fault

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -11,6 +11,7 @@ Legend:
    !! Fix build on MacOSX detecting new dependency HarfBuzz
    !! Fix warnings when parsing etter.(m)dns file when built w/o IPv6 support
    !! Fix capture delay with libpcap v1.9.1 (fixes #974)
+   !! Fix segmentation fault when etterlog concatinate files
     + Take over client-side SNI extension in ClientHello in SSL interception (req. OpenSSL 1.1.1)
     + Take over SAN certificate extension from server certificate in SSL interception
     + Use server certificate sign algorithm to sign fake certificate defaulting to SHA256

--- a/utils/etterlog/el_log.c
+++ b/utils/etterlog/el_log.c
@@ -394,6 +394,11 @@ static void dump_file(gzFile fd, struct log_global_header *hdr)
    u_char *pckbuf;
    int count = 0;
 
+
+   memset(&pck,0,sizeof(struct log_header_packet));
+   memset(&inf,0,sizeof(struct log_header_info));
+   memset(&infbuf,0,sizeof(struct dissector_info));
+
    /* loop until EOF */
    LOOP {
       switch (hdr->type) {


### PR DESCRIPTION
came across an issue where etterlog was seg faulting, this was due to the fact the `struct dissector_info infbuf;` in ec_log.c had not been initalized therfore pointers had been set to random values and SAFE_FREE caused a seg fault.