### PR TITLE
Fix build issue with -fno-common CFLAG

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ if(NOT DISABLE_RPATH)
 endif()
 
 # set general build flags for debug build-type
-set(CMAKE_C_FLAGS_DEBUG "-O0 -ggdb3 -DDEBUG -Wall -Wno-pointer-sign -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Wextra -Wredundant-decls" CACHE STRING "" FORCE)
+set(CMAKE_C_FLAGS_DEBUG "-O0 -ggdb3 -DDEBUG -fno-common -Wall -Wno-pointer-sign -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Wextra -Wredundant-decls" CACHE STRING "" FORCE)
 ## append ASAN build flags if compiler version has support
 #if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
 #   if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 4.8)

--- a/include/ec_globals.h
+++ b/include/ec_globals.h
@@ -176,6 +176,11 @@ struct wifi_env {
 	size_t wkey_len;
 };
 
+/* threads structure */
+struct thread_env {
+   pthread_t ec_pthread_null;
+};
+
 /* the globals container */
 struct ec_globals {
    struct ec_conf *conf;
@@ -191,6 +196,7 @@ struct ec_globals {
    struct target_env *t1;
    struct target_env *t2;
    struct wifi_env *wifi;
+   struct thread_env *thread;
    LIST_HEAD(, hosts_list) hosts_list;
    TAILQ_HEAD(gbl_ptail, host_profile) profiles_list_head;
    struct filter_list *filters;
@@ -213,6 +219,7 @@ EC_API_EXTERN struct ec_globals *ec_gbls;
 #define EC_GBL_TARGET1        (EC_GBLS->t1)
 #define EC_GBL_TARGET2        (EC_GBLS->t2)
 #define EC_GBL_WIFI           (EC_GBLS->wifi)
+#define EC_GBL_THREAD         (EC_GBLS->thread)
 #define EC_GBL_HOSTLIST       (EC_GBLS->hosts_list)
 #define EC_GBL_PROFILES       (EC_GBLS->profiles_list_head)
 #define EC_GBL_FILTERS        &(EC_GBLS->filters)

--- a/include/ec_threads.h
+++ b/include/ec_threads.h
@@ -12,7 +12,7 @@ struct ec_thread {
 };
 
 /* a value to be used to return errors in fuctcions using pthread_t values */
-pthread_t EC_PTHREAD_NULL;
+#define EC_PTHREAD_NULL EC_GBL_THREAD->ec_pthread_null
 #define EC_PTHREAD_SELF EC_PTHREAD_NULL
 #define PTHREAD_ID(id)  (*(unsigned long*)&(id)) 
 

--- a/src/ec_globals.c
+++ b/src/ec_globals.c
@@ -52,6 +52,7 @@ void ec_globals_alloc(void)
    SAFE_CALLOC(ec_gbls->t1, 1, sizeof(struct target_env));
    SAFE_CALLOC(ec_gbls->t2, 1, sizeof(struct target_env));
    SAFE_CALLOC(ec_gbls->wifi, 1, sizeof(struct wifi_env));
+   SAFE_CALLOC(ec_gbls->thread, 1, sizeof(struct thread_env));
    /* filter list entries are allocated as needed */
    ec_gbls->filters = NULL;
 
@@ -72,6 +73,8 @@ void ec_globals_free(void)
    EC_GBL_FREE(ec_gbls->bridge);
    EC_GBL_FREE(ec_gbls->sm);
    EC_GBL_FREE(ec_gbls->filters);
+   EC_GBL_FREE(ec_gbls->wifi);
+   EC_GBL_FREE(ec_gbls->thread);
 
    free_ip_list(ec_gbls->t1);
    EC_GBL_FREE(ec_gbls->t1);


### PR DESCRIPTION
Fix #795 
This PR addresses the changed default [behavior of GCC](https://gcc.gnu.org/PR85678) that it will not continue to accept common variable names shared among multiple files.

Instead defining `EC_PTHREAD_NULL` as a stack variable where ever _ec_threads.c_ is being included, it's defined as a globally allocated heap variable and `EC_PTHREAD_NULL` becomes an alias for this global variable.