### PR TITLE
Fix compiling with GCC 10 / -fno-common

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ Legend:
    !! Fix warnings when parsing etter.(m)dns file when built w/o IPv6 support
    !! Fix capture delay with libpcap v1.9.1 (fixes #974)
    !! Fix segmentation fault when etterlog concatinate files
+   !! Fix compiling with GCC 10 / -fno-common
     + Take over client-side SNI extension in ClientHello in SSL interception (req. OpenSSL 1.1.1)
     + Take over SAN certificate extension from server certificate in SSL interception
     + Use server certificate sign algorithm to sign fake certificate defaulting to SHA256

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ if(NOT DISABLE_RPATH)
 endif()
 
 # set general build flags for debug build-type
-set(CMAKE_C_FLAGS_DEBUG "-O0 -ggdb3 -DDEBUG -Wall -Wno-pointer-sign -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Wextra -Wredundant-decls" CACHE STRING "" FORCE)
+set(CMAKE_C_FLAGS_DEBUG "-O0 -ggdb3 -DDEBUG -fno-common -Wall -Wno-pointer-sign -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Wextra -Wredundant-decls" CACHE STRING "" FORCE)
 ## append ASAN build flags if compiler version has support
 #if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
 #   if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 4.8)

--- a/include/ec_threads.h
+++ b/include/ec_threads.h
@@ -12,7 +12,7 @@ struct ec_thread {
 };
 
 /* a value to be used to return errors in fuctcions using pthread_t values */
-pthread_t EC_PTHREAD_NULL;
+extern pthread_t EC_PTHREAD_NULL;
 #define EC_PTHREAD_SELF EC_PTHREAD_NULL
 #define PTHREAD_ID(id)  (*(unsigned long*)&(id)) 
 

--- a/src/ec_threads.c
+++ b/src/ec_threads.c
@@ -46,6 +46,8 @@ static pthread_cond_t init_cond = PTHREAD_COND_INITIALIZER;
 #define INIT_LOCK     do{ DEBUG_MSG("thread_init_lock"); pthread_mutex_lock(&init_mtx); } while(0)
 #define INIT_UNLOCK   do{ DEBUG_MSG("thread_init_unlock"); pthread_mutex_unlock(&init_mtx); } while(0)
 
+pthread_t EC_PTHREAD_NULL;
+
 /* protos... */
 
 pthread_t ec_thread_detached(char *name, char *desc, void *(*function)(void *), void *args, int detached);


### PR DESCRIPTION
With GCC 10 -fno-common is enabled by default[0] which causes linking
problems that might look like this[1]:
```
ld: src/interfaces/CMakeFiles/ec_interfaces.dir/text/ec_text.c.o:(.bss+0x80):
multiple definition of `EC_PTHREAD_NULL';
src/interfaces/CMakeFiles/ec_interfaces.dir/__/ec_interfaces.c.o:(.bss+0x0):
first defined here
```
and which was previously reported at [2].

Fix this by declaring EC_PTHREAD_NULL as extern in include/ec_threads.h
and by defining it in ec_threads.c.

[0] https://gcc.gnu.org/gcc-10/porting_to.html#common
[1] https://bugs.gentoo.org/707674
[2] https://github.com/Ettercap/ettercap/issues/795

Signed-off-by: Jeroen Roovers <jer@gentoo.org>