### PR TITLE
Alternative approach to fix comiplation with GCC version 10

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -12,6 +12,7 @@ Legend:
    !! Fix warnings when parsing etter.(m)dns file when built w/o IPv6 support
    !! Fix capture delay with libpcap v1.9.1 (fixes #974)
    !! Fix segmentation fault when etterlog concatinate files
+   !! Fix compiling with GCC version / defaulting to -fno-common
     + Take over client-side SNI extension in ClientHello in SSL interception (req. OpenSSL 1.1.1)
     + Take over SAN certificate extension from server certificate in SSL interception
     + Use server certificate sign algorithm to sign fake certificate defaulting to SHA256

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ if(NOT DISABLE_RPATH)
 endif()
 
 # set general build flags for debug build-type
-set(CMAKE_C_FLAGS_DEBUG "-O0 -ggdb3 -DDEBUG -Wall -Wno-pointer-sign -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Wextra -Wredundant-decls" CACHE STRING "" FORCE)
+set(CMAKE_C_FLAGS_DEBUG "-O0 -ggdb3 -DDEBUG -fno-common -Wall -Wno-pointer-sign -D_FORTIFY_SOURCE=2 -Wformat -Wformat-security -Werror=format-security -Wextra -Wredundant-decls" CACHE STRING "" FORCE)
 ## append ASAN build flags if compiler version has support
 #if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
 #   if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 4.8)

--- a/include/ec_threads.h
+++ b/include/ec_threads.h
@@ -11,9 +11,6 @@ struct ec_thread {
    pthread_t id;
 };
 
-/* a value to be used to return errors in fuctcions using pthread_t values */
-pthread_t EC_PTHREAD_NULL;
-#define EC_PTHREAD_SELF EC_PTHREAD_NULL
 #define PTHREAD_ID(id)  (*(unsigned long*)&(id)) 
 
 #define EC_THREAD_FUNC(x) void * x(void *args)

--- a/plug-ins/dos_attack/dos_attack.c
+++ b/plug-ins/dos_attack/dos_attack.c
@@ -156,7 +156,7 @@ static int dos_attack_fini(void *dummy)
    pid = ec_thread_getpid("golem");
    
    /* the thread is active or not ? */
-   if (!pthread_equal(pid, EC_PTHREAD_NULL))
+   if (!pthread_equal(pid, ec_thread_getpid(NULL)))
       ec_thread_destroy(pid);
 
    INSTANT_USER_MSG("dos_attack: plugin terminated...\n");

--- a/plug-ins/fraggle_attack/fraggle_attack.c
+++ b/plug-ins/fraggle_attack/fraggle_attack.c
@@ -88,7 +88,7 @@ static int fraggle_attack_fini(void *dummy)
 
    DEBUG_MSG("fraggle_attack_fini");
 
-   while(!pthread_equal(EC_PTHREAD_NULL, pid = ec_thread_getpid("fraggler"))) {
+   while(!pthread_equal(ec_thread_getpid(NULL), pid = ec_thread_getpid("fraggler"))) {
       ec_thread_destroy(pid);
    }
 
@@ -116,7 +116,7 @@ static EC_THREAD_FUNC(fraggler)
    length= (size_t) sizeof(payload);
 
    if((proto != AF_INET) && (proto != AF_INET6))
-	   ec_thread_destroy(EC_PTHREAD_SELF);
+	   ec_thread_destroy(ec_thread_getpid(NULL));
 
    LOOP {
       CANCELLATION_POINT();

--- a/plug-ins/isolate/isolate.c
+++ b/plug-ins/isolate/isolate.c
@@ -108,7 +108,7 @@ static int isolate_fini(void *dummy)
    hook_del(HOOK_PACKET_ARP_RQ, &parse_arp);
    
    /* get those pids and kill 'em all */ 
-   while(!pthread_equal(pid = ec_thread_getpid("isolate"), EC_PTHREAD_NULL))
+   while(!pthread_equal(pid = ec_thread_getpid("isolate"), ec_thread_getpid(NULL)))
       ec_thread_destroy(pid);   
    
    /* free the list */

--- a/plug-ins/link_type/link_type.c
+++ b/plug-ins/link_type/link_type.c
@@ -186,7 +186,7 @@ static int link_type_fini(void *dummy)
 
    pid = ec_thread_getpid("link_type");
 
-   if (!pthread_equal(pid, EC_PTHREAD_NULL))
+   if (!pthread_equal(pid, ec_thread_getpid(NULL)))
          ec_thread_destroy(pid);
 
    INSTANT_USER_MSG("link_type: plugin terminated...\n");

--- a/plug-ins/rand_flood/rand_flood.c
+++ b/plug-ins/rand_flood/rand_flood.c
@@ -121,7 +121,7 @@ static int rand_flood_fini(void *dummy)
    pid = ec_thread_getpid("flooder");
 
    /* the thread is active or not ? */
-   if (!pthread_equal(pid, EC_PTHREAD_NULL))
+   if (!pthread_equal(pid, ec_thread_getpid(NULL)))
       ec_thread_destroy(pid);
 
    INSTANT_USER_MSG("rand_flood: plugin stopped...\n");

--- a/plug-ins/scan_poisoner/scan_poisoner.c
+++ b/plug-ins/scan_poisoner/scan_poisoner.c
@@ -164,7 +164,7 @@ static int scan_poisoner_fini(void *dummy)
 
    pid = ec_thread_getpid("scan_poisoner");
 
-   if (!pthread_equal(pid, EC_PTHREAD_NULL))
+   if (!pthread_equal(pid, ec_thread_getpid(NULL)))
          ec_thread_destroy(pid);
 
    INSTANT_USER_MSG("scan_poisoner: plugin terminated...\n");

--- a/plug-ins/search_promisc/search_promisc.c
+++ b/plug-ins/search_promisc/search_promisc.c
@@ -176,7 +176,7 @@ static int search_promisc_fini(void *dummy)
 
    pid = ec_thread_getpid("search_promisc");
 
-   if (!pthread_equal(pid, EC_PTHREAD_NULL))
+   if (!pthread_equal(pid, ec_thread_getpid(NULL)))
          ec_thread_destroy(pid);
 
    INSTANT_USER_MSG("search_promisc: plugin terminated...\n");

--- a/plug-ins/smurf_attack/smurf_attack.c
+++ b/plug-ins/smurf_attack/smurf_attack.c
@@ -85,7 +85,7 @@ static int smurf_attack_fini(void *dummy)
 
    DEBUG_MSG("smurf_attack_fini");
 
-   while(!pthread_equal(EC_PTHREAD_NULL, pid = ec_thread_getpid("smurfer"))) {
+   while(!pthread_equal(ec_thread_getpid(NULL), pid = ec_thread_getpid("smurfer"))) {
       ec_thread_destroy(pid);
    }
 
@@ -125,7 +125,7 @@ static EC_THREAD_FUNC(smurfer)
        * if no other network layer protocol
        * is added.
        */
-         ec_thread_destroy(EC_PTHREAD_SELF);
+         ec_thread_destroy(ec_thread_getpid(NULL));
          break;
    }
 

--- a/plug-ins/sslstrip/sslstrip.c
+++ b/plug-ins/sslstrip/sslstrip.c
@@ -299,17 +299,17 @@ static int sslstrip_fini(void *dummy)
    /* stop accept wrapper */
    pthread_t pid = ec_thread_getpid("http_accept_thread");
    
-   if (!pthread_equal(pid, EC_PTHREAD_NULL))
+   if (!pthread_equal(pid, ec_thread_getpid(NULL)))
            ec_thread_destroy(pid);
 
    /* now destroy all http_child_thread */
    do {
       pid = ec_thread_getpid("http_child_thread");
       
-      if(!pthread_equal(pid, EC_PTHREAD_NULL))
+      if(!pthread_equal(pid, ec_thread_getpid(NULL)))
          ec_thread_destroy(pid);
 
-   } while (!pthread_equal(pid, EC_PTHREAD_NULL));
+   } while (!pthread_equal(pid, ec_thread_getpid(NULL)));
 
    close(main_fd);
 #ifdef WITH_IPV6

--- a/plug-ins/stp_mangler/stp_mangler.c
+++ b/plug-ins/stp_mangler/stp_mangler.c
@@ -130,7 +130,7 @@ static int stp_mangler_fini(void *dummy)
    pid = ec_thread_getpid("mangler");
 
    /* the thread is active or not ? */
-   if (!pthread_equal(pid, EC_PTHREAD_NULL))
+   if (!pthread_equal(pid, ec_thread_getpid(NULL)))
       ec_thread_destroy(pid);
 
    INSTANT_USER_MSG("stp_mangler: plugin stopped...\n");

--- a/src/ec_capture.c
+++ b/src/ec_capture.c
@@ -60,7 +60,7 @@ void capture_stop(struct iface_env *iface)
 
    snprintf(thread_name, sizeof(thread_name), "capture[%s]", iface->name);
    pid = ec_thread_getpid(thread_name);
-   if(!pthread_equal(pid, EC_PTHREAD_NULL))
+   if(!pthread_equal(pid, ec_thread_getpid(NULL)))
       ec_thread_destroy(pid);
 }
 

--- a/src/ec_debug.c
+++ b/src/ec_debug.c
@@ -143,7 +143,7 @@ void debug_msg(const char *message, ...)
    if (debug_file == NULL)
       return;
 
-   fprintf(debug_file, "[%9s]\t", ec_thread_getname(EC_PTHREAD_SELF));
+   fprintf(debug_file, "[%9s]\t", ec_thread_getname(ec_thread_getpid(NULL)));
 
    strlcpy(debug_message, message, sizeof(debug_message));
    strlcat(debug_message, "\n", sizeof(debug_message));

--- a/src/ec_main.c
+++ b/src/ec_main.c
@@ -69,7 +69,7 @@ int main(int argc, char *argv[])
    filter_init_mutex();
    
    /* register the main thread as "init" */
-   ec_thread_register(EC_PTHREAD_SELF, "init", "initialization phase");
+   ec_thread_register(ec_thread_getpid(NULL), "init", "initialization phase");
    
    /* activate the signal handler */
    signal_handler();
@@ -190,7 +190,7 @@ int main(int argc, char *argv[])
    ec_thread_new("top_half", "dispatching module", &top_half, NULL);
 
    /* this thread becomes the UI then displays it */
-   ec_thread_register(EC_PTHREAD_SELF, EC_GBL_PROGRAM, "the user interface");
+   ec_thread_register(ec_thread_getpid(NULL), EC_GBL_PROGRAM, "the user interface");
 
    /* start unified sniffing for curses and GTK at startup */
    if ((EC_GBL_UI->type == UI_CURSES || EC_GBL_UI->type == UI_GTK) &&

--- a/src/ec_plugins.c
+++ b/src/ec_plugins.c
@@ -327,7 +327,7 @@ int plugin_kill_thread(char *name, char *thread)
    pid = ec_thread_getpid(thread); 
 
    /* do not execute if not being a thread */
-   if (pthread_equal(pid, EC_PTHREAD_NULL))
+   if (pthread_equal(pid, ec_thread_getpid(NULL)))
       return -E_INVALID;
 
    /* the thread can only kill itself */

--- a/src/ec_resolv.c
+++ b/src/ec_resolv.c
@@ -359,7 +359,7 @@ void resolv_cache_insert(struct ip_addr *ip, char *name)
     * can lead to segmentation faults due to race conditions
     */
    pid = pthread_self();
-   if (pthread_equal(pid, EC_PTHREAD_NULL)) {
+   if (pthread_equal(pid, ec_thread_getpid(NULL))) {
       DEBUG_MSG("resolv_cache_insert: not called by a thread - aborting");
       return;
    }

--- a/src/ec_sniff_bridge.c
+++ b/src/ec_sniff_bridge.c
@@ -58,7 +58,7 @@ void start_bridge_sniff(void)
       pthread_t pid;
       
       pid = ec_thread_getpid("timer");
-      if (pthread_equal(pid, EC_PTHREAD_NULL))
+      if (pthread_equal(pid, ec_thread_getpid(NULL)))
          ec_thread_new("timer", "conntrack timeouter", &conntrack_timeouter, NULL);
    }
 

--- a/src/ec_sniff_unified.c
+++ b/src/ec_sniff_unified.c
@@ -54,7 +54,7 @@ void start_unified_sniff(void)
       pthread_t pid;
       
       pid = ec_thread_getpid("timer");
-      if (pthread_equal(pid, EC_PTHREAD_NULL))
+      if (pthread_equal(pid, ec_thread_getpid(NULL)))
          ec_thread_new("timer", "conntrack timeouter", &conntrack_timeouter, NULL);
    }
 
@@ -93,7 +93,7 @@ void stop_unified_sniff(void)
       secondary_sources_foreach(capture_stop);
    
    pid = ec_thread_getpid("sslwrap");
-   if (!pthread_equal(pid, EC_PTHREAD_NULL))
+   if (!pthread_equal(pid, ec_thread_getpid(NULL)))
       ec_thread_destroy(pid);
 
    USER_MSG("Unified sniffing was stopped.\n");

--- a/src/ec_threads.c
+++ b/src/ec_threads.c
@@ -32,6 +32,11 @@ struct thread_list {
 
 
 /* global data */
+
+/* a value to be used to return errors in fuctcions using pthread_t values */
+static pthread_t EC_PTHREAD_NULL = 0;
+#define EC_PTHREAD_SELF EC_PTHREAD_NULL
+
 #define DETACHED_THREAD 1
 #define JOINABLE_THREAD 0
 
@@ -93,6 +98,13 @@ pthread_t ec_thread_getpid(char *name)
 {
    struct thread_list *current;
    pthread_t pid;
+
+   /*
+    * if "name" is explicitely set up NULL, the top-level pthread_t 
+    * is returned w/o iterating through the thread-list
+    */
+   if (name == NULL)
+      return EC_PTHREAD_NULL;
    
    THREADS_LOCK;
 

--- a/src/mitm/ec_arp_poisoning.c
+++ b/src/mitm/ec_arp_poisoning.c
@@ -156,7 +156,7 @@ static void arp_poisoning_stop(void)
    pid = ec_thread_getpid("arp_poisoner");
 
    /* the thread is active or not ? */
-   if (!pthread_equal(pid, EC_PTHREAD_NULL))
+   if (!pthread_equal(pid, ec_thread_getpid(NULL)))
       ec_thread_destroy(pid);
    else
       return;

--- a/src/mitm/ec_ip6nd_poison.c
+++ b/src/mitm/ec_ip6nd_poison.c
@@ -113,7 +113,7 @@ static void ndp_poison_stop(void)
    DEBUG_MSG("ndp_poison_stop");
    
    pid = ec_thread_getpid("ndp_poisoner");
-   if(!pthread_equal(pid, EC_PTHREAD_NULL))
+   if(!pthread_equal(pid, ec_thread_getpid(NULL)))
       ec_thread_destroy(pid);
    else {
       DEBUG_MSG("no poisoner thread found");

--- a/src/mitm/ec_port_stealing.c
+++ b/src/mitm/ec_port_stealing.c
@@ -215,7 +215,7 @@ static void port_stealing_stop(void)
    pid = ec_thread_getpid("port_stealer");
    
    /* the thread is active or not ? */
-   if (!pthread_equal(pid, EC_PTHREAD_NULL))
+   if (!pthread_equal(pid, ec_thread_getpid(NULL)))
       ec_thread_destroy(pid);
    else
       return;


### PR DESCRIPTION
This pull request fixes the compiling issue, by avoiding the included stack variable at all.
To refer to the top-level thread ID, the function `ec_thread_getpid(char* name)` is amended, to directly return the **pthread_t** variable (which is statically set to 0) used for the top-level thread.

@eaescob: I have the feeling this is the most correct approach to address this issue. So I'd factorize this pull request. What's your opinion?