### PR TITLE
Added execreplace filter function

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -15,6 +15,7 @@ Legend:
    !! Fix capture delay with libpcap v1.9.1 (fixes #974)
    !! Fix segmentation fault when etterlog concatinate files
    !! Fix compiling with GCC version / defaulting to -fno-common
+   !! Fix bad UDP length for packets changed with replace()
     + Take over client-side SNI extension in ClientHello in SSL interception (req. OpenSSL 1.1.1)
     + Take over SAN certificate extension from server certificate in SSL interception
     + Use server certificate sign algorithm to sign fake certificate defaulting to SHA256

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,10 @@ Legend:
          - old feature removed
          !! bug fixed
 =========================================
+0.8.5-XXXXXXXXX    YYYYMMDD
+    + New execreplace etterfilter command
+
+=========================================
 0.8.4-XXXXXXXXX    YYYYMMDD
    !! Fix SSL protocol failure with older TLS client/server versions (min. TLS1.0)
    !! Fix blackholing SSL packets when specific redirection is used

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,10 +4,6 @@ Legend:
          - old feature removed
          !! bug fixed
 =========================================
-0.8.5-XXXXXXXXX    YYYYMMDD
-    + New execreplace etterfilter command
-
-=========================================
 0.8.4-XXXXXXXXX    YYYYMMDD
    !! Fix SSL protocol failure with older TLS client/server versions (min. TLS1.0)
    !! Fix blackholing SSL packets when specific redirection is used
@@ -24,6 +20,7 @@ Legend:
     + Use server certificate sign algorithm to sign fake certificate defaulting to SHA256
     + CLI provided plugins are now also autostarted in graphical UI
     + Added --plugin-list CLI parameter
+    + New execreplace etterfilter command
     - Remove source IP specification from customizable SSL redirects
     - Remove of deprecated redirect commands from etter.conf
     - Remove Easter Egg (Sorry ALoR and NaGA)

--- a/include/ec_filter.h
+++ b/include/ec_filter.h
@@ -52,6 +52,7 @@ struct filter_op {
             #define FFUNC_MSG       8
             #define FFUNC_EXEC      9
             #define FFUNC_EXECINJECT 10
+            #define FFUNC_EXECREPLACE 11
          u_int8 level; 
          u_int8 *string;
          size_t slen;

--- a/man/etterfilter.8.in
+++ b/man/etterfilter.8.in
@@ -360,6 +360,19 @@ execinject("/bin/cat /tmp/foo")
 
 
 .TP
+.B execreplace(\fIcommand\fR)
+this function operates similar to the \fBreplace\fR function except that it uses the output of a shell command to replace entire data rather than the contents of a file.
+An other difference, is that orinal packet content is pass to the shell command in stdin.
+It always injects in DATA.data. You can use it to replace the entire packet with a 
+fake one depending on the original one.
+
+.Sp
+example:
+.br
+execreplace("tr A-Z a-z")
+
+
+.TP
 .B exit()
 this function causes the filter engine to stop executing the code. It is useful
 to stop the execution of the script on some circumstance checked by an 'if' statement.

--- a/share/etter.filter.examples
+++ b/share/etter.filter.examples
@@ -100,6 +100,11 @@ if (udp.dst == 53 && pcre_regex(DATA.data, ".*\x03com\x00.*")) {
    msg("faked");
 }
 
+if (udp.dst == 53 && pcre_regex(DATA.data, ".*\x03com\x00.*")) {
+   execreplace("/bin/sed 's/\x03com\x00/\x02my\x04page\x02de\x00/g'");
+   msg("faked");
+}
+
 # filter only a specific ip address
 if (ip.src == '192.168.0.2') {
    drop();

--- a/src/ec_filter.c
+++ b/src/ec_filter.c
@@ -968,7 +968,11 @@ static int func_execreplace(struct filter_op *fop, struct packet_object *po)
    memcpy(po->DATA.data, output, offset);
 
    /* Adjust packet len and delta */
-   po->DATA.delta = offset;
+   if ((u_int)offset > po->DATA.len) {
+      po->DATA.delta += (int)((u_int)offset - po->DATA.len);
+   } else {
+      po->DATA.delta -= (int)(po->DATA.len - (u_int)offset);
+   }
    po->DATA.len = offset;
 
    /* mark the packet as modified */

--- a/src/ec_filter.c
+++ b/src/ec_filter.c
@@ -921,7 +921,7 @@ static int func_execreplace(struct filter_op *fop, struct packet_object *po)
       return -E_FATAL;
    }
    if (child_pid == 0) {
-       char *const argv[] = { "/bin/sh", "-c", fop->op.func.string };
+       char *const argv[] = { "/bin/sh", "-c", fop->op.func.string, NULL };
        if (dup2(child_stdin[0], STDIN_FILENO) == -1 || dup2(child_stdout[1], STDOUT_FILENO) == -1) {
            exit(EXIT_FAILURE);
        }

--- a/src/ec_filter.c
+++ b/src/ec_filter.c
@@ -921,7 +921,7 @@ static int func_execreplace(struct filter_op *fop, struct packet_object *po)
       return -E_FATAL;
    }
    if (child_pid == 0) {
-       char *const argv[] = { "/bin/sh", "-c", (const char*)fop->op.func.string };
+       char *const argv[] = { "/bin/sh", "-c", fop->op.func.string };
        if (dup2(child_stdin[0], STDIN_FILENO) == -1 || dup2(child_stdout[1], STDOUT_FILENO) == -1) {
            exit(EXIT_FAILURE);
        }

--- a/src/protocols/ec_ip6.c
+++ b/src/protocols/ec_ip6.c
@@ -181,7 +181,7 @@ FUNC_DECODER(decode_ip6)
    /* XXX - recheck this */
    if(!EC_GBL_OPTIONS->unoffensive && !EC_GBL_OPTIONS->read && (PACKET->flags & PO_FORWARDABLE)) {
       if(PACKET->flags & PO_MODIFIED) {
-         ORDER_ADD_SHORT(PACKET->L3.payload_len, PACKET->DATA.delta);
+         ORDER_ADD_SHORT(ip6->payload_len, PACKET->DATA.delta);
 
          /*
           * In case some upper level encapsulated ip6 decoder

--- a/src/protocols/ec_udp.c
+++ b/src/protocols/ec_udp.c
@@ -140,6 +140,7 @@ FUNC_DECODER(decode_udp)
    /* Adjustments after filters */
    if ((PACKET->flags & PO_MODIFIED) && (PACKET->flags & PO_FORWARDABLE)) {
             
+      ORDER_ADD_SHORT(udp->ulen, PACKET->DATA.delta);
       /* Recalculate checksum */
       udp->csum = CSUM_INIT; 
       udp->csum = L4_checksum(PACKET);

--- a/utils/etterfilter/ef_encode.c
+++ b/utils/etterfilter/ef_encode.c
@@ -303,6 +303,16 @@ int encode_function(char *string, struct filter_op *fop)
          ret = E_SUCCESS;
       } else
          SCRIPT_ERROR("Wrong number of arguments for function \"%s\" ", name);
+   } else if (!strcmp(name, "execreplace")) {
+      if (nargs == 1) {
+         fop->op.func.op = FFUNC_EXECREPLACE;
+         /* execreplace always operate at DATA level */
+         fop->op.func.level = 5;
+         fop->op.func.string = (u_char*)strdup(dec_args[0]);
+         fop->op.func.slen = strlen((const char*)fop->op.func.string);
+         ret = E_SUCCESS;
+      } else
+         SCRIPT_ERROR("Wrong number of arguments for function \"%s\" ", name);
    } else if (!strcmp(name, "log")) {
       if (nargs == 2) {
          /* get the level (DATA or DECODED) */


### PR DESCRIPTION
Added command `execreplace(COMMAND)`. It acts as:
```
log(DATA.data, "/tmp/output");
drop();
inject("cat /tmp/output | COMMAND");
exec("rm -f /tmp/output");
```