### PR TITLE
pass LUA script arguments from ettercap to the script

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -16,6 +16,7 @@ Legend:
    !! Fix segmentation fault when etterlog concatinate files
    !! Fix compiling with GCC version / defaulting to -fno-common
    !! Fix bad UDP length for packets changed with replace()
+   !! Fix passing --lua-args arguments to LUA scripts
     + Take over client-side SNI extension in ClientHello in SSL interception (req. OpenSSL 1.1.1)
     + Take over SAN certificate extension from server certificate in SSL interception
     + Use server certificate sign algorithm to sign fake certificate defaulting to SHA256

--- a/README.LUA
+++ b/README.LUA
@@ -9,3 +9,26 @@ Building.
    cmake -DENABLE_LUA=On ..
    make
    sudo make install
+
+Example Scripts:
+   See example scripts under src/lua/share/scripts/ or when installed under
+   /usr/local/share/ettercap/lua/scripts/.
+
+Script Execution:
+   Pass the script to the --lua-script parameter. More scripts can be
+   specficied separated with comma (no spaces).
+
+   ettercap [OPTIONS] --lua-script=<script1>[,<script2>,...]
+
+Script Parameters:
+   You can pass parameters to the LUA script by passing them to the
+   --lua-args parameter in key-value pairs. Multiple key-value pairs can be
+   specified separated with comma (no spaces).
+
+   ettercap [OPTIONS] --lua-args n1=v1,[n2=v2,...]
+
+   To access these parameters in the LUA script, they're available as a
+   table variable called SCRIPT_AGRS. So the following example access the
+   parameter key "n1":
+
+   ettercap.log("value for n1: %s", SCRIPT_ARGS["n1"])

--- a/src/lua/share/core/ettercap.lua
+++ b/src/lua/share/core/ettercap.lua
@@ -145,6 +145,7 @@ do
 
     local env = {
       SCRIPT_PATH = script_path,
+      SCRIPT_ARGS = script_params,
       dependencies = {},
     };
 


### PR DESCRIPTION
@justfalter I'm not sure if this pull request is necessary of if there is another way to pass the arguments to the LUA script that I haven't seen. Could you please confirm?

I've tested that scripts that expect only one argument (which is the packet object) are still working w/o complains even though the caller (hook handler) is passing a second argument.

This pull request is supposed to fix #1011 