### PR TITLE
Release candidate version numbering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project(ettercap C)
 
-set(VERSION "0.8.3")
+set(VERSION "0.8.4-rc")
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 set(CMAKE_SCRIPT_PATH "${CMAKE_SOURCE_DIR}/cmake/Scripts")

--- a/include/ec_version.h
+++ b/include/ec_version.h
@@ -1,10 +1,10 @@
 #ifndef ETTERCAP_VERS_H
 #define ETTERCAP_VERS_H
 
-#define EC_VERSION            "0.8.3"
+#define EC_VERSION            "0.8.4-rc"
 #define EC_VERSION_MAJOR      0
 #define EC_VERSION_MINOR      8
-#define EC_VERSION_REVISION   3
+#define EC_VERSION_REVISION   4
 #ifndef PROGRAM
    #define PROGRAM            "ettercap"
 #endif


### PR DESCRIPTION
This pull request fixes #1030 .
In order to be able to better differentiate during troubleshooting (analyzing debug files) if the distribution provided version or a version under development has been used, the version is numbered with the next version with the suffix "-rc".
