### PR TITLE
fix etter.mdns install issue

### DIFF
--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -7,6 +7,7 @@ endif()
 
 set(EC_CONFFILES
     etter.dns
+    etter.mdns
     etter.nbns
 )
 
@@ -42,8 +43,6 @@ endforeach()
 install(FILES
         ${CMAKE_CURRENT_BINARY_DIR}/${EC_CONFFILES}
         ${CMAKE_CURRENT_BINARY_DIR}/etter.conf
-        ${CMAKE_CURRENT_BINARY_DIR}/etter.dns
-        ${CMAKE_CURRENT_BINARY_DIR}/etter.mdns
         DESTINATION ${INSTALL_SYSCONFDIR}/ettercap)
 install(FILES
         ${CMAKE_CURRENT_BINARY_DIR}/${EC_DATAFILES}


### PR DESCRIPTION
Fixes #1054 
01bc0b2f41f8b5e100196c434f34f3dbb353dc76 introduced a install issue for etter.mdns file since the file hasn't been in scope of the configure step.
