### PR TITLE
Set 0.8.4-rc as candidate version for next minor release

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 project(ettercap C)
 
-set(VERSION "0.8.3.1")
+set(VERSION "0.8.4-rc")
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/Modules")
 set(CMAKE_SCRIPT_PATH "${CMAKE_SOURCE_DIR}/cmake/Scripts")

--- a/include/ec_version.h
+++ b/include/ec_version.h
@@ -1,11 +1,11 @@
 #ifndef ETTERCAP_VERS_H
 #define ETTERCAP_VERS_H
 
-#define EC_VERSION            "0.8.3.1"
+#define EC_VERSION            "0.8.4-rc"
 #define EC_VERSION_MAJOR       0
 #define EC_VERSION_MINOR       8
-#define EC_VERSION_REVISION    3
-#define EC_VERSION_SUBREVISION 1
+#define EC_VERSION_REVISION    4
+#define EC_VERSION_SUBREVISION 0
 #ifndef PROGRAM
    #define PROGRAM            "ettercap"
 #endif


### PR DESCRIPTION
This is just to differentiate between 0.8.3.1 release and current master branch.