### PR TITLE
Explicitely free globals at exit

### DIFF
--- a/include/ec_capture.h
+++ b/include/ec_capture.h
@@ -11,6 +11,7 @@ EC_API_EXTERN EC_THREAD_FUNC(capture);
 
 EC_API_EXTERN int is_pcap_file(char *file, char *pcap_errbuf);
 EC_API_EXTERN void capture_getifs(void);
+EC_API_EXTERN void capture_freeifs(void);
 EC_API_EXTERN char* capture_default_if(void);
 
 #define FUNC_ALIGNER(func) int func(void)

--- a/include/ec_globals.h
+++ b/include/ec_globals.h
@@ -120,6 +120,7 @@ struct program_env {
 
 /* global pcap structure */
 struct pcap_env {
+   pcap_if_t     *allifs;
    pcap_if_t     *ifs;
    u_int8         align;         /* alignment needed on sparc 4*n - sizeof(media_hdr) */
    char           promisc;

--- a/src/ec_capture.c
+++ b/src/ec_capture.c
@@ -104,21 +104,35 @@ EC_THREAD_FUNC(capture)
  */
 void capture_getifs(void)
 {
-   pcap_if_t *dev, *pdev, *ndev;
+   pcap_if_t *dev, *pdev, *ndev, *cdev;
    char pcap_errbuf[PCAP_ERRBUF_SIZE];
    
    DEBUG_MSG("capture_getifs");
+
+   /* pointer for the filtered list */
+   pdev = cdev = NULL;
   
-   /* retrieve the list */
-   if (pcap_findalldevs((pcap_if_t **)&EC_GBL_PCAP->ifs, pcap_errbuf) == -1)
+   /* retrieve the list of all interfaces */
+   if (pcap_findalldevs((pcap_if_t **)&EC_GBL_PCAP->allifs, pcap_errbuf) == -1)
       ERROR_MSG("%s", pcap_errbuf);
 
-   /* analize the list and remove unwanted entries */
-   for (pdev = dev = (pcap_if_t *)EC_GBL_PCAP->ifs; dev != NULL; dev = ndev) {
+   /* analyze the list and take over only wanted entries to the filtered list */
+   for (dev = (pcap_if_t *)EC_GBL_PCAP->allifs; dev != NULL; dev = ndev) {
       
       /* the next entry in the list */
       ndev = dev->next;
       
+      /* skip the pseudo device 'any' 'nflog' and 'nfqueue' */
+      /* skip the pseudo device 'dbus-system' and 'dbus-session' shown on mac when ran without sudo*/
+      if (
+            !strcmp(dev->name, "any") ||
+            !strcmp(dev->name, "nflog") ||
+            !strcmp(dev->name, "nfqueue")  ||
+            !strcmp(dev->name, "dbus-system") ||
+            !strcmp(dev->name, "dbus-session")
+         )
+         continue;
+
       /* set the description for the local loopback */
       if (dev->flags & PCAP_IF_LOOPBACK) {
          SAFE_FREE(dev->description);
@@ -127,28 +141,25 @@ void capture_getifs(void)
      
       /* fill the empty descriptions */
       if (dev->description == NULL)
-         dev->description = dev->name;
+         dev->description = strdup(dev->name);
 
-      /* remove the pseudo device 'any' 'nflog' and 'nfqueue' */
-      /* remove the pseudo device 'dbus-system' and 'dbus-session' shown on mac when ran without sudo*/
-      if (!strcmp(dev->name, "any") || !strcmp(dev->name, "nflog") || !strcmp(dev->name, "nfqueue")  || !strcmp(dev->name, "dbus-system") || !strcmp(dev->name, "dbus-session")) {
-         /* check if it is the first in the list */
-         if (dev == EC_GBL_PCAP->ifs)
-            EC_GBL_PCAP->ifs = ndev;
-         else
-            pdev->next = ndev;
+      /* take over entry in filtered list */
+      SAFE_CALLOC(cdev, 1, sizeof(pcap_if_t));
+      memcpy(cdev, dev, sizeof(pcap_if_t));
+      DEBUG_MSG("capture_getifs: [%s] %s", cdev->name, cdev->description);
 
-         SAFE_FREE(dev->name);
-         SAFE_FREE(dev->description);
-         SAFE_FREE(dev);
+      /* reset link to next list element */
+      cdev->next = NULL;
 
-         continue;
-      }
+      /* Safe the head of list of not done already */
+      if (EC_GBL_PCAP->ifs == NULL)
+         EC_GBL_PCAP->ifs = cdev;
+      else /* redefine list link */
+         pdev->next = cdev;
+
+      /* preserve pointer for next run */
+      pdev = cdev;
      
-      /* remember the previous device for the next loop */
-      pdev = dev;
-      
-      DEBUG_MSG("capture_getifs: [%s] %s", dev->name, dev->description);
    }
 
    /* do we have to print the list ? */
@@ -165,6 +176,25 @@ void capture_getifs(void)
       clean_exit(0);
    }
                    
+}
+
+/*
+ * properly free interfaces list from libpcap
+ */
+void capture_freeifs(void)
+{
+   pcap_if_t *dev, *ndev;
+
+   /* first free filtered list entries */
+   for (dev = EC_GBL_PCAP->ifs; dev != NULL; dev = ndev) {
+      /* save the next entry in the list and free memory for the entry */
+      ndev = dev->next;
+      SAFE_FREE(dev);
+   }
+
+   /* Finally free the complete data structure using libpcap */
+   if (EC_GBL_PCAP && EC_GBL_PCAP->allifs)
+      pcap_freealldevs(EC_GBL_PCAP->allifs);
 }
 
 /*

--- a/src/ec_globals.c
+++ b/src/ec_globals.c
@@ -23,6 +23,7 @@
 #include <ec_sniff.h>
 #include <ec_filter.h>
 #include <ec_plugins.h>
+#include <ec_capture.h>
 
 #define EC_GBL_FREE(x) do{ if (x != NULL) { free(x); x = NULL; } }while(0)
 
@@ -58,6 +59,10 @@ void ec_globals_alloc(void)
    /* init the structures */
    TAILQ_INIT(&EC_GBL_PROFILES);
    LIST_INIT(&EC_GBL_HOSTLIST);
+
+   /* properly free at exit */
+   /* 1st call of atexit - will be executed last */
+   atexit(ec_globals_free);
    
    return;
 }
@@ -66,6 +71,7 @@ void ec_globals_alloc(void)
 void ec_globals_free(void)
 {
  
+   capture_freeifs();
    EC_GBL_FREE(ec_gbls->pcap);
    EC_GBL_FREE(ec_gbls->lnet);
    EC_GBL_FREE(ec_gbls->iface);


### PR DESCRIPTION
This PR fixes #1070 
Function `ec_globals_free()` is for whatever reason not called at all.
However, due to manipulating the list of interfaces from *libpcap*, the list could not be properly freed using the library provided function to free the complete data structure as it would lead to double-free memory corruption.

Additionally to schedule the freeing of the globals at exit, this PR changes the approach to filter the interface list, as it creates a parallel linked list linked only with the filtered entries.

This way the double-free corruption is circumvented since the original list from *libpcap* remains unchanged throughout the lifecycle of the program.