### PR TITLE
Fix detection of latest libnet

### DIFF
--- a/cmake/Modules/FindLIBNET.cmake
+++ b/cmake/Modules/FindLIBNET.cmake
@@ -37,9 +37,9 @@ endif()
 function(_LIBNET_GET_VERSION _OUT_version _OUT_version_major _OUT_version_minor _libnet_hdr)
   file(READ ${_libnet_hdr} _contents)
   if(_contents)
-    string(REGEX REPLACE ".*#define LIBNET_VERSION[ \t]+\"([0-9.rc-]+)\".*" "\\1" ${_OUT_version} "${_contents}")
+    string(REGEX REPLACE ".*#define LIBNET_VERSION[ \t]+\"([0-9.a-zA-Z-]+)\".*" "\\1" ${_OUT_version} "${_contents}")
 
-    if(NOT ${_OUT_version} MATCHES "[0-9.rc-]+")
+    if(NOT ${_OUT_version} MATCHES "[0-9.a-zA-Z-]+")
       message(FATAL_ERROR "Version parsing failed for LIBNET_VERSION!")
     endif()
 


### PR DESCRIPTION
Latest head of https://github.com/libnet/libnet.git specifies version as "1.3-dev".