### PR TITLE
manipulate and properly free interface description only on filtered copy

### DIFF
--- a/src/ec_capture.c
+++ b/src/ec_capture.c
@@ -133,19 +133,20 @@ void capture_getifs(void)
          )
          continue;
 
-      /* set the description for the local loopback */
-      if (dev->flags & PCAP_IF_LOOPBACK) {
-         SAFE_FREE(dev->description);
-         dev->description = strdup("Local Loopback");
-      }
-     
-      /* fill the empty descriptions */
-      if (dev->description == NULL)
-         dev->description = strdup(dev->name);
-
       /* take over entry in filtered list */
       SAFE_CALLOC(cdev, 1, sizeof(pcap_if_t));
       memcpy(cdev, dev, sizeof(pcap_if_t));
+
+      /* set the description for the local loopback */
+      if (cdev->flags & PCAP_IF_LOOPBACK) {
+         SAFE_FREE(cdev->description);
+         cdev->description = strdup("Local Loopback");
+      }
+     
+      /* fill the empty descriptions */
+      if (cdev->description == NULL)
+         cdev->description = strdup(cdev->name);
+
       DEBUG_MSG("capture_getifs: [%s] %s", cdev->name, cdev->description);
 
       /* reset link to next list element */
@@ -189,6 +190,7 @@ void capture_freeifs(void)
    for (dev = EC_GBL_PCAP->ifs; dev != NULL; dev = ndev) {
       /* save the next entry in the list and free memory for the entry */
       ndev = dev->next;
+      SAFE_FREE(dev->description);
       SAFE_FREE(dev);
    }
 


### PR DESCRIPTION
This PR addresses the concern raised by @LocutusOfBorg in #1075 about the freeing of allocated memory when the description of an PCAP interface is manipulated.

The approach of this PR is to not do any modification on the PCAP data structure to not risk any influence on the inside functions provided and used from **libpcap** including `pcap_freealldevs()`.

The manipulations are only done on the copy of the _pcap_if_ structure and then consequently freed in `capture_freeifs()`.