### PR TITLE
fix disabling forwarding if sub-interfaces are specified on Linux

### DIFF
--- a/include/ec_inet.h
+++ b/include/ec_inet.h
@@ -118,7 +118,7 @@ EC_API_EXTERN void disable_interface_offload(void);
 #endif
 
 #if defined OS_LINUX && defined WITH_IPV6
-EC_API_EXTERN void check_tempaddr(const char *iface);
+EC_API_EXTERN void check_tempaddr(const char *interface);
 #endif
 
 /********************/


### PR DESCRIPTION
This PR is supposed to fix #1094 
Since sub-interfaces are not maintained by the kernel as dedicated interfaces that can be configured, the Linux dependent code should ignore the sub-part of the interface specification when disabling or re-enabling the forwarding configuration.