### PR TITLE
Fix profile host addition for hosts subject of SSL interception

### DIFF
--- a/src/ec_profiles.c
+++ b/src/ec_profiles.c
@@ -175,7 +175,13 @@ static int profile_add_host(struct packet_object *po)
    /* We don't need a profile on ourselves, do we? */
    if(!memcmp(&po->L2.src, &EC_GBL_IFACE->mac, MEDIA_ADDR_LEN) ||
       !memcmp(&po->L2.src, &EC_GBL_BRIDGE->mac, MEDIA_ADDR_LEN))
-      return 0;
+      /*
+       * This check does not apply when the packet is subject to SSL
+       * interception as the decrypted packet object is a constructed
+       * packet object w/o L2 info
+       */
+      if (!(po->flags & PO_FROMSSL))
+         return 0;
    
    /* 
     * if the type is FP_HOST_NONLOCAL 


### PR DESCRIPTION
When credentials are sniffed using SSL interception, a basic L2 check prevents the SSL host to be added to the profiles list.

The SSL engine creates "_fake_" packet objects only with reconstructed IP address and TCP port information, but it's missing Layer 2 information, hence set to 0 (`00:00:00:00:00:00`).

This is because the SSL engine uses sockets from the operating system to communicate with the SSL client and SSL server.
The Layer2 information is not accessible through the sockets API.

When ettercap is operating in Unified mode, the MAC address of the bridge interface is also initialized with 0 (`00:00:00:00:00:00`). 

This makes the origin check matching, which is originally supposed to prevent creating profile host for packets from/to our own host running ettercap. This effectively prevents the profile host being created for decypted packet that might even contain credential information.

The pull request overrules this check when the treated packet object is coming from the SSL engine as a fake packet object.