### PR TITLE
Install app icon in XDG hicolor icon theme

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,7 +121,7 @@ endif()
 set(PKEXEC_INSTALL_WRAPPER org.pkexec.ettercap CACHE PATH "Name of the pkexec action file")
 set(DESKTOP_DIR ${INSTALL_PREFIX}/share/applications/ CACHE PATH "Desktop file installation directory")
 set(METAINFO_DIR ${INSTALL_PREFIX}/share/metainfo/ CACHE PATH "Metainfo file installation directory")
-set(ICON_DIR ${INSTALL_PREFIX}/share/pixmaps CACHE PATH "Icon file installation directory")
+set(ICON_DIR ${INSTALL_PREFIX}/share/icons/hicolor CACHE PATH "XDG hicolor icon theme installation directory")
 set(MAN_INSTALLDIR ${INSTALL_PREFIX}/share/man CACHE PATH "Path for manual pages")
 
 if(NOT DISABLE_RPATH)

--- a/share/CMakeLists.txt
+++ b/share/CMakeLists.txt
@@ -51,6 +51,6 @@ install(FILES
 # since ettercap now uses this file as the application icon
 # we still need the icon even if the desktop file is not being installed
 if(ENABLE_GTK)
-  install(FILES ettercap.svg DESTINATION ${ICON_DIR})
+  install(FILES ettercap.svg DESTINATION ${ICON_DIR}/scalable/apps)
 endif()
 

--- a/src/interfaces/gtk/ec_gtk.c
+++ b/src/interfaces/gtk/ec_gtk.c
@@ -919,7 +919,7 @@ static void gtkui_setup(void)
    gtk_window_set_default_size(GTK_WINDOW (window), width, height);
 
    /* set window icon */
-   path = ICON_DIR "/" ICON_FILE;
+   path = ICON_DIR "/scalable/apps/" ICON_FILE;
    if (g_file_test(path, G_FILE_TEST_EXISTS)) {
       gtk_window_set_icon(GTK_WINDOW(window), gdk_pixbuf_new_from_file(path, NULL));
    }

--- a/src/interfaces/gtk3/ec_gtk3.c
+++ b/src/interfaces/gtk3/ec_gtk3.c
@@ -1138,7 +1138,7 @@ static void gtkui_build_widgets(GApplication* app, gpointer data)
    gtk_window_set_default_size(GTK_WINDOW(window), width, height);
 
    /* set window icon */
-   path = ICON_DIR "/" ICON_FILE;
+   path = ICON_DIR "/scalable/apps/" ICON_FILE;
    if (g_file_test(path, G_FILE_TEST_EXISTS)) {
       gtk_window_set_icon(GTK_WINDOW(window), gdk_pixbuf_new_from_file(path, NULL));
    }


### PR DESCRIPTION
Install the icon of the application in the hicolor XDG icon theme; this way it can be properly loaded by XDG menus in the currently set XDG icon theme, without looking in the legacy pixmaps location.

`ICON_DIR` is changed to refer to the top-level of the XDG hicolor icon theme rather than the precise location for the application SVGs, so it can be used in the future to install more icons in hicolor.