### PR TITLE
increase default connection buffer maximum

### DIFF
--- a/share/etter.conf.v4
+++ b/share/etter.conf.v4
@@ -32,7 +32,7 @@ port_steal_send_delay = 2000  # microseconds
 [connections]
 connection_timeout = 300      # seconds
 connection_idle = 5           # seconds
-connection_buffer = 10000     # bytes
+connection_buffer = 10000000  # bytes
 connect_timeout = 5           # seconds
 
 [stats]

--- a/share/etter.conf.v6
+++ b/share/etter.conf.v6
@@ -38,7 +38,7 @@ icmp6_probe_delay = 3         # seconds
 [connections]
 connection_timeout = 300      # seconds
 connection_idle = 5           # seconds
-connection_buffer = 10000     # bytes
+connection_buffer = 10000000  # bytes
 connect_timeout = 5           # seconds
 
 [stats]


### PR DESCRIPTION
For some connections it happens that either side (RX/TX) is showing no data.
This is mostly reasoned by exceeding the `cb->max_size` which is configurable with the **connection_buffer** configuration parameter.

This pull request increases the default maximum setting from ~10KB to ~10MB to reduce the risk of displaying incomplete connection buffers.