### PR TITLE
Fix build failures due to new ncurses adding -Werror=format-security

### DIFF
--- a/src/interfaces/curses/widgets/wdg_compound.c
+++ b/src/interfaces/curses/widgets/wdg_compound.c
@@ -378,7 +378,7 @@ static void wdg_compound_border(struct wdg_object *wo)
             wmove(ww->win, 0, c - strlen(wo->title) - 3);
             break;
       }
-      wprintw(ww->win, wo->title);
+      wprintw(ww->win, "%s", wo->title);
    }
    
    /* restore the attribute */

--- a/src/interfaces/curses/widgets/wdg_dialog.c
+++ b/src/interfaces/curses/widgets/wdg_dialog.c
@@ -209,7 +209,7 @@ static int wdg_dialog_redraw(struct wdg_object *wo)
   
    /* print the message text */
    wmove(ww->sub, 0, 0);
-   wprintw(ww->sub, ww->text);
+   wprintw(ww->sub, "%s", ww->text);
    
    /* refresh the window */
    redrawwin(ww->sub);
@@ -327,7 +327,7 @@ static void wdg_dialog_border(struct wdg_object *wo)
             wmove(ww->win, 0, c - strlen(wo->title) - 3);
             break;
       }
-      wprintw(ww->win, wo->title);
+      wprintw(ww->win, "%s", wo->title);
    }
    
    /* restore the attribute */

--- a/src/interfaces/curses/widgets/wdg_dynlist.c
+++ b/src/interfaces/curses/widgets/wdg_dynlist.c
@@ -295,7 +295,7 @@ static void wdg_dynlist_border(struct wdg_object *wo)
             wmove(ww->win, 0, c - strlen(wo->title) - 3);
             break;
       }
-      wprintw(ww->win, wo->title);
+      wprintw(ww->win, "%s", wo->title);
    }
    
    /* restore the attribute */

--- a/src/interfaces/curses/widgets/wdg_file.c
+++ b/src/interfaces/curses/widgets/wdg_file.c
@@ -336,7 +336,7 @@ static void wdg_file_borders(struct wdg_object *wo)
             wmove(ww->win, 0, c - strlen(wo->title) - 3);
             break;
       }
-      wprintw(ww->win, wo->title);
+      wprintw(ww->win, "%s", wo->title);
    }
    
    /* restore the attribute */

--- a/src/interfaces/curses/widgets/wdg_input.c
+++ b/src/interfaces/curses/widgets/wdg_input.c
@@ -314,7 +314,7 @@ static void wdg_input_borders(struct wdg_object *wo)
             wmove(ww->win, 0, c - strlen(wo->title) - 3);
             break;
       }
-      wprintw(ww->win, wo->title);
+      wprintw(ww->win, "%s", wo->title);
    }
    
    /* restore the attribute */

--- a/src/interfaces/curses/widgets/wdg_list.c
+++ b/src/interfaces/curses/widgets/wdg_list.c
@@ -303,7 +303,7 @@ static void wdg_list_borders(struct wdg_object *wo)
             wmove(ww->win, 0, c - strlen(wo->title) - 3);
             break;
       }
-      wprintw(ww->win, wo->title);
+      wprintw(ww->win, "%s", wo->title);
    }
    
    /* restore the attribute */

--- a/src/interfaces/curses/widgets/wdg_menu.c
+++ b/src/interfaces/curses/widgets/wdg_menu.c
@@ -319,7 +319,7 @@ static void wdg_menu_titles(struct wdg_object *wo)
       wmove(ww->menu, 0, current_screen.cols - strlen(wo->title) - 1);
       wbkgdset(ww->menu, COLOR_PAIR(wo->title_color));
       wattron(ww->menu, A_BOLD);
-      wprintw(ww->menu, wo->title);
+      wprintw(ww->menu, "%s", wo->title);
       wattroff(ww->menu, A_BOLD);
       wbkgdset(ww->menu, COLOR_PAIR(wo->window_color));
    }
@@ -338,7 +338,7 @@ static void wdg_menu_titles(struct wdg_object *wo)
          wprintw(ww->menu, "%s", mu->title);
 
       /* separator between two unit title */
-      wprintw(ww->menu, "  ");
+      wprintw(ww->menu, "%s", "  ");
    }
    
 }

--- a/src/interfaces/curses/widgets/wdg_panel.c
+++ b/src/interfaces/curses/widgets/wdg_panel.c
@@ -272,7 +272,7 @@ static void wdg_panel_border(struct wdg_object *wo)
             wmove(W(ww->win), 0, c - strlen(wo->title) - 3);
             break;
       }
-      wprintw(W(ww->win), wo->title);
+      wprintw(W(ww->win), "%s", wo->title);
    }
    
    /* restore the attribute */

--- a/src/interfaces/curses/widgets/wdg_percentage.c
+++ b/src/interfaces/curses/widgets/wdg_percentage.c
@@ -279,7 +279,7 @@ static void wdg_percentage_border(struct wdg_object *wo)
    /* there is a title: print it */
    if (wo->title) {
       wmove(ww->sub, 1, 2);
-      wprintw(ww->sub, wo->title);
+      wprintw(ww->sub, "%s", wo->title);
    }
    
    /* restore the attribute */

--- a/src/interfaces/curses/widgets/wdg_scroll.c
+++ b/src/interfaces/curses/widgets/wdg_scroll.c
@@ -309,7 +309,7 @@ static void wdg_scroll_border(struct wdg_object *wo)
             wmove(ww->win, 0, c - strlen(wo->title) - 3);
             break;
       }
-      wprintw(ww->win, wo->title);
+      wprintw(ww->win, "%s", wo->title);
    }
    
    /* restore the attribute */

--- a/src/interfaces/curses/widgets/wdg_window.c
+++ b/src/interfaces/curses/widgets/wdg_window.c
@@ -257,7 +257,7 @@ static void wdg_window_border(struct wdg_object *wo)
             wmove(ww->win, 0, c - strlen(wo->title) - 3);
             break;
       }
-      wprintw(ww->win, wo->title);
+      wprintw(ww->win, "%s", wo->title);
    }
    
    /* restore the attribute */

--- a/src/os/ec_mingw.c
+++ b/src/os/ec_mingw.c
@@ -1060,7 +1060,7 @@ int vwprintw (WINDOW *win, const char *fmt, va_list args)
   if (trace_on)
      PDC_debug ("vwprintw() - called\n");
   _vsnprintf (buf, sizeof(buf), fmt, args);
-  return wprintw (win, buf);
+  return wprintw (win, "%s", buf);
 }
 #endif  /* HAVE_NCURSES && !BUILDING_UTILS */
 


### PR DESCRIPTION
(See: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=995474)