### PR TITLE
Fix memory leak in sslw_hook_handled

### DIFF
--- a/src/ec_sslwrap.c
+++ b/src/ec_sslwrap.c
@@ -419,6 +419,7 @@ static void sslw_hook_handled(struct packet_object *po)
       memcpy(s->data, &po->L3.dst, sizeof(struct ip_addr));
       session_put(s);
 #else
+      SAFE_FREE(s->data);
       SAFE_FREE(s); /* Just get rid of it */
 #endif
    } else /* Pass only the SYN for conntrack */


### PR DESCRIPTION
sslw_create_session also allocates memory in the data field of the ec_session
struct.

(The `sslw_create_session(&s, PACKET);` call that allocates `s` and `s->data` is 7 lines above)