### PR TITLE
Alternative approach to fix memory leak when on Windows

### DIFF
--- a/plug-ins/sslstrip/sslstrip.c
+++ b/plug-ins/sslstrip/sslstrip.c
@@ -158,7 +158,7 @@ static int sslstrip_fini(void *);
 static void sslstrip(struct packet_object *po);
 static int sslstrip_is_http(struct packet_object *po);
 
-#ifndef OS_LINUX
+#if defined OS_LINUX || defined OS_DARWIN
 static void sslstrip_create_session(struct ec_session **s, struct packet_object *po);
 static int sslstrip_match(void *id_sess, void *id_curr);
 static size_t http_create_ident(void **i, struct packet_object *po);
@@ -338,7 +338,7 @@ static int sslstrip_is_http(struct packet_object *po)
    return 0;
 }
 
-#ifndef OS_LINUX
+#if defined OS_LINUX || defined OS_DARWIN
 static int sslstrip_match(void *id_sess, void *id_curr)
 {
    struct  http_ident *ids = id_sess;
@@ -398,7 +398,7 @@ static void sslstrip(struct packet_object *po)
    if ( (po->flags & PO_FORWARDABLE) &&
         (po->L4.flags & TH_SYN) &&
        !(po->L4.flags & TH_ACK) ) {
-#ifndef OS_LINUX
+#if defined OS_LINUX || defined OS_DARWIN
       struct ec_session *s = NULL;
       sslstrip_create_session(&s, PACKET);   
       memcpy(s->data, &po->L3.dst, sizeof(struct ip_addr));
@@ -648,7 +648,7 @@ static int http_get_peer(struct http_connection *connection)
 }
 
 
-#ifndef OS_LINUX
+#if defined OS_LINUX || defined OS_DARWIN
 static size_t http_create_ident(void **i, struct packet_object *po)
 {
    struct http_ident *ident;

--- a/src/ec_sslwrap.c
+++ b/src/ec_sslwrap.c
@@ -407,6 +407,7 @@ static void sslw_hook_handled(struct packet_object *po)
    /* If it's an ssl packet don't forward */
    po->flags |= PO_DROPPED;
    
+#if defined OS_LINUX || defined OS_DARWIN
    /* If it's a new connection */
    if ( (po->flags & PO_FORWARDABLE) && 
         (po->L4.flags & TH_SYN) &&
@@ -414,12 +415,9 @@ static void sslw_hook_handled(struct packet_object *po)
 
       sslw_create_session(&s, PACKET);
 
-#ifndef OS_LINUX
       /* Remember the real destination IP */
       memcpy(s->data, &po->L3.dst, sizeof(struct ip_addr));
       session_put(s);
-#else
-      SAFE_FREE(s); /* Just get rid of it */
 #endif
    } else /* Pass only the SYN for conntrack */
       po->flags |= PO_IGNORE;


### PR DESCRIPTION
This PR is an alternative approach to the aborted PR #1176 .
As discussed, I've turned around the pre-processor condition so that the session handling code parts are **only** compiled when on Linux or MacOS as these are the platforms with the best interception / redirect support.
When compiled on Windows, this section is not included anymore.

I've test this in a lab and intercepted a IMAPS connection via IPv4 and via IPv6. Both were working as expected.