### PR TITLE
Fix NDP spoofing "FATAL: NDP poisoning failed to start" 

### DIFF
--- a/src/mitm/ec_ip6nd_poison.c
+++ b/src/mitm/ec_ip6nd_poison.c
@@ -90,7 +90,7 @@ static int ndp_poison_start(char *args)
       SAFE_FREE(h);
    }
 
-   if(EC_GBL_OPTIONS->silent) {
+   if(EC_GBL_OPTIONS->silent && !EC_GBL_OPTIONS->load_hosts) {
       ret = create_list_silent();
    } else 
       ret = create_list();


### PR DESCRIPTION
Fix bug where when in NDP spoofing the provided list file was not taken into consideration to create the targets lists.
PR for Issue https://github.com/Ettercap/ettercap/issues/1182