### PR TITLE
fix segmentation fault when stopping isolate plugin

### DIFF
--- a/plug-ins/isolate/isolate.c
+++ b/plug-ins/isolate/isolate.c
@@ -113,8 +113,8 @@ static int isolate_fini(void *dummy)
    
    /* free the list */
    LIST_FOREACH_SAFE(h, &victims, next, tmp) {
-      SAFE_FREE(h);
       LIST_REMOVE(h, next);
+      SAFE_FREE(h);
    }
    
    return PLUGIN_FINISHED;


### PR DESCRIPTION
should be quite self-explaining
First remove entry from linked-list, then free the removed entry is the correct order.