### PR TITLE
Fix BSD build issues

### DIFF
--- a/include/ec.h
+++ b/include/ec.h
@@ -14,11 +14,6 @@
    #include <windows.h>
 #endif
 
-#if defined OS_DARWIN || defined OS_BSD
-   #define PCAP_DONT_INCLUDE_PCAP_BPF_H 1
-   #include <net/bpf.h>
-#endif
-
 #ifndef PATH_MAX
    #define PATH_MAX  1024
 #endif
@@ -51,6 +46,12 @@
    #define EC_API_EXTERN extern
 #endif
 
+/* on MacOSX net/bpf.h must be included before pcap.h in ec_globals.h */
+#ifdef OS_DARWIN
+   #define PCAP_DONT_INCLUDE_PCAP_BPF_H 1
+   #include <net/bpf.h>
+#endif
+
 /* these are often needed... */
 #include <ec_queue.h>
 #include <ec_error.h>
@@ -61,6 +62,12 @@
 
 #ifdef OS_MINGW
    #include <ec_os_mingw.h>
+#endif
+
+/* on BSD net/bpf.h must be included after queue.h in ec_queue.h */
+#ifdef OS_BSD
+   #define PCAP_DONT_INCLUDE_PCAP_BPF_H 1
+   #include <net/bpf.h>
 #endif
 
 

--- a/plug-ins/sslstrip/sslstrip.c
+++ b/plug-ins/sslstrip/sslstrip.c
@@ -161,7 +161,7 @@ static int sslstrip_fini(void *);
 static void sslstrip(struct packet_object *po);
 static int sslstrip_is_http(struct packet_object *po);
 
-#if defined OS_LINUX || defined OS_DARWIN
+#if defined OS_LINUX || defined OS_DARWIN || defined OS_BSD
 static void sslstrip_create_session(struct ec_session **s, struct packet_object *po);
 static int sslstrip_match(void *id_sess, void *id_curr);
 static size_t http_create_ident(void **i, struct packet_object *po);
@@ -366,7 +366,7 @@ static int sslstrip_is_http(struct packet_object *po)
    return 0;
 }
 
-#if defined OS_LINUX || defined OS_DARWIN
+#if defined OS_LINUX || defined OS_DARWIN || defined OS_BSD
 static int sslstrip_match(void *id_sess, void *id_curr)
 {
    struct  http_ident *ids = id_sess;
@@ -426,7 +426,7 @@ static void sslstrip(struct packet_object *po)
    if ( (po->flags & PO_FORWARDABLE) &&
         (po->L4.flags & TH_SYN) &&
        !(po->L4.flags & TH_ACK) ) {
-#if defined OS_LINUX || defined OS_DARWIN
+#if defined OS_LINUX || defined OS_DARWIN || defined OS_BSD
       struct ec_session *s = NULL;
       sslstrip_create_session(&s, PACKET);   
       memcpy(s->data, &po->L3.dst, sizeof(struct ip_addr));
@@ -676,7 +676,7 @@ static int http_get_peer(struct http_connection *connection)
 }
 
 
-#if defined OS_LINUX || defined OS_DARWIN
+#if defined OS_LINUX || defined OS_DARWIN || defined OS_BSD
 static size_t http_create_ident(void **i, struct packet_object *po)
 {
    struct http_ident *ident;

--- a/src/dissectors/ec_ssh.c
+++ b/src/dissectors/ec_ssh.c
@@ -146,6 +146,10 @@ FUNC_DECODER(dissector_ssh)
    BIGNUM *h_n, *s_n, *m_h_n, *m_s_n;
    BIGNUM *h_e, *s_e, *m_h_e, *m_s_e;
    BIGNUM *h_d, *s_d, *m_h_d, *m_s_d;
+   h_n = h_e = h_d = NULL;
+   s_n = s_e = s_d = NULL;
+   m_h_n = m_h_e = m_h_d = NULL;
+   m_s_n = m_s_e = m_s_d = NULL;
 #endif
 
    /* don't complain about unused var */

--- a/src/ec_debug.c
+++ b/src/ec_debug.c
@@ -101,10 +101,14 @@ void debug_init(void)
    fprintf(debug_file, "-> libpcre version %s\n", pcre_version());
    #endif
    #ifdef HAVE_PCRE2
-   if(EC_TOSTRING(PCRE2_PRERELEASE)[1] == 0)
-       fprintf(debug_file, "-> libpcre2 version %s.%s %s\n", EC_TOSTRING(PCRE2_MAJOR), EC_TOSTRING(PCRE2_MINOR), EC_TOSTRING(PCRE2_DATE));
+   if(strlen(EC_TOSTRING(PCRE2_PRERELEASE)))
+       fprintf(debug_file, "-> libpcre2 version %s.%s %s %s\n",
+             EC_TOSTRING(PCRE2_MAJOR), EC_TOSTRING(PCRE2_MINOR),
+             EC_TOSTRING(PCRE2_PRERELEASE), EC_TOSTRING(PCRE2_DATE));
    else
-       fprintf(debug_file, "-> libpcre2 version %s.%s %s %s\n", EC_TOSTRING(PCRE2_MAJOR), EC_TOSTRING(PCRE2_MINOR), EC_TOSTRING(PCRE2_PRERELEASE), EC_TOSTRING(PCRE2_DATE));
+       fprintf(debug_file, "-> libpcre2 version %s.%s %s\n",
+             EC_TOSTRING(PCRE2_MAJOR), EC_TOSTRING(PCRE2_MINOR),
+             EC_TOSTRING(PCRE2_DATE));
    #endif
    #ifdef HAVE_EC_LUA
 	ec_lua_print_version(debug_file);

--- a/src/ec_geoip.c
+++ b/src/ec_geoip.c
@@ -87,7 +87,7 @@ void geoip_init (void)
    descr = mmdb->metadata.description.descriptions[0];
    DEBUG_MSG("geoip_init: Description: %s Lang: %s.",
          descr->description, descr->language);
-   DEBUG_MSG("geoip_init: Info: IP version: %d, Epoch: %lu",
+   DEBUG_MSG("geoip_init: Info: IP version: %d, Epoch: %" PRIu64,
          mmdb->metadata.ip_version, mmdb->metadata.build_epoch);
 
    /* Output mandatory attribution for Maxmind Geolite2 database */

--- a/src/ec_sslwrap.c
+++ b/src/ec_sslwrap.c
@@ -407,7 +407,6 @@ static void sslw_hook_handled(struct packet_object *po)
    /* If it's an ssl packet don't forward */
    po->flags |= PO_DROPPED;
    
-#if defined OS_LINUX || defined OS_DARWIN
    /* If it's a new connection */
    if ( (po->flags & PO_FORWARDABLE) && 
         (po->L4.flags & TH_SYN) &&
@@ -418,7 +417,6 @@ static void sslw_hook_handled(struct packet_object *po)
       /* Remember the real destination IP */
       memcpy(s->data, &po->L3.dst, sizeof(struct ip_addr));
       session_put(s);
-#endif
    } else /* Pass only the SYN for conntrack */
       po->flags |= PO_IGNORE;
 }


### PR DESCRIPTION
The latest merges introduced some issues and warnings on BSD based systems including MacOSX.
This PR fixes the various issues and has been tested on MacOSX, FreeBSD and OpenBSD and on Linux of course.

A little bit tricky was the ordering of the header files, which was triggered externally due to an update on FreeBSD OS side, where they have included `queue.h` implicitly through `net/bpf.h` which blocked our customized `ec_queue.h` being included correctly.
However re-ordering this had the consequence on MacOSX that `pcap.h` was included too early for `net/bpf.h` for the MacOSX version.
So this is the reason to include `net/bpf.h` for the one BSD OS before and for the other after our set of general custom includes.

Further the removal of the differentiation of OS'es in `ec_sslwrap.c` do not really make sense to me, even though they've been motivated as a fix for #1176, however since there is now no more differentiation, there should also be no issue with memory leak on Windows anymore. Effectively the pre-processor implementation introduced a syntax error on non-Linux or non-MacOSX platforms, namely Windows and BSD.

On the `sslstrip.c` side, I just extended the supported OS with all BSD based OS'es, however I'm still not 100% confident if this is the right approach. If on Windows platform the OS driven limitations make such features effectively unavailable, it would be more consequent to make them really unavailable by excluding them with _CMake_. But this is something beyond the scope of this pull-request.