### PR TITLE
Fix plugin unload

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,7 +137,7 @@ set(CMAKE_C_FLAGS_DEBUG "-O0 -ggdb3 -DDEBUG -fno-common -Wall -Wno-pointer-sign 
 ## append ASAN build flags if compiler version has support
 #if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
 #   if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 4.8)
-#      set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address
+#      set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address \
 #         -fno-omit-frame-pointer" CACHE STRING "" FORCE)
 #      message("Building with ASAN support (GNU compiler)")
 #   else()
@@ -145,7 +145,7 @@ set(CMAKE_C_FLAGS_DEBUG "-O0 -ggdb3 -DDEBUG -fno-common -Wall -Wno-pointer-sign 
 #   endif()
 #elseif("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
 #   if(CMAKE_C_COMPILER_VERSION VERSION_GREATER 3.1)
-#      set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address
+#      set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -fsanitize=address \
 #         -fno-omit-frame-pointer" CACHE STRING "" FORCE)
 #      message("Building with ASAN support (Clang compiler)")
 #   elseif(CMAKE_C_COMPILER_VERSION VERSION_GREATER 3.1)

--- a/include/ec_plugins.h
+++ b/include/ec_plugins.h
@@ -14,6 +14,7 @@ struct plugin_ops
    char *version;                   /* the plugin version. note: 15 will be displayed as 1.5 */
    int (*init)(void *);          /* activation function */
    int (*fini)(void *);          /* deactivation function */
+   int (*unload)(void *);          /* clean-up function */
 };
 
 struct plugin_list
@@ -44,6 +45,7 @@ EC_API_EXTERN int plugin_init(char *name);
 EC_API_EXTERN int plugin_fini(char *name);
 EC_API_EXTERN int plugin_kill_thread(char *name, char *thread);
 
+#define PLUGIN_UNLOADED -1
 #define PLUGIN_FINISHED 0
 #define PLUGIN_RUNNING  1
 

--- a/plug-ins/arp_cop/arp_cop.c
+++ b/plug-ins/arp_cop/arp_cop.c
@@ -31,6 +31,7 @@
 int plugin_load(void *);
 static int arp_cop_init(void *);
 static int arp_cop_fini(void *);
+static int arp_cop_unload(void *);
 
 static void parse_arp(struct packet_object *po);
 static void arp_init_list(void);
@@ -53,6 +54,8 @@ struct plugin_ops arp_cop_ops = {
    .init =              &arp_cop_init,
    /* deactivation function */                     
    .fini =              &arp_cop_fini,
+   /* clean-up function */
+   .unload =              &arp_cop_unload,
 };
 
 /**********************************************************/
@@ -92,6 +95,23 @@ static int arp_cop_fini(void *dummy)
    hook_del(HOOK_PACKET_ARP_RQ, &parse_arp);
    hook_del(HOOK_PACKET_ARP_RP, &parse_arp);
    return PLUGIN_FINISHED;
+}
+
+static int arp_cop_unload(void *dummy)
+{
+   struct hosts_list *h;
+
+   /* variable not used */
+   (void) dummy;
+
+   /* free dynamically allocated memory */
+   while (!LIST_EMPTY(&arp_cop_table)) {
+      h = LIST_FIRST(&arp_cop_table);
+      LIST_REMOVE(h, next);
+      SAFE_FREE(h);
+   }
+
+   return PLUGIN_UNLOADED;
 }
 
 /*********************************************************/

--- a/plug-ins/autoadd/autoadd.c
+++ b/plug-ins/autoadd/autoadd.c
@@ -30,6 +30,7 @@
 int plugin_load(void *);
 static int autoadd_init(void *);
 static int autoadd_fini(void *);
+static int autoadd_unload(void *);
 
 static void parse_arp(struct packet_object *po);
 static int add_to_victims(void *group, struct packet_object *po);
@@ -49,6 +50,8 @@ struct plugin_ops autoadd_ops = {
    .init =              &autoadd_init,
    /* deactivation function */                     
    .fini =              &autoadd_fini,
+   /* clean-up function */
+   .unload =            &autoadd_unload,
 };
 
 /**********************************************************/
@@ -83,6 +86,14 @@ static int autoadd_fini(void *dummy)
 
    hook_del(HOOK_PACKET_ARP_RQ, &parse_arp);
    return PLUGIN_FINISHED;
+}
+
+static int autoadd_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 /*********************************************************/

--- a/plug-ins/chk_poison/chk_poison.c
+++ b/plug-ins/chk_poison/chk_poison.c
@@ -51,6 +51,7 @@ static pthread_mutex_t poison_mutex = PTHREAD_MUTEX_INITIALIZER;
 int plugin_load(void *);
 static int chk_poison_init(void *);
 static int chk_poison_fini(void *);
+static int chk_poison_unload(void *);
 static void parse_icmp(struct packet_object *po);
 
 /* plugin operations */
@@ -68,6 +69,8 @@ struct plugin_ops chk_poison_ops = {
    .init =              &chk_poison_init,
    /* deactivation function */                     
    .fini =              &chk_poison_fini,
+   /* clean-up function */
+   .unload =            &chk_poison_unload,
 };
 
 /**********************************************************/
@@ -181,6 +184,14 @@ static int chk_poison_fini(void *dummy)
    (void) dummy;
 
    return PLUGIN_FINISHED;
+}
+
+static int chk_poison_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 /*********************************************************/

--- a/plug-ins/dns_spoof/dns_spoof.c
+++ b/plug-ins/dns_spoof/dns_spoof.c
@@ -95,6 +95,7 @@ static SLIST_HEAD(, rr_entry) additional_list;
 int plugin_load(void *);
 static int dns_spoof_init(void *);
 static int dns_spoof_fini(void *);
+static int dns_spoof_unload(void *);
 static int load_db(void);
 static int parse_line(const char *str, int line, int *type_p, char **ip_p, u_int16 *port_p, char **name_p, u_int32 *ttl_p);
 static void dns_spoof(struct packet_object *po);
@@ -124,6 +125,8 @@ struct plugin_ops dns_spoof_ops = {
    .init =              &dns_spoof_init,
    /* deactivation function */                     
    .fini =              &dns_spoof_fini,
+   /* clean-up function */
+   .unload =            &dns_spoof_unload,
 };
 
 /**********************************************************/
@@ -160,13 +163,25 @@ static int dns_spoof_init(void *dummy)
 
 static int dns_spoof_fini(void *dummy) 
 {
-   struct dns_spoof_entry *d;
-
    /* variable not used */
    (void) dummy;
 
    /* remove the hook */
    hook_del(HOOK_PROTO_DNS, &dns_spoof);
+
+   return PLUGIN_FINISHED;
+}
+
+
+/*
+ * unload database list
+ */
+static int dns_spoof_unload(void *dummy)
+{
+   struct dns_spoof_entry *d;
+
+   /* variable not used */
+   (void) dummy;
 
    /* Free dynamically allocated memory */
    while (!SLIST_EMPTY(&dns_spoof_head)) {
@@ -178,7 +193,7 @@ static int dns_spoof_fini(void *dummy)
    }
 
 
-   return PLUGIN_FINISHED;
+   return PLUGIN_UNLOADED;
 }
 
 

--- a/plug-ins/dos_attack/dos_attack.c
+++ b/plug-ins/dos_attack/dos_attack.c
@@ -32,6 +32,7 @@
 int plugin_load(void *);
 static int dos_attack_init(void *);
 static int dos_attack_fini(void *);
+static int dos_attack_unload(void *);
 static void parse_arp(struct packet_object *po);
 
 #ifdef WITH_IPV6
@@ -65,6 +66,8 @@ struct plugin_ops dos_attack_ops = {
    .init =              &dos_attack_init,
    /* deactivation function */                     
    .fini =              &dos_attack_fini,
+   /* clean-up function */
+   .unload =            &dos_attack_unload,
 };
 
 /**********************************************************/
@@ -162,6 +165,14 @@ static int dos_attack_fini(void *dummy)
    INSTANT_USER_MSG("dos_attack: plugin terminated...\n");
 
    return PLUGIN_FINISHED;   
+}
+
+static int dos_attack_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 /*********************************************************/

--- a/plug-ins/dummy/dummy.c
+++ b/plug-ins/dummy/dummy.c
@@ -38,6 +38,7 @@ int plugin_load(void *);
 /* additional functions */
 static int dummy_init(void *);
 static int dummy_fini(void *);
+static int dummy_unload(void *);
 
 
 /* plugin operations */
@@ -55,6 +56,8 @@ struct plugin_ops dummy_ops = {
    .init =              &dummy_init,
    /* deactivation function */                     
    .fini =              &dummy_fini,
+   /* clean-up function */
+   .unload =            &dummy_unload,
 };
 
 /**********************************************************/
@@ -116,6 +119,24 @@ static int dummy_fini(void *dummy)
    USER_MSG("DUMMY: plugin finalization\n");
    return PLUGIN_FINISHED;
 }
+
+
+static int dummy_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   /*
+    * called during application shutdown.
+    * usually to free allocated memory during
+    * load function, init function or through
+    * the course of the plugin's lifetime
+    * but not free'd on purpose.
+    */
+   USER_MSG("DUMMY: plugin clean-up\n");
+   return PLUGIN_UNLOADED;
+}
+
 
 
 /* EOF */

--- a/plug-ins/find_conn/find_conn.c
+++ b/plug-ins/find_conn/find_conn.c
@@ -29,6 +29,7 @@
 int plugin_load(void *);
 static int find_conn_init(void *);
 static int find_conn_fini(void *);
+static int find_conn_unload(void *);
 
 static void parse_arp(struct packet_object *po);
 
@@ -47,6 +48,8 @@ struct plugin_ops find_conn_ops = {
    .init =              &find_conn_init,
    /* deactivation function */                     
    .fini =              &find_conn_fini,
+   /* clean-up function */
+   .unload =            &find_conn_unload,
 };
 
 /**********************************************************/
@@ -80,6 +83,14 @@ static int find_conn_fini(void *dummy)
 
    hook_del(HOOK_PACKET_ARP_RQ, &parse_arp);
    return PLUGIN_FINISHED;
+}
+
+static int find_conn_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 /*********************************************************/

--- a/plug-ins/find_ettercap/find_ettercap.c
+++ b/plug-ins/find_ettercap/find_ettercap.c
@@ -35,6 +35,7 @@
 int plugin_load(void *);
 static int find_ettercap_init(void *);
 static int find_ettercap_fini(void *);
+static int find_ettercap_unload(void *);
 static void parse_ip(struct packet_object *po);
 static void parse_icmp(struct packet_object *po);
 static void parse_tcp(struct packet_object *po);
@@ -54,6 +55,8 @@ struct plugin_ops find_ettercap_ops = {
    .init =              &find_ettercap_init,
    /* deactivation function */                     
    .fini =              &find_ettercap_fini,
+   /* clean-up function */
+   .unload =            &find_ettercap_unload,
 };
 
 /**********************************************************/
@@ -91,6 +94,14 @@ static int find_ettercap_fini(void *dummy)
    hook_del(HOOK_PACKET_TCP, &parse_tcp);
 
    return PLUGIN_FINISHED;
+}
+
+static int find_ettercap_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 /* 

--- a/plug-ins/find_ip/find_ip.c
+++ b/plug-ins/find_ip/find_ip.c
@@ -28,6 +28,7 @@
 int plugin_load(void *);
 static int find_ip_init(void *);
 static int find_ip_fini(void *);
+static int find_ip_unload(void *);
 static int in_list(struct ip_addr *scanip);
 static struct ip_addr *search_netmask(void);
 static struct ip_addr *search_targets(void);
@@ -47,6 +48,8 @@ struct plugin_ops find_ip_ops = {
    .init =              &find_ip_init,
    /* deactivation function */                     
    .fini =              &find_ip_fini,
+   /* clean-up function */
+   .unload =            &find_ip_unload,
 };
 
 /**********************************************************/
@@ -99,6 +102,14 @@ static int find_ip_fini(void *dummy)
    (void) dummy;
 
    return PLUGIN_FINISHED;
+}
+
+static int find_ip_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 /*********************************************************/

--- a/plug-ins/finger/finger.c
+++ b/plug-ins/finger/finger.c
@@ -43,6 +43,7 @@ static char fingerprint[FINGER_LEN + 1];
 int plugin_load(void *);
 static int finger_init(void *);
 static int finger_fini(void *);
+static int finger_unload(void *);
 
 static void get_finger(struct packet_object *po);
 static int good_target(struct ip_addr *ip, u_int16 *port);
@@ -64,6 +65,8 @@ struct plugin_ops finger_ops = {
    .init =              &finger_init,
    /* deactivation function */                     
    .fini =              &finger_fini,
+   /* clean-up function */
+   .unload =            &finger_unload,
 };
 
 /**********************************************************/
@@ -130,6 +133,14 @@ static int finger_fini(void *dummy)
    (void) dummy;
 
    return PLUGIN_FINISHED;
+}
+
+static int finger_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 /*********************************************************/

--- a/plug-ins/finger_submit/finger_submit.c
+++ b/plug-ins/finger_submit/finger_submit.c
@@ -34,6 +34,7 @@
 int plugin_load(void *);
 static int finger_submit_init(void *);
 static int finger_submit_fini(void *);
+static int finger_submit_unload(void *);
 
 
 /* plugin operations */
@@ -51,6 +52,8 @@ struct plugin_ops finger_submit_ops = {
    .init =              &finger_submit_init,
    /* deactivation function */                     
    .fini =              &finger_submit_fini,
+   /* clean-up function */
+   .unload =            &finger_submit_unload,
 };
 
 /**********************************************************/
@@ -130,6 +133,14 @@ static int finger_submit_fini(void *dummy)
    (void) dummy;
 
    return PLUGIN_FINISHED;
+}
+
+static int finger_submit_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 

--- a/plug-ins/fraggle_attack/fraggle_attack.c
+++ b/plug-ins/fraggle_attack/fraggle_attack.c
@@ -21,6 +21,7 @@
 int plugin_load(void *);
 static int fraggle_attack_init(void *);
 static int fraggle_attack_fini(void *);
+static int fraggle_attack_unload(void *);
 static EC_THREAD_FUNC(fraggler);
 
 /* globals */
@@ -31,6 +32,7 @@ struct plugin_ops fraggle_attack_ops = {
    .version =              "1.0",
    .init =                 &fraggle_attack_init,
    .fini =                 &fraggle_attack_fini,
+   .unload =               &fraggle_attack_unload,
 };
 
 
@@ -93,6 +95,14 @@ static int fraggle_attack_fini(void *dummy)
    }
 
    return PLUGIN_FINISHED;
+}
+
+static int fraggle_attack_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 static EC_THREAD_FUNC(fraggler)

--- a/plug-ins/gre_relay/gre_relay.c
+++ b/plug-ins/gre_relay/gre_relay.c
@@ -82,6 +82,7 @@ struct ip_addr fake_ip;
 int plugin_load(void *);
 static int gre_relay_init(void *);
 static int gre_relay_fini(void *);
+static int gre_relay_unload(void *);
 
 static void parse_gre(struct packet_object *po);
 static void parse_arp(struct packet_object *po);
@@ -104,6 +105,8 @@ struct plugin_ops gre_relay_ops = {
    .init =              &gre_relay_init,
    /* deactivation function */                     
    .fini =              &gre_relay_fini,
+   /* clean-up function */
+   .unload =            &gre_relay_unload,
 };
 
 /**********************************************************/
@@ -168,6 +171,15 @@ static int gre_relay_fini(void *dummy)
 #endif
 
    return PLUGIN_FINISHED;
+}
+
+
+static int gre_relay_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 /*********************************************************/

--- a/plug-ins/gw_discover/gw_discover.c
+++ b/plug-ins/gw_discover/gw_discover.c
@@ -40,6 +40,7 @@ static u_int16 port;
 int plugin_load(void *);
 static int gw_discover_init(void *);
 static int gw_discover_fini(void *);
+static int gw_discover_unload(void *);
 
 static int get_remote_target(struct ip_addr *ip, u_int16 *port);
 static void do_discover(void);
@@ -60,6 +61,8 @@ struct plugin_ops gw_discover_ops = {
    .init =              &gw_discover_init,
    /* deactivation function */                     
    .fini =              &gw_discover_fini,
+   /* clean-up function */
+   .unload =            &gw_discover_unload,
 };
 
 /**********************************************************/
@@ -98,6 +101,14 @@ static int gw_discover_fini(void *dummy)
    (void) dummy;
 
    return PLUGIN_FINISHED;
+}
+
+static int gw_discover_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 /*********************************************************/

--- a/plug-ins/isolate/isolate.c
+++ b/plug-ins/isolate/isolate.c
@@ -36,6 +36,7 @@ LIST_HEAD(, hosts_list) victims;
 int plugin_load(void *);
 static int isolate_init(void *);
 static int isolate_fini(void *);
+static int isolate_unload(void *);
 
 static void parse_arp(struct packet_object *po);
 static int add_to_victims(struct packet_object *po);
@@ -56,6 +57,8 @@ struct plugin_ops isolate_ops = {
    .init =              &isolate_init,
    /* deactivation function */                     
    .fini =              &isolate_fini,
+   /* clean-up function */
+   .unload =            &isolate_unload,
 };
 
 /**********************************************************/
@@ -120,6 +123,13 @@ static int isolate_fini(void *dummy)
    return PLUGIN_FINISHED;
 }
 
+static int isolate_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
+}
 /*********************************************************/
 
 /* Parse the arp packets */

--- a/plug-ins/krb5_downgrade/krb5_downgrade.c
+++ b/plug-ins/krb5_downgrade/krb5_downgrade.c
@@ -65,6 +65,7 @@
 int plugin_load(void *);
 static int krb5_downgrade_init(void *);
 static int krb5_downgrade_fini(void *);
+static int krb5_downgrade_unload(void *);
 
 static void parse_krb5(struct packet_object *po);
 
@@ -83,6 +84,8 @@ struct plugin_ops krb5_downgrade_ops = {
    .init = &krb5_downgrade_init,
    /* deactivation function */
    .fini = &krb5_downgrade_fini,
+   /* clean-up function */
+   .unload = &krb5_downgrade_unload,
 };
 
 int plugin_load(void *handle)
@@ -117,6 +120,16 @@ static int krb5_downgrade_fini(void *dummy)
    hook_del(HOOK_PROTO_KRB5, &parse_krb5);
    return PLUGIN_FINISHED;
 }
+
+static int krb5_downgrade_unload(void *dummy)
+{
+   /* variable not used */
+   (void)dummy;
+
+   return PLUGIN_UNLOADED;
+}
+
+
 
 /* Downgrade the "etype" values present in AS-REQ request */
 static void parse_krb5(struct packet_object *po)

--- a/plug-ins/mdns_spoof/mdns_spoof.c
+++ b/plug-ins/mdns_spoof/mdns_spoof.c
@@ -59,6 +59,7 @@ static SLIST_HEAD(, mdns_spoof_entry) mdns_spoof_head;
 int plugin_load(void *);
 static int mdns_spoof_init(void *);
 static int mdns_spoof_fini(void *);
+static int mdns_spoof_unload(void *);
 static int load_db(void);
 static void mdns_spoof(struct packet_object *po);
 static int parse_line(const char *str, int line, int *type_p, char **ip_p, u_int16 *port_p, char **name_p);
@@ -85,6 +86,8 @@ struct plugin_ops mdns_spoof_ops = {
    .init =              &mdns_spoof_init,
    /* deactivation function */                     
    .fini =              &mdns_spoof_fini,
+   /* clean-up function */
+   .unload =            &mdns_spoof_unload,
 };
 
 /* this function is called on plugin load */
@@ -125,6 +128,29 @@ static int mdns_spoof_fini(void *dummy)
 
    return PLUGIN_FINISHED;
 }
+
+
+/*
+ * unload database list
+ */
+static int mdns_spoof_unload(void *dummy)
+{
+   struct mdns_spoof_entry *d;
+
+   /* variable not used */
+   (void) dummy;
+
+   /* Free dynamically allocated memory */
+   while (!SLIST_EMPTY(&mdns_spoof_head)) {
+      d = SLIST_FIRST(&mdns_spoof_head);
+      SLIST_REMOVE_HEAD(&mdns_spoof_head, next);
+      SAFE_FREE(d->name);
+      SAFE_FREE(d);
+   }
+
+   return PLUGIN_UNLOADED;
+}
+
 
 /*
  * load the database in the list 

--- a/plug-ins/nbns_spoof/nbns_spoof.c
+++ b/plug-ins/nbns_spoof/nbns_spoof.c
@@ -191,7 +191,7 @@ struct plugin_ops nbns_spoof_ops = {
 	.version = 			"1.1",
 	.init = 			&nbns_spoof_init,
 	.fini = 			&nbns_spoof_fini,	
-	.unload = 		&nbns_spoof_unload,
+	.unload =			&nbns_spoof_unload,
 };
 
 int plugin_load(void *handle)

--- a/plug-ins/nbns_spoof/nbns_spoof.c
+++ b/plug-ins/nbns_spoof/nbns_spoof.c
@@ -173,6 +173,7 @@ typedef struct {
 int plugin_load(void *);
 static int nbns_spoof_init(void *);
 static int nbns_spoof_fini(void *);
+static int nbns_spoof_unload(void *);
 static int load_db(void);
 static void nbns_spoof(struct packet_object *po);
 static void nbns_set_challenge(struct packet_object *po);
@@ -190,6 +191,7 @@ struct plugin_ops nbns_spoof_ops = {
 	.version = 			"1.1",
 	.init = 			&nbns_spoof_init,
 	.fini = 			&nbns_spoof_fini,	
+	.unload = 		&nbns_spoof_unload,
 };
 
 int plugin_load(void *handle)
@@ -223,6 +225,27 @@ static int nbns_spoof_fini(void *dummy)
 
 	hook_del(HOOK_PROTO_NBNS, &nbns_spoof);
 	return PLUGIN_FINISHED;
+}
+
+/*
+ * unload databsae list
+ */
+static int nbns_spoof_unload(void *dummy)
+{
+   struct nbns_spoof_entry *d;
+
+   /* variable not used */
+   (void) dummy;
+
+   /* Free dynamically allocated memory */
+   while (!SLIST_EMPTY(&nbns_spoof_head)) {
+      d = SLIST_FIRST(&nbns_spoof_head);
+      SLIST_REMOVE_HEAD(&nbns_spoof_head, next);
+      SAFE_FREE(d->name);
+      SAFE_FREE(d);
+   }
+
+	return PLUGIN_UNLOADED;
 }
 
 /* load database */

--- a/plug-ins/pptp_chapms1/pptp_chapms1.c
+++ b/plug-ins/pptp_chapms1/pptp_chapms1.c
@@ -47,6 +47,7 @@ struct ppp_lcp_header {
 int plugin_load(void *);
 static int pptp_chapms1_init(void *);
 static int pptp_chapms1_fini(void *);
+static int pptp_chapms1_unload(void *);
 
 static void parse_ppp(struct packet_object *po);
 static u_char *parse_option(u_char * buffer, u_char option, int16 tot_len);
@@ -65,6 +66,8 @@ struct plugin_ops pptp_chapms1_ops = {
    .init =              &pptp_chapms1_init,
    /* deactivation function */                     
    .fini =              &pptp_chapms1_fini,
+   /* clean-up function */
+   .unload =            &pptp_chapms1_unload,
 };
 
 /**********************************************************/
@@ -104,6 +107,14 @@ static int pptp_chapms1_fini(void *dummy)
 
    hook_del(HOOK_PACKET_LCP, &parse_ppp);
    return PLUGIN_FINISHED;
+}
+
+static int pptp_chapms1_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 /*********************************************************/

--- a/plug-ins/pptp_clear/pptp_clear.c
+++ b/plug-ins/pptp_clear/pptp_clear.c
@@ -49,6 +49,7 @@ struct ppp_lcp_header {
 int plugin_load(void *);
 static int pptp_clear_init(void *);
 static int pptp_clear_fini(void *);
+static int pptp_clear_unload(void *);
 
 static void parse_lcp(struct packet_object *po);
 static void parse_ecp(struct packet_object *po);
@@ -70,6 +71,8 @@ struct plugin_ops pptp_clear_ops = {
    .init =              &pptp_clear_init,
    /* deactivation function */                     
    .fini =              &pptp_clear_fini,
+   /* clean-up function */
+   .unload =            &pptp_clear_unload,
 };
 
 /**********************************************************/
@@ -113,6 +116,14 @@ static int pptp_clear_fini(void *dummy)
    hook_del(HOOK_PACKET_ECP, &parse_ecp);
    hook_del(HOOK_PACKET_IPCP, &parse_ipcp);
    return PLUGIN_FINISHED;
+}
+
+static int pptp_clear_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 /*********************************************************/

--- a/plug-ins/pptp_pap/pptp_pap.c
+++ b/plug-ins/pptp_pap/pptp_pap.c
@@ -44,6 +44,7 @@ struct ppp_lcp_header {
 int plugin_load(void *);
 static int pptp_pap_init(void *);
 static int pptp_pap_fini(void *);
+static int pptp_pap_unload(void *);
 
 static void parse_ppp(struct packet_object *po);
 static u_char *parse_option(u_char * buffer, u_char option, int16 tot_len);
@@ -62,6 +63,8 @@ struct plugin_ops pptp_pap_ops = {
    .init =              &pptp_pap_init,
    /* deactivation function */                     
    .fini =              &pptp_pap_fini,
+   /* clean-up function */
+   .unload =            &pptp_pap_unload,
 };
 
 /**********************************************************/
@@ -101,6 +104,14 @@ static int pptp_pap_fini(void *dummy)
 
    hook_del(HOOK_PACKET_LCP, &parse_ppp);
    return PLUGIN_FINISHED;
+}
+
+static int pptp_pap_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 /*********************************************************/

--- a/plug-ins/pptp_reneg/pptp_reneg.c
+++ b/plug-ins/pptp_reneg/pptp_reneg.c
@@ -51,6 +51,7 @@ SLIST_HEAD(, call_list) call_table;
 int plugin_load(void *);
 static int pptp_reneg_init(void *);
 static int pptp_reneg_fini(void *);
+static int pptp_reneg_unload(void *);
 
 static void parse_ppp(struct packet_object *po);
 static int found_in_list(struct packet_object *po);
@@ -69,6 +70,8 @@ struct plugin_ops pptp_reneg_ops = {
    .init =              &pptp_reneg_init,
    /* deactivation function */                     
    .fini =              &pptp_reneg_fini,
+   /* clean-up function */
+   .unload =            &pptp_reneg_unload,
 };
 
 /**********************************************************/
@@ -119,6 +122,15 @@ static int pptp_reneg_fini(void *dummy)
 
    return PLUGIN_FINISHED;
 }
+
+static int pptp_reneg_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
+}
+
 
 /*********************************************************/
 

--- a/plug-ins/rand_flood/rand_flood.c
+++ b/plug-ins/rand_flood/rand_flood.c
@@ -61,6 +61,7 @@ char fake_pck[FAKE_PCK_LEN];
 int plugin_load(void *);
 static int rand_flood_init(void *);
 static int rand_flood_fini(void *);
+static int rand_flood_unload(void *);
 EC_THREAD_FUNC(flooder);
 
 
@@ -79,6 +80,8 @@ struct plugin_ops rand_flood_ops = {
    .init =              &rand_flood_init,
    /* deactivation function */                     
    .fini =              &rand_flood_fini,
+   /* clean-up function */
+   .unload =            &rand_flood_unload,
 };
 
 /**********************************************************/
@@ -128,6 +131,15 @@ static int rand_flood_fini(void *dummy)
 
    return PLUGIN_FINISHED;
 }
+
+static int rand_flood_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
+}
+
 
 
 EC_THREAD_FUNC(flooder)

--- a/plug-ins/remote_browser/remote_browser.c
+++ b/plug-ins/remote_browser/remote_browser.c
@@ -34,6 +34,7 @@
 int plugin_load(void *);
 static int remote_browser_init(void *);
 static int remote_browser_fini(void *);
+static int remote_browser_unload(void *);
 static void remote_browser(struct packet_object *po);
 static int good_page(char *str);
 
@@ -52,6 +53,8 @@ struct plugin_ops remote_browser_ops = {
    .init =              &remote_browser_init,
    /* deactivation function */                     
    .fini =              &remote_browser_fini,
+   /* clean-up function */
+   .unload =            &remote_browser_unload,
 };
 
 /**********************************************************/
@@ -87,6 +90,14 @@ static int remote_browser_fini(void *dummy)
    hook_del(HOOK_PROTO_HTTP, &remote_browser);
 
    return PLUGIN_FINISHED;
+}
+
+static int remote_browser_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 /* 

--- a/plug-ins/reply_arp/reply_arp.c
+++ b/plug-ins/reply_arp/reply_arp.c
@@ -31,6 +31,7 @@
 int plugin_load(void *);
 static int reply_arp_init(void *);
 static int reply_arp_fini(void *);
+static int reply_arp_unload(void *);
 static void parse_arp(struct packet_object *po);
 
 /* plugin operations */
@@ -47,6 +48,8 @@ struct plugin_ops reply_arp_ops = {
    .init =              &reply_arp_init,
    /* deactivation function */                     
    .fini =              &reply_arp_fini,
+   /* clean-up function */
+   .unload =            &reply_arp_unload,
 };
 
 /**********************************************************/
@@ -86,6 +89,14 @@ static int reply_arp_fini(void *dummy)
    hook_del(HOOK_PACKET_ARP_RQ, &parse_arp);
 
    return PLUGIN_FINISHED;
+}
+
+static int reply_arp_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 /*********************************************************/

--- a/plug-ins/repoison_arp/repoison_arp.c
+++ b/plug-ins/repoison_arp/repoison_arp.c
@@ -33,6 +33,7 @@
 int plugin_load(void *);
 static int repoison_arp_init(void *);
 static int repoison_arp_fini(void *);
+static int repoison_arp_unload(void *);
 static void repoison_func(struct packet_object *po);
 void repoison_victims(void *group_ptr, struct packet_object *po);
 
@@ -51,6 +52,8 @@ struct plugin_ops repoison_arp_ops = {
    .init =              &repoison_arp_init,
    /* deactivation function */                     
    .fini =              &repoison_arp_fini,
+   /* clean-up function */
+   .unload =            &repoison_arp_unload,
 };
 
 /**********************************************************/
@@ -93,6 +96,14 @@ static int repoison_arp_fini(void *dummy)
    hook_del(HOOK_PACKET_ARP_RP, &repoison_func);
 
    return PLUGIN_FINISHED;
+}
+
+static int repoison_arp_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 /*********************************************************/

--- a/plug-ins/smb_clear/smb_clear.c
+++ b/plug-ins/smb_clear/smb_clear.c
@@ -47,6 +47,7 @@ typedef struct {
 int plugin_load(void *);
 static int smb_clear_init(void *);
 static int smb_clear_fini(void *);
+static int smb_clear_unload(void *);
 
 static void parse_smb(struct packet_object *po);
 
@@ -65,6 +66,8 @@ struct plugin_ops smb_clear_ops = {
    .init =              &smb_clear_init,
    /* deactivation function */                     
    .fini =              &smb_clear_fini,
+   /* clean-up function */
+   .unload =            &smb_clear_unload,
 };
 
 /**********************************************************/
@@ -104,6 +107,14 @@ static int smb_clear_fini(void *dummy)
 
    hook_del(HOOK_PROTO_SMB, &parse_smb);
    return PLUGIN_FINISHED;
+}
+
+static int smb_clear_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 /*********************************************************/

--- a/plug-ins/smb_down/smb_down.c
+++ b/plug-ins/smb_down/smb_down.c
@@ -48,6 +48,7 @@ typedef struct {
 int plugin_load(void *);
 static int smb_down_init(void *);
 static int smb_down_fini(void *);
+static int smb_down_unload(void *);
 
 static void parse_smb(struct packet_object *po);
 
@@ -66,6 +67,8 @@ struct plugin_ops smb_down_ops = {
    .init =              &smb_down_init,
    /* deactivation function */                     
    .fini =              &smb_down_fini,
+   /* clean-up function */
+   .unload =            &smb_down_unload,
 };
 
 /**********************************************************/
@@ -105,6 +108,14 @@ static int smb_down_fini(void *dummy)
 
    hook_del(HOOK_PROTO_SMB_CHL, &parse_smb);
    return PLUGIN_FINISHED;
+}
+
+static int smb_down_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 /*********************************************************/

--- a/plug-ins/smurf_attack/smurf_attack.c
+++ b/plug-ins/smurf_attack/smurf_attack.c
@@ -16,6 +16,7 @@
 int plugin_load(void *);
 static int smurf_attack_init(void *);
 static int smurf_attack_fini(void *);
+static int smurf_attack_unload(void *);
 static EC_THREAD_FUNC(smurfer);
 
 /* globals */
@@ -27,6 +28,7 @@ struct plugin_ops smurf_attack_ops = {
    .version =              "1.0",
    .init =                 &smurf_attack_init,
    .fini =                 &smurf_attack_fini,
+   .unload =               &smurf_attack_unload,
 };
 
 /* teh c0d3 */
@@ -90,6 +92,14 @@ static int smurf_attack_fini(void *dummy)
    }
 
    return PLUGIN_FINISHED;
+}
+
+static int smurf_attack_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 static EC_THREAD_FUNC(smurfer)

--- a/plug-ins/sslstrip/sslstrip.c
+++ b/plug-ins/sslstrip/sslstrip.c
@@ -158,6 +158,7 @@ static regex_t find_cookie_re;
 int plugin_load(void *);
 static int sslstrip_init(void *);
 static int sslstrip_fini(void *);
+static int sslstrip_unload(void *);
 static void sslstrip(struct packet_object *po);
 static int sslstrip_is_http(struct packet_object *po);
 
@@ -208,6 +209,7 @@ struct plugin_ops sslstrip_ops = {
    .version =      "1.2",
    .init =         &sslstrip_init,
    .fini =         &sslstrip_fini,
+   .unload =       &sslstrip_unload,
 };
 
 int plugin_load(void *handle)
@@ -348,6 +350,14 @@ static int sslstrip_fini(void *dummy)
    hook_del(HOOK_HANDLED, &sslstrip);
 
    return PLUGIN_FINISHED;
+}
+
+static int sslstrip_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 static int sslstrip_is_http(struct packet_object *po)

--- a/plug-ins/stp_mangler/stp_mangler.c
+++ b/plug-ins/stp_mangler/stp_mangler.c
@@ -70,6 +70,7 @@ char fake_pck[FAKE_PCK_LEN];
 int plugin_load(void *);
 static int stp_mangler_init(void *);
 static int stp_mangler_fini(void *);
+static int stp_mangler_unload(void *);
 EC_THREAD_FUNC(mangler);
 
 
@@ -88,6 +89,8 @@ struct plugin_ops stp_mangler_ops = {
    .init =              &stp_mangler_init,
    /* deactivation function */                     
    .fini =              &stp_mangler_fini,
+   /* clean-up function */
+   .unload =            &stp_mangler_unload,
 };
 
 /**********************************************************/
@@ -136,6 +139,15 @@ static int stp_mangler_fini(void *dummy)
    INSTANT_USER_MSG("stp_mangler: plugin stopped...\n");
 
    return PLUGIN_FINISHED;
+}
+
+
+static int stp_mangler_unload(void *dummy)
+{
+   /* variable not used */
+   (void) dummy;
+
+   return PLUGIN_UNLOADED;
 }
 
 


### PR DESCRIPTION
This pull request fixes some memory leaks reported in #1201.
But it also fixes an issue in dns_spoof plugin:
If the plugin gets activated everything works as expected. When the plugin gets deactivated and re-activated,  the plugin doesn't know about any information specifiied in the __etter.dns__ configuration file.

This is due to an too-early free of entries read from `etter.dns` file.

However the ASAN reports are calmed down only when #1205 has been merged.