### PR TITLE
sslstrip: Enhance the libcurl version check to consider version 8+

### DIFF
--- a/plug-ins/sslstrip/sslstrip.c
+++ b/plug-ins/sslstrip/sslstrip.c
@@ -51,7 +51,7 @@
 
 #include <curl/curl.h>
 
-#if (LIBCURL_VERSION_MAJOR < 7) || (LIBCURL_VERSION_MINOR < 26)
+#if (LIBCURL_VERSION_MAJOR < 7) || (LIBCURL_VERSION_MAJOR == 7 && LIBCURL_VERSION_MINOR < 26)
 #error libcurl 7.26.0 or up is needed
 #endif
 


### PR DESCRIPTION
Lately curl has released version 8 and hence LIBCURL_VERSION_MAJOR is reset to 0, current check assumes major version to be 7 at max and hence on systems with libcurl 8+ this check breaks and build fails

Fixes

TOPDIR/build/tmp/work/cortexa15t2hf-neon-yoe-linux-gnueabi/ettercap/0.8.3.1-r0/git/plug-ins/sslstrip/sslstrip.c:57:2: error: libcurl 7.26.0 or up is needed
 ^
1 error generated.