### PR TITLE
cmake: Set minimum required version to 3.5 for CMake 4+ compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5)
 project(ettercap C)
 
 set(VERSION "0.8.4-rc")

--- a/cmake/Modules/FindGTK3.cmake
+++ b/cmake/Modules/FindGTK3.cmake
@@ -351,7 +351,7 @@ endif()
 #
 if(GTK3_FIND_VERSION)
   if(NOT DEFINED CMAKE_MINIMUM_REQUIRED_VERSION)
-    cmake_minimum_required(VERSION 2.6.2)
+    cmake_minimum_required(VERSION 3.5)
   endif()
   set(GTK3_FAILED_VERSION_CHECK true)
   if(GTK3_DEBUG)


### PR DESCRIPTION
| CMake Error at CMakeLists.txt:1 (cmake_minimum_required):
|   Compatibility with CMake < 3.5 has been removed from CMake.
|
|   Update the VERSION argument <min> value.  Or, use the <min>...<max> syntax
|   to tell CMake that the project requires at least <min> but has been updated
|   to work with policies introduced by <max> or earlier.
|
|   Or, add -DCMAKE_POLICY_VERSION_MINIMUM=3.5 to try configuring anyway.
|
|
| -- Configuring incomplete, errors occurred!