### PR TITLE
Fix #1284 - buffer length check for str_tohex()

### DIFF
--- a/src/ec_strings.c
+++ b/src/ec_strings.c
@@ -412,6 +412,10 @@ char * str_tohex(u_char *bin, size_t len, char *dst, size_t dst_len)
 
    memset(dst, 0, dst_len);
 
+   /* truncate to avoid write beyond buffer */
+   if (dst_len <= len*2)
+      len = (dst_len-1)/2; // keep buffer for trailing NULL byte
+
    for (i = 0; i < len; i++)
       sprintf(dst + i*2, "%02X", bin[i]);
 


### PR DESCRIPTION
This fix implements option 2 from the suggested counter measures against the potential which is probably least impacting one in terms of processing overhead.

@LocutusOfBorg What do you think? Merge or Keep as is, since with the current code, this condition is never met.