### PR TITLE
Increase minimum CMake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.25)
 project(ettercap C)
 
 set(VERSION "0.8.4-rc")

--- a/cmake/Modules/FindGTK3.cmake
+++ b/cmake/Modules/FindGTK3.cmake
@@ -351,7 +351,7 @@ endif()
 #
 if(GTK3_FIND_VERSION)
   if(NOT DEFINED CMAKE_MINIMUM_REQUIRED_VERSION)
-    cmake_minimum_required(VERSION 3.5)
+    cmake_minimum_required(VERSION 3.25)
   endif()
   set(GTK3_FAILED_VERSION_CHECK true)
   if(GTK3_DEBUG)


### PR DESCRIPTION
To fix Gentoo bug #955891 we incrase minimum CMake version to the minimum CMake version on the supported OS'es:
- Debian bookwork (oldstable): 3.25
- FreeBSD: 3.31
- OpenBSD: 3.31

Successfully tested on all supported OS'es.