### PR TITLE
Fix FreeBSD redirect (de-)installation issue

### DIFF
--- a/share/etter.conf.v4
+++ b/share/etter.conf.v4
@@ -175,7 +175,7 @@ geoip_data_file = ""
 #    Mac Os X
 #---------------
 
-   #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
+   #redir_command_on = "(pfctl -Psn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
    #redir_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet .+ any to %destination port = %port' | pfctl -f - 2> /dev/null"
 
 
@@ -192,7 +192,7 @@ geoip_data_file = ""
 # `pfctl -si | grep Status | awk '{print $2;}'`. If "Disabled", enable it with
 # `pfctl -e`.
 
-   #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
+   #redir_command_on = "(pfctl -Psn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
    #redir_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet .+ any to %destination port = %port' | pfctl -f - 2> /dev/null"
 
 

--- a/share/etter.conf.v6
+++ b/share/etter.conf.v6
@@ -191,11 +191,11 @@ geoip_data_file = ""
 #    Mac Os X
 #---------------
 
-   #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
+   #redir_command_on = "(pfctl -Psn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
    #redir_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet .+ any to %destination port = %port' | pfctl -f - 2> /dev/null"
 
 # BSD PF for IPv6:
-   #redir6_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet6 proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
+   #redir6_command_on = "(pfctl -Psn 2> /dev/null; echo 'rdr pass on %iface inet6 proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
    #redir6_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet6 .+ any to %destination port = %port' | pfctl -f - 2> /dev/null"
 
 
@@ -211,11 +211,11 @@ geoip_data_file = ""
 # `pfctl -si | grep Status | awk '{print $2;}'`. If "Disabled", enable it with
 # `pfctl -e`.
 
-   #redir_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
+   #redir_command_on = "(pfctl -Psn 2> /dev/null; echo 'rdr pass on %iface inet proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
    #redir_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet .+ any to %destination port = %port' | pfctl -f - 2> /dev/null"
 
 # pendant for IPv6
-   #redir6_command_on = "(pfctl -sn 2> /dev/null; echo 'rdr pass on %iface inet6 proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
+   #redir6_command_on = "(pfctl -Psn 2> /dev/null; echo 'rdr pass on %iface inet6 proto tcp from any to %destination port %port -> localhost port %rport') | pfctl -f - 2> /dev/null"
    #redir6_command_off = "pfctl -Psn 2> /dev/null | egrep -v 'inet6 .+ any to %destination port = %port' | pfctl -f - 2> /dev/null"
 
 #---------------


### PR DESCRIPTION
Due to an addition to `/etc/services` on a recent FreeBSD, the **http-alt** service name for 8080 got a ambiguous redundant entry.
Since the script to install redirect rules used port names and the script to uninstall used port numbers, the ambiguous installed **http-alt** rules could not be reverted when Ettercap closed and effectively haven't an effect since the port was not 8080:
```
$ grep http-alt /etc/services
http-alt	591/tcp	   #FileMaker, Inc. - HTTP Alternate (see Port 80)
http-alt	591/udp	   #FileMaker, Inc. - HTTP Alternate (see Port 80)
http-alt	8080/tcp   #HTTP Alternate (see port 80)
http-alt	8080/udp   #HTTP Alternate (see port 80)
$ 
```

Therefore, the fix is to use port numbers for installing new rules using `pfctl`.
