### PR TITLE
fix filter regression while keeping (CVE-2026-3606) fixed

### DIFF
--- a/include/ec.h
+++ b/include/ec.h
@@ -94,12 +94,6 @@
    ON_ERROR(x, NULL, "virtual memory exhausted"); \
 } while(0)
 
-#define SAFE_RECALLOC(x, s) do { \
-   x = realloc(x, s); \
-   ON_ERROR(x, NULL, "virtual memory exhausted"); \
-   memset(x, 0, s); \
-} while(0)
-
 #define SAFE_STRDUP(x, s) do{ \
    x = strdup(s); \
    ON_ERROR(x, NULL, "virtual memory exhausted"); \

--- a/utils/etterfilter/ef_output.c
+++ b/utils/etterfilter/ef_output.c
@@ -150,9 +150,10 @@ static size_t create_data_segment(u_char** data, struct filter_header *fh, struc
 static size_t add_data_segment(u_char **data, size_t base, u_char **string, size_t slen)
 {
    /* make room for the new string */
-   SAFE_RECALLOC(*data, base + slen + 1);
+   SAFE_REALLOC(*data, base + slen + 1);
 
    /* copy the string, NULL separated */
+   memset(*data + base, 0, slen + 1);
    memcpy(*data + base, *string, slen);
 
    /* 


### PR DESCRIPTION
This pull request is to fix #1248 
The error was, that the `*data` pointer always pointed to the same start address and `SAFE_RECALLOC` was then always overwriting more data per iteration except the last.

To avoid further confusion, I removed the macro `SAFE_RECALLOC`.

I tested the fix with ASAN support enabled, and it didn't trigger, since `memcpy()` is still not allowed to write the extra byte.
