### PR TITLE
curses: fix widgets drawing onto stdscr and wiping the screen

### DIFF
--- a/src/interfaces/curses/widgets/wdg.c
+++ b/src/interfaces/curses/widgets/wdg.c
@@ -193,6 +193,62 @@ void wdg_exit(void)
 }
 
 /*
+ * create the sub-window a menu or a form is posted into.
+ *
+ * derwin() refuses (and returns NULL) as soon as the requested geometry
+ * does not fit entirely within the parent window. Handing that NULL to
+ * set_menu_sub() / set_form_sub() is not an error for ncurses: it
+ * normalizes the NULL sub-window to stdscr, so the menu or the form is
+ * silently posted full-screen on stdscr instead of inside its widget.
+ * The next refresh of stdscr then wipes every other widget off the
+ * screen -- the menu bar included.
+ *
+ * So clamp the geometry to the parent, and never return NULL: falling
+ * back to the parent window itself keeps the widget self-contained.
+ */
+WINDOW * wdg_derwin(WINDOW *parent, int lines, int cols, int begin_y, int begin_x)
+{
+   WINDOW *sub;
+   int maxl, maxc;
+
+   if (parent == NULL)
+      return NULL;
+
+   getmaxyx(parent, maxl, maxc);
+
+   /* the offset alone must leave room for at least one line/column */
+   if (begin_y < 0 || begin_y >= maxl)
+      begin_y = 0;
+   if (begin_x < 0 || begin_x >= maxc)
+      begin_x = 0;
+
+   /* clamp the geometry to what is left of the parent */
+   if (lines <= 0 || lines > maxl - begin_y)
+      lines = maxl - begin_y;
+   if (cols <= 0 || cols > maxc - begin_x)
+      cols = maxc - begin_x;
+
+   sub = derwin(parent, lines, cols, begin_y, begin_x);
+
+   WDG_ON_ERROR(sub, NULL, "Cannot create a %dx%d sub-window", cols, lines);
+
+   /* never hand a NULL sub-window to the menu/form library */
+   return (sub != NULL) ? sub : parent;
+}
+
+/*
+ * destroy a sub-window created by wdg_derwin()
+ */
+void wdg_delderwin(WINDOW *parent, WINDOW *sub)
+{
+   /* wdg_derwin() fell back to the parent, nothing of our own to delete */
+   if (sub == NULL || sub == parent)
+      return;
+
+   delwin(sub);
+}
+
+/*
  * update the screen
  */
 void wdg_update_screen(void)

--- a/src/interfaces/curses/widgets/wdg_dialog.c
+++ b/src/interfaces/curses/widgets/wdg_dialog.c
@@ -177,13 +177,15 @@ static int wdg_dialog_redraw(struct wdg_object *wo)
       mvwin(ww->win, y, x);
       wresize(ww->win, l, c);
       wdg_dialog_border(wo);
-      wdg_dialog_buttons(wo);
-      
+
       /* resize the actual window and touch it */
       mvwin(ww->sub, y + 2, x + 2);
       wresize(ww->sub, l - 4, c - 4);
       /* set the window color */
       wbkgdset(ww->sub, COLOR_PAIR(wo->window_color));
+
+      /* the buttons live in ww->sub, so draw them at the new size */
+      wdg_dialog_buttons(wo);
 
    /* the first time we have to allocate the window */
    } else {
@@ -192,18 +194,21 @@ static int wdg_dialog_redraw(struct wdg_object *wo)
       if ((ww->win = newwin(l, c, y, x)) == NULL)
          return -WDG_E_FATAL;
 
-      /* draw the borders */
-      wdg_dialog_border(wo);
-      wdg_dialog_buttons(wo);
-
-      /* create the inner (actual) window */
+      /*
+       * create the inner (actual) window before drawing anything into
+       * it -- wdg_dialog_buttons() writes to ww->sub
+       */
       if ((ww->sub = newwin(l - 4, c - 4, y + 2, x + 2)) == NULL)
          return -WDG_E_FATAL;
-      
+
       /* set the window color */
       wbkgdset(ww->sub, COLOR_PAIR(wo->window_color));
       werase(ww->sub);
       redrawwin(ww->sub);
+
+      /* draw the borders */
+      wdg_dialog_border(wo);
+      wdg_dialog_buttons(wo);
 
    }
   
@@ -431,7 +436,16 @@ static void wdg_dialog_buttons(struct wdg_object *wo)
    /* no button to be displayed */
    if (ww->flags == WDG_NO_BUTTONS)
       return;
-   
+
+   /*
+    * never let a NULL window reach wprintw(): ncurses derives the screen
+    * from the window, so a single wprintw(NULL, ...) leaves its internal
+    * formatting buffer unusable and *every* later wprintw() in the
+    * process silently returns ERR without drawing anything.
+    */
+   if (ww->sub == NULL)
+      return;
+
    /* get the line of the message */
    wdg_dialog_get_size(wo, &l, &c);
 

--- a/src/interfaces/curses/widgets/wdg_file.c
+++ b/src/interfaces/curses/widgets/wdg_file.c
@@ -40,6 +40,7 @@ struct wdg_file_handle {
    WINDOW *win;
    MENU *m;
    WINDOW *mwin;
+   WINDOW *msub;
    ITEM **items;
    size_t nitems;
    int nlist;
@@ -68,6 +69,10 @@ static void wdg_file_menu_create(struct wdg_object *wo);
 static int wdg_file_virtualize(int key);
 static int wdg_file_driver(struct wdg_object *wo, int key, struct wdg_mouse_event *mouse);
 static void wdg_file_callback(struct wdg_object *wo, const char *path, char *file);
+
+/* implemented in wdg.c */
+extern WINDOW * wdg_derwin(WINDOW *parent, int lines, int cols, int begin_y, int begin_x);
+extern void wdg_delderwin(WINDOW *parent, WINDOW *sub);
 
 /*******************************************/
 
@@ -425,6 +430,14 @@ static void wdg_file_menu_destroy(struct wdg_object *wo)
    
    unpost_menu(ww->m);
    free_menu(ww->m);
+   ww->m = NULL;
+
+   /* the sub-window has to go before its parent */
+   wdg_delderwin(ww->mwin, ww->msub);
+   ww->msub = NULL;
+
+   delwin(ww->mwin);
+   ww->mwin = NULL;
 
    /* free all the items */
    while(ww->items[i] != NULL) 
@@ -547,9 +560,14 @@ static void wdg_file_menu_create(struct wdg_object *wo)
   
    /* associate with the menu */
    set_menu_win(ww->m, ww->mwin);
-   
-   /* the subwin for the menu */
-   set_menu_sub(ww->m, derwin(ww->mwin, mrows + 1, mcols, 1, 1));
+
+   /*
+    * the subwin for the menu.
+    * it must fit entirely within mwin, otherwise derwin() returns NULL
+    * and ncurses silently posts the menu on stdscr, wiping the screen.
+    */
+   ww->msub = wdg_derwin(ww->mwin, mrows, mcols, 0, 0);
+   set_menu_sub(ww->m, ww->msub);
 
    /* menu attributes */
    set_menu_mark(ww->m, "");

--- a/src/interfaces/curses/widgets/wdg_input.c
+++ b/src/interfaces/curses/widgets/wdg_input.c
@@ -32,6 +32,7 @@ struct wdg_input_handle {
    WINDOW *win;
    FORM *form;
    WINDOW *fwin;
+   WINDOW *fsub;
    FIELD **fields;
    size_t nfields;
    size_t x, y;
@@ -57,6 +58,10 @@ static int wdg_input_driver(struct wdg_object *wo, int key, struct wdg_mouse_eve
 static void wdg_input_form_destroy(struct wdg_object *wo);
 static void wdg_input_form_create(struct wdg_object *wo);
 static void wdg_input_consolidate(struct wdg_object *wo);
+
+/* implemented in wdg.c */
+extern WINDOW * wdg_derwin(WINDOW *parent, int lines, int cols, int begin_y, int begin_x);
+extern void wdg_delderwin(WINDOW *parent, WINDOW *sub);
 
 /*******************************************/
 
@@ -427,7 +432,13 @@ static void wdg_input_form_destroy(struct wdg_object *wo)
    unpost_form(ww->form);
    free_form(ww->form);
    ww->form = NULL;
+
+   /* the sub-window has to go before its parent */
+   wdg_delderwin(ww->fwin, ww->fsub);
+   ww->fsub = NULL;
+
    delwin(ww->fwin);
+   ww->fwin = NULL;
 }
 
 /*
@@ -456,16 +467,21 @@ static void wdg_input_form_create(struct wdg_object *wo)
    /* set the color */
    wbkgd(ww->fwin, COLOR_PAIR(wo->window_color));
    keypad(ww->fwin, TRUE);
-  
+
    /* associate with the form */
    set_form_win(ww->form, ww->fwin);
-   
-   /* the subwin for the form */
-   set_form_sub(ww->form, derwin(ww->fwin, mrows + 1, mcols, 1, 1));
+
+   /*
+    * the subwin for the form.
+    * it must fit entirely within fwin, otherwise derwin() returns NULL
+    * and ncurses silently posts the form on stdscr, wiping the screen.
+    */
+   ww->fsub = wdg_derwin(ww->fwin, mrows, mcols, 0, 0);
+   set_form_sub(ww->form, ww->fsub);
 
    /* make the active field in reverse mode */
    set_field_back(current_field(ww->form), A_REVERSE);
-   
+
    /* display the form */
    post_form(ww->form);
 

--- a/src/interfaces/curses/widgets/wdg_list.c
+++ b/src/interfaces/curses/widgets/wdg_list.c
@@ -37,6 +37,7 @@ struct wdg_list_call {
 struct wdg_list_handle {
    MENU *menu;
    WINDOW *mwin;
+   WINDOW *msub;
    WINDOW *win;
    ITEM *current;
    ITEM **items;
@@ -64,6 +65,10 @@ static void wdg_list_menu_create(struct wdg_object *wo);
 static void wdg_list_menu_destroy(struct wdg_object *wo);
 
 static int wdg_list_callback(struct wdg_object *wo, int key);
+
+/* implemented in wdg.c */
+extern WINDOW * wdg_derwin(WINDOW *parent, int lines, int cols, int begin_y, int begin_x);
+extern void wdg_delderwin(WINDOW *parent, WINDOW *sub);
 
 /*******************************************/
 
@@ -441,9 +446,14 @@ static void wdg_list_menu_create(struct wdg_object *wo)
    
    /* associate with the menu */
    set_menu_win(ww->menu, ww->mwin);
-   
-   /* the subwin for the menu */
-   set_menu_sub(ww->menu, derwin(ww->mwin, mrows + 1, mcols, 2, 2));
+
+   /*
+    * the subwin for the menu.
+    * it must fit entirely within mwin, otherwise derwin() returns NULL
+    * and ncurses silently posts the menu on stdscr, wiping the screen.
+    */
+   ww->msub = wdg_derwin(ww->mwin, mrows, mcols, 0, 0);
+   set_menu_sub(ww->menu, ww->msub);
 
    /* menu attributes */
    set_menu_mark(ww->menu, "");
@@ -487,6 +497,13 @@ static void wdg_list_menu_destroy(struct wdg_object *wo)
    free_menu(ww->menu);
 
    ww->menu = NULL;
+
+   /* the sub-window has to go before its parent */
+   wdg_delderwin(ww->mwin, ww->msub);
+   ww->msub = NULL;
+
+   delwin(ww->mwin);
+   ww->mwin = NULL;
 }
 
 /*

--- a/src/interfaces/curses/widgets/wdg_menu.c
+++ b/src/interfaces/curses/widgets/wdg_menu.c
@@ -42,6 +42,7 @@ struct wdg_menu_unit {
    size_t nitems;
    MENU *m;
    WINDOW *win;
+   WINDOW *sub;
    ITEM **items;
    TAILQ_ENTRY(wdg_menu_unit) next;
 };
@@ -72,6 +73,10 @@ static void wdg_menu_close(struct wdg_object *wo);
 static int wdg_menu_virtualize(int key);
 static int wdg_menu_driver(struct wdg_object *wo, int key, struct wdg_mouse_event *mouse);
 static int wdg_menu_shortcut(struct wdg_object *wo, int key);
+
+/* implemented in wdg.c */
+extern WINDOW * wdg_derwin(WINDOW *parent, int lines, int cols, int begin_y, int begin_x);
+extern void wdg_delderwin(WINDOW *parent, WINDOW *sub);
 
 /*******************************************/
 
@@ -561,8 +566,13 @@ static void wdg_menu_open(struct wdg_object *wo)
    /* associate with the menu */
    set_menu_win(ww->focus_unit->m, ww->focus_unit->win);
    
-   /* the subwin for the menu */
-   set_menu_sub(ww->focus_unit->m, derwin(ww->focus_unit->win, mrows + 1, mcols, 1, 1));
+   /*
+    * the subwin for the menu -- inset by one to stay within the box.
+    * it must fit entirely within win, otherwise derwin() returns NULL
+    * and ncurses silently posts the menu on stdscr, wiping the screen.
+    */
+   ww->focus_unit->sub = wdg_derwin(ww->focus_unit->win, mrows, mcols, 1, 1);
+   set_menu_sub(ww->focus_unit->m, ww->focus_unit->sub);
 
    /* menu attributes */
    set_menu_mark(ww->focus_unit->m, "");
@@ -609,8 +619,13 @@ static void wdg_menu_close(struct wdg_object *wo)
    free_menu(ww->focus_unit->m);
    ww->focus_unit->m = NULL;
 
+   /* the sub-window has to go before its parent */
+   wdg_delderwin(ww->focus_unit->win, ww->focus_unit->sub);
+   ww->focus_unit->sub = NULL;
+
    delwin(ww->focus_unit->win);
-  
+   ww->focus_unit->win = NULL;
+
    /* repaint the whole screen since a menu might have overlapped something */
    wdg_redraw_all();
 }

--- a/src/interfaces/curses/widgets/wdg_panel.c
+++ b/src/interfaces/curses/widgets/wdg_panel.c
@@ -290,6 +290,15 @@ void wdg_panel_print(wdg_t *wo, size_t x, size_t y, char *fmt, ...)
    
    WDG_DEBUG_MSG("wdg_panel_print");
 
+   /*
+    * never let a NULL window reach vw_printw(): ncurses derives the screen
+    * from the window, so a single printw on a NULL window leaves its
+    * internal formatting buffer unusable and *every* later wprintw() in
+    * the process silently returns ERR without drawing anything.
+    */
+   if (ww->sub == NULL || W(ww->sub) == NULL)
+      return;
+
    /* move the pointer */
    wmove(W(ww->sub), y, x);
 

--- a/src/interfaces/curses/widgets/wdg_percentage.c
+++ b/src/interfaces/curses/widgets/wdg_percentage.c
@@ -141,16 +141,18 @@ static int wdg_percentage_redraw(struct wdg_object *wo)
       touchwin(ww->win);
       wnoutrefresh(ww->win);
       
-      /* resize the window and draw the new border */
+      /* resize the window */
       mvwin(ww->win, y, x);
       wresize(ww->win, l, c);
-      wdg_percentage_border(wo);
-      
+
       /* resize the actual window and touch it */
       mvwin(ww->sub, y + 1, x + 1);
       wresize(ww->sub, l - 2, c - 2);
       /* set the window color */
       wbkgdset(ww->sub, COLOR_PAIR(wo->window_color));
+
+      /* the title and the bar live in ww->sub, so draw them at the new size */
+      wdg_percentage_border(wo);
 
    /* the first time we have to allocate the window */
    } else {
@@ -159,13 +161,14 @@ static int wdg_percentage_redraw(struct wdg_object *wo)
       if ((ww->win = newwin(l, c, y, x)) == NULL)
          return -WDG_E_FATAL;
 
-      /* draw the borders */
-      wdg_percentage_border(wo);
-
-      /* create the inner (actual) window */
+      /*
+       * create the inner (actual) window before drawing anything into
+       * it -- wdg_percentage_border() writes the title and the bar to
+       * ww->sub
+       */
       if ((ww->sub = newwin(l - 2, c - 2, y + 1, x + 1)) == NULL)
          return -WDG_E_FATAL;
-      
+
       /* set the window color */
       wbkgdset(ww->sub, COLOR_PAIR(wo->window_color));
       werase(ww->sub);
@@ -175,6 +178,9 @@ static int wdg_percentage_redraw(struct wdg_object *wo)
       wmove(ww->sub, 0, 0);
 
       scrollok(ww->sub, TRUE);
+
+      /* draw the borders */
+      wdg_percentage_border(wo);
 
    }
    
@@ -262,7 +268,16 @@ static void wdg_percentage_border(struct wdg_object *wo)
 {
    WDG_WO_EXT(struct wdg_percentage, ww);
    size_t c = wdg_get_ncols(wo);
-      
+
+   /*
+    * never let a NULL window reach wprintw(): ncurses derives the screen
+    * from the window, so a single wprintw(NULL, ...) leaves its internal
+    * formatting buffer unusable and *every* later wprintw() in the
+    * process silently returns ERR without drawing anything.
+    */
+   if (ww->win == NULL || ww->sub == NULL)
+      return;
+
    /* the object was focused */
    if (wo->flags & WDG_OBJ_FOCUSED) {
       wattron(ww->win, A_BOLD);

--- a/src/interfaces/curses/widgets/wdg_scroll.c
+++ b/src/interfaces/curses/widgets/wdg_scroll.c
@@ -350,6 +350,15 @@ void wdg_scroll_print(wdg_t *wo, int color, char *fmt, ...)
    
    WDG_DEBUG_MSG("wdg_scroll_print");
 
+   /*
+    * never let a NULL window reach vw_printw(): ncurses derives the screen
+    * from the window, so a single printw on a NULL window leaves its
+    * internal formatting buffer unusable and *every* later wprintw() in
+    * the process silently returns ERR without drawing anything.
+    */
+   if (ww->sub == NULL)
+      return;
+
    /* move to the bottom of the pad */
    wdg_set_scroll(wo, ww->y_max - l + 1);
 

--- a/src/interfaces/curses/widgets/wdg_window.c
+++ b/src/interfaces/curses/widgets/wdg_window.c
@@ -273,7 +273,16 @@ void wdg_window_print(wdg_t *wo, size_t x, size_t y, char *fmt, ...)
 {
    WDG_WO_EXT(struct wdg_window, ww);
    va_list ap;
-   
+
+   /*
+    * never let a NULL window reach vw_printw(): ncurses derives the screen
+    * from the window, so a single printw on a NULL window leaves its
+    * internal formatting buffer unusable and *every* later wprintw() in
+    * the process silently returns ERR without drawing anything.
+    */
+   if (ww->sub == NULL)
+      return;
+
    /* move the pointer */
    wmove(ww->sub, y, x);
    


### PR DESCRIPTION
Fixes #1231.

Two independent bugs in the bundled widget library (`libwdg`) made the curses
UI fall apart. Both are misuse of the ncurses API on our side — ncurses did not
change behaviour, our calls were always wrong and modern ncurses is simply less
forgiving about it.

## 1. Menus and forms were posted onto `stdscr`

`wdg_input`, `wdg_list` and `wdg_file` build their menu/form sub-window with a
geometry that does not fit inside its parent:

```c
mwin = newwin(mrows, MAX(mcols, c - 4), y + 1, x + 2);   /* mrows lines */
set_menu_sub(m, derwin(mwin, mrows + 1, mcols, 1, 1));   /* needs mrows + 2 */
```

`derwin()` returns `NULL`. Passing that to `set_menu_sub()` / `set_form_sub()`
is **not** an error for ncurses: it normalises the `NULL` sub-window to
`stdscr`, so the widget's content is drawn full-screen on `stdscr` instead of
inside its own box. The next refresh of `stdscr` then paints over the entire
panel stack.

Confirmed directly — after `set_form_sub(form, NULL)`, `form_sub(form)` is
`stdscr`, and the fields render at their raw `frow`/`fcol` on the physical
screen.

The fix adds `wdg_derwin()`, which clamps the requested geometry to the parent
and never returns `NULL`, and uses it from all four widgets that post a menu or
a form. `wdg_menu` was already sized correctly, which is why the drop-down
menus kept working while everything else broke.

Because `derwin()` now actually succeeds, the derived sub-windows have to be
deleted before their parent — `delwin()` fails on a window that still has
children — so `wdg_delderwin()` is called from the destroy paths. That also
stops leaking one window per dialog open.

## 2. `wprintw(NULL, ...)` permanently broke every later `wprintw()`

`wdg_dialog_redraw()` and `wdg_percentage_redraw()` drew into `ww->sub` before
creating it:

```c
ww->win = newwin(...);
wdg_percentage_border(wo);   /* wprintw(ww->sub, ...) — ww->sub is still NULL */
ww->sub = newwin(...);       /* only created afterwards */
```

ncurses derives the `SCREEN` from the window handle, so a single `wprintw()` on
a `NULL` window leaves its internal formatting buffer unusable and **every**
subsequent `wprintw()` in the process returns `ERR` without drawing anything —
on any window:

```
baseline              wprintw=0  waddstr=0
wprintw(NULL) = -1
after wprintw(NULL)   wprintw=-1 waddstr=0
again                 wprintw=-1 waddstr=0
```

The menu bar titles (`wdg_menu_titles`) and the user-message log
(`wdg_scroll_print`) are drawn with `wprintw()` / `vw_printw()`. That is exactly
the reported symptom: after the first error dialog or host-scan progress bar the
menu bar goes blank *but still responds to keys*, and the log stops updating.

The fix creates `ww->sub` before drawing into it, in both the create and the
resize paths, and guards every `printw` on a caller-supplied window — a single
slip of this kind silently disables all output for the rest of the session.

## Verification

Tested against **ncurses 6.6** (newer than Ubuntu 24.04's 6.4 and 22.04's 6.3,
so a stricter test) using a standalone harness that links ettercap's real widget
library and drives it under `tmux`, capturing the pane after each keystroke.

Reproducing the issue's own scenario — scan for hosts — before and after:

```
BEFORE (menu bar gone, log pane stripped)
                                        <- menu bar blank but still functional
lqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqk
x                                    a  <- "User messages:" title gone, no log

AFTER
 File  Sniff  Options                                       0.8.4.1
lqqUser messages:qqqqqqqqqqqqqqqqqqqqk
x7 hosts added to the hosts list...  a
```

Also checked: the netmask/pcap-filter input dialog (previously wiped the whole
screen and drew `Netmask :` at the top-left corner), the interface picker and
hosts list (previously drew an empty box), the error and message dialogs
(previously drew a box with no title, text or buttons), and the progress bar.
All render inside their own windows now, and the menu bar and message log
survive every one of them.

Builds clean under `-Wall -Wextra`.

## Possibly related

The use-before-init in `wdg_dialog_redraw()` is a plausible cause of #724
(segfault when showing an error with the ncurses UI), since that path drew into
a `NULL` window. I have not reproduced that crash, so I am not claiming it as
fixed — but it is worth a re-test against this branch.

## Note on ncurses itself

Worth recording since it comes up in #1231: ncurses remains the right library
here. 6.6 shipped in December 2025, is actively maintained, and is
source-compatible back to 5.0. The alternatives (notcurses, termbox2) abandon
the X/Open Curses API and have no menu/form/panel equivalents, so switching
would mean rewriting `libwdg` wholesale and changing the look and feel. The
failures in this issue were our own three-line geometry and ordering bugs.
