### PR TITLE
Fix #1201, #709, #1087, and #899

### DIFF
--- a/src/ec_checksum.c
+++ b/src/ec_checksum.c
@@ -146,7 +146,14 @@ static u_int16 v4_checksum(struct packet_object *po)
 static u_int16 v6_checksum(struct packet_object *po)
 {
    u_int8 *buf = po->L4.header;
-   u_int16 plen = po->L3.payload_len;
+   /*
+    * Use the actual upper-layer length (header + data) instead of the
+    * IPv6 payload length.  This is required when the payload has been
+    * modified by a filter, because decode_ip6 has not yet had a chance
+    * to update po->L3.payload_len when the transport checksum is
+    * recalculated.
+    */
+   u_int16 plen = po->L4.len + po->DATA.len;
    u_int32 csum;
 
    csum = sum(buf, plen);

--- a/src/ec_globals.c
+++ b/src/ec_globals.c
@@ -77,6 +77,8 @@ void ec_globals_free(void)
    EC_GBL_FREE(ec_gbls->iface);
    EC_GBL_FREE(ec_gbls->bridge);
    EC_GBL_FREE(ec_gbls->sm);
+   EC_GBL_FREE(ec_gbls->ui);
+   EC_GBL_FREE(ec_gbls->wifi);
    EC_GBL_FREE(ec_gbls->filters);
 
    free_ip_list(ec_gbls->t1);

--- a/src/ec_passive.c
+++ b/src/ec_passive.c
@@ -155,6 +155,29 @@ void print_host(struct host_profile *h)
 
 
 /*
+ * print a string to the XML output, escaping characters that are special
+ * to XML (prevents the output from being broken by user/foreign data).
+ */
+
+static void print_xml_escaped(FILE *f, const char *s)
+{
+   if (s == NULL)
+      return;
+
+   while (*s) {
+      switch (*s) {
+         case '<':  fputs("&lt;", f); break;
+         case '>':  fputs("&gt;", f); break;
+         case '&':  fputs("&amp;", f); break;
+         case '"':  fputs("&quot;", f); break;
+         case '\'': fputs("&apos;", f); break;
+         default:   fputc((unsigned char)*s, f); break;
+      }
+      s++;
+   }
+}
+
+/*
  * prints the infos of a single host in XML format
  */
 
@@ -171,13 +194,18 @@ void print_host_xml(struct host_profile *h)
    memset(os, 0, sizeof(os));
    
    fprintf(stdout, "\t<host ip=\"%s\">\n", ip_addr_ntoa(&h->L3_addr, tmp));
-   if (strcmp(h->hostname, ""))
-      fprintf(stdout, "\t\t<hostname>%s</hostname>\n", h->hostname);
+   if (strcmp(h->hostname, "")) {
+      fputs("\t\t<hostname>", stdout);
+      print_xml_escaped(stdout, h->hostname);
+      fputs("</hostname>\n", stdout);
+   }
    
 #ifdef HAVE_GEOIP
-   if (EC_GBL_CONF->geoip_support_enable)
-      fprintf(stdout, "\t\t<location>%s</location>\n", 
-            geoip_get_by_ip(&h->L3_addr, GEOIP_CNAME, country, MAX_GEOIP_STR_LEN));
+   if (EC_GBL_CONF->geoip_support_enable) {
+      fputs("\t\t<location>", stdout);
+      print_xml_escaped(stdout, geoip_get_by_ip(&h->L3_addr, GEOIP_CNAME, country, MAX_GEOIP_STR_LEN));
+      fputs("</location>\n", stdout);
+   }
 #endif
 
    if (h->type & FP_HOST_LOCAL || h->type == FP_UNKNOWN) {
@@ -200,36 +228,60 @@ void print_host_xml(struct host_profile *h)
    
    if (strcmp((const char*)h->fingerprint, "")) {
       if (fingerprint_search((const char*)h->fingerprint, os) == E_SUCCESS) {
-         fprintf(stdout, "\t\t<fingerprint type=\"known\">%s</fingerprint>\n", h->fingerprint);
-         fprintf(stdout, "\t\t<os type=\"exact\">%s</os>\n", os);
+         fputs("\t\t<fingerprint type=\"known\">", stdout);
+         print_xml_escaped(stdout, (const char*)h->fingerprint);
+         fputs("</fingerprint>\n", stdout);
+         fputs("\t\t<os type=\"exact\">", stdout);
+         print_xml_escaped(stdout, os);
+         fputs("</os>\n", stdout);
       } else {
-         fprintf(stdout, "\t\t<fingerprint type=\"unknown\">%s</fingerprint>\n", h->fingerprint);
-         fprintf(stdout, "\t\t<os type=\"nearest\">%s</os>\n", os);
+         fputs("\t\t<fingerprint type=\"unknown\">", stdout);
+         print_xml_escaped(stdout, (const char*)h->fingerprint);
+         fputs("</fingerprint>\n", stdout);
+         fputs("\t\t<os type=\"nearest\">", stdout);
+         print_xml_escaped(stdout, os);
+         fputs("</os>\n", stdout);
       }
    }
    
    LIST_FOREACH(o, &(h->open_ports_head), next) {
       
-      fprintf(stdout, "\t\t<port proto=\"%s\" addr=\"%d\" service=\"%s\">\n", 
+      fprintf(stdout, "\t\t<port proto=\"%s\" addr=\"%d\" service=\"",
             (o->L4_proto == NL_TYPE_TCP) ? "tcp" : "udp", 
-            ntohs(o->L4_addr),
-            service_search(o->L4_addr, o->L4_proto));
+            ntohs(o->L4_addr));
+      print_xml_escaped(stdout, service_search(o->L4_addr, o->L4_proto));
+      fputs("\">\n", stdout);
       
-      if (o->banner)
-         fprintf(stdout, "\t\t\t<banner>%s</banner>\n", o->banner);
+      if (o->banner) {
+         fputs("\t\t\t<banner>", stdout);
+         print_xml_escaped(stdout, o->banner);
+         fputs("</banner>\n", stdout);
+      }
       
       LIST_FOREACH(u, &(o->users_list_head), next) {
          
-         if (u->failed)  
-            fprintf(stdout, "\t\t\t<account user=\"%s\" failed=\"1\">\n", u->user);
-         else
-            fprintf(stdout, "\t\t\t<account user=\"%s\">\n", u->user);
+         if (u->failed)  {
+            fputs("\t\t\t<account user=\"", stdout);
+            print_xml_escaped(stdout, u->user);
+            fputs("\" failed=\"1\">\n", stdout);
+         } else {
+            fputs("\t\t\t<account user=\"", stdout);
+            print_xml_escaped(stdout, u->user);
+            fputs("\">\n", stdout);
+         }
             
-         fprintf(stdout, "\t\t\t\t<user>%s</user>\n", u->user);
-         fprintf(stdout, "\t\t\t\t<pass>%s</pass>\n", u->pass);
+         fputs("\t\t\t\t<user>", stdout);
+         print_xml_escaped(stdout, u->user);
+         fputs("</user>\n", stdout);
+         fputs("\t\t\t\t<pass>", stdout);
+         print_xml_escaped(stdout, u->pass);
+         fputs("</pass>\n", stdout);
          fprintf(stdout, "\t\t\t\t<client>%s</client>\n", ip_addr_ntoa(&u->client, tmp));
-         if (u->info)
-            fprintf(stdout, "\t\t\t\t<info>%s</info>\n", u->info);
+         if (u->info) {
+            fputs("\t\t\t\t<info>", stdout);
+            print_xml_escaped(stdout, u->info);
+            fputs("</info>\n", stdout);
+         }
          
          fprintf(stdout, "\t\t\t</account>\n");
       }

--- a/utils/etterfilter/ef_test.c
+++ b/utils/etterfilter/ef_test.c
@@ -29,8 +29,11 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include <ctype.h>
 
 /* protos */
+
+static char *escape_binary(const u_char *s, size_t len);
 
 void test_filter(char *filename);
 
@@ -42,6 +45,54 @@ static void print_dec(struct filter_op *fop, u_int32 eip);
 static void print_function(struct filter_op *fop, u_int32 eip);
 
 /*******************************************/
+
+/*
+ * escape a binary string so it can be safely printed as a C-style string.
+ * caller must SAFE_FREE the returned buffer.
+ */
+static char *escape_binary(const u_char *s, size_t len)
+{
+   char *out = NULL;
+   size_t out_len = 0;
+   size_t out_cap = 0;
+   char hex[5];
+   size_t i;
+
+   if (s == NULL || len == 0) {
+      SAFE_CALLOC(out, 1, sizeof(char));
+      return out;
+   }
+
+   for (i = 0; i < len; i++) {
+      u_char c = s[i];
+      size_t needed;
+
+      if (isprint((int)c) && c != '"' && c != '\\') {
+         needed = 1;
+      } else {
+         needed = 4;  /* \\xNN */
+      }
+
+      if (out_len + needed + 1 > out_cap) {
+         out_cap = out_cap ? out_cap * 2 : 16;
+         if (out_cap < out_len + needed + 1)
+            out_cap = out_len + needed + 1;
+         SAFE_REALLOC(out, out_cap);
+      }
+
+      if (needed == 1) {
+         out[out_len++] = (char)c;
+      } else {
+         snprintf(hex, sizeof(hex), "\\x%02x", c);
+         memcpy(out + out_len, hex, 4);
+         out_len += 4;
+      }
+   }
+
+   out[out_len] = '\0';
+   return out;
+}
+
 
 /*
  * test a binary filter against a given file 
@@ -133,23 +184,31 @@ void print_fop(struct filter_op *fop, u_int32 eip)
 
 void print_test(struct filter_op *fop, u_int32 eip)
 {
+   char *escaped;
+
    switch(fop->op.test.op) {
       case FTEST_EQ:
          if (fop->op.test.size != 0)
             USER_MSG("%04lu: TEST level %d, offset %d, size %d, == %lu [%#x]\n", (unsigned long)eip,
                fop->op.test.level, fop->op.test.offset, fop->op.test.size, (unsigned long)fop->op.test.value, (unsigned int)fop->op.test.value);
-         else
+         else {
+            escaped = escape_binary(fop->op.test.string, fop->op.test.slen);
             USER_MSG("%04lu: TEST level %d, offset %d, \"%s\"\n", (unsigned long)eip,
-               fop->op.test.level, fop->op.test.offset, fop->op.test.string);
+               fop->op.test.level, fop->op.test.offset, escaped);
+            SAFE_FREE(escaped);
+         }
          break;
          
       case FTEST_NEQ:
          if (fop->op.test.size != 0)
             USER_MSG("%04lu: TEST level %d, offset %d, size %d, != %lu [%#x]\n", (unsigned long)eip,
                fop->op.test.level, fop->op.test.offset, fop->op.test.size, (unsigned long)fop->op.test.value, (unsigned int)fop->op.test.value);
-         else
+         else {
+            escaped = escape_binary(fop->op.test.string, fop->op.test.slen);
             USER_MSG("%04lu: TEST level %d, offset %d, not \"%s\"\n", (unsigned long)eip,
-               fop->op.test.level, fop->op.test.offset, fop->op.test.string);
+               fop->op.test.level, fop->op.test.offset, escaped);
+            SAFE_FREE(escaped);
+         }
          break;
 
       case FTEST_LT:
@@ -181,13 +240,17 @@ void print_test(struct filter_op *fop, u_int32 eip)
 
 void print_assign(struct filter_op *fop, u_int32 eip)
 {
+   char *escaped;
+
    if (fop->op.assign.size != 0)
       USER_MSG("%04lu: ASSIGNMENT level %d, offset %d, size %d, value %lu [%#x]\n", (unsigned long)eip,
             fop->op.assign.level, fop->op.assign.offset, fop->op.assign.size, (unsigned long)fop->op.assign.value, (unsigned int)fop->op.assign.value);
-   else
-      USER_MSG("%04lu: ASSIGNMENT level %d, offset %d, string \"%s\"\n", (unsigned long)eip, 
-            fop->op.assign.level, fop->op.assign.offset, fop->op.assign.string);
-      
+   else {
+      escaped = escape_binary(fop->op.assign.string, fop->op.assign.slen);
+      USER_MSG("%04lu: ASSIGNMENT level %d, offset %d, string \"%s\"\n", (unsigned long)eip,
+            fop->op.assign.level, fop->op.assign.offset, escaped);
+      SAFE_FREE(escaped);
+   }
 }
 
 void print_inc(struct filter_op *fop, u_int32 eip)
@@ -204,66 +267,91 @@ void print_dec(struct filter_op *fop, u_int32 eip)
 
 void print_function(struct filter_op *fop, u_int32 eip)
 {
+   char *escaped;
+   char *replaced;
+
    switch (fop->op.func.op) {
       case FFUNC_SEARCH:
-         USER_MSG("%04lu: SEARCH level %d, string \"%s\"\n", (unsigned long)eip, 
-               fop->op.func.level, fop->op.func.string);
+         escaped = escape_binary(fop->op.func.string, fop->op.func.slen);
+         USER_MSG("%04lu: SEARCH level %d, string \"%s\"\n", (unsigned long)eip,
+               fop->op.func.level, escaped);
+         SAFE_FREE(escaped);
          break;
-         
+
       case FFUNC_REGEX:
-         USER_MSG("%04lu: REGEX level %d, string \"%s\"\n", (unsigned long)eip, 
-               fop->op.func.level, fop->op.func.string);
+         escaped = escape_binary(fop->op.func.string, fop->op.func.slen);
+         USER_MSG("%04lu: REGEX level %d, string \"%s\"\n", (unsigned long)eip,
+               fop->op.func.level, escaped);
+         SAFE_FREE(escaped);
          break;
-         
+
       case FFUNC_PCRE:
-         if (fop->op.func.replace)
-            USER_MSG("%04lu: PCRE_REGEX level %d, string \"%s\", replace \"%s\"\n", (unsigned long)eip, 
-               fop->op.func.level, fop->op.func.string, fop->op.func.replace);
-         else
-            USER_MSG("%04lu: PCRE_REGEX level %d, string \"%s\"\n", (unsigned long)eip, 
-               fop->op.func.level, fop->op.func.string);
+         escaped = escape_binary(fop->op.func.string, fop->op.func.slen);
+         if (fop->op.func.replace) {
+            replaced = escape_binary(fop->op.func.replace, fop->op.func.rlen);
+            USER_MSG("%04lu: PCRE_REGEX level %d, string \"%s\", replace \"%s\"\n", (unsigned long)eip,
+                  fop->op.func.level, escaped, replaced);
+            SAFE_FREE(replaced);
+         } else
+            USER_MSG("%04lu: PCRE_REGEX level %d, string \"%s\"\n", (unsigned long)eip,
+                  fop->op.func.level, escaped);
+         SAFE_FREE(escaped);
          break;
 
       case FFUNC_REPLACE:
-         USER_MSG("%04lu: REPLACE \"%s\" --> \"%s\"\n", (unsigned long)eip, 
-               fop->op.func.string, fop->op.func.replace);
+         escaped = escape_binary(fop->op.func.string, fop->op.func.slen);
+         replaced = escape_binary(fop->op.func.replace, fop->op.func.rlen);
+         USER_MSG("%04lu: REPLACE \"%s\" --> \"%s\"\n", (unsigned long)eip,
+               escaped, replaced);
+         SAFE_FREE(escaped);
+         SAFE_FREE(replaced);
          break;
-         
+
       case FFUNC_INJECT:
-         USER_MSG("%04lu: INJECT \"%s\"\n", (unsigned long)eip, 
-               fop->op.func.string);
+         escaped = escape_binary(fop->op.func.string, fop->op.func.slen);
+         USER_MSG("%04lu: INJECT \"%s\"\n", (unsigned long)eip,
+               escaped);
+         SAFE_FREE(escaped);
          break;
-         
+
       case FFUNC_EXECINJECT:
-         USER_MSG("%04lu: EXECINJECT \"%s\"\n", (unsigned long)eip, 
-               fop->op.func.string);
+         escaped = escape_binary(fop->op.func.string, fop->op.func.slen);
+         USER_MSG("%04lu: EXECINJECT \"%s\"\n", (unsigned long)eip,
+               escaped);
+         SAFE_FREE(escaped);
          break;
-         
+
       case FFUNC_RANDOM:
          USER_MSG("%04lu: RANDOM level %d start offset %d length %d\n", (unsigned long)eip,
                fop->op.func.level, fop->op.func.offset, fop->op.func.olen);
          break;
 
       case FFUNC_LOG:
-         USER_MSG("%04lu: LOG to \"%s\"\n", (unsigned long)eip, fop->op.func.string);
+         escaped = escape_binary(fop->op.func.string, fop->op.func.slen);
+         USER_MSG("%04lu: LOG to \"%s\"\n", (unsigned long)eip, escaped);
+         SAFE_FREE(escaped);
          break;
-         
+
       case FFUNC_DROP:
          USER_MSG("%04lu: DROP\n", (unsigned long)eip);
          break;
-         
+
       case FFUNC_KILL:
          USER_MSG("%04lu: KILL\n", (unsigned long)eip);
          break;
-         
+
       case FFUNC_MSG:
-         USER_MSG("%04lu: MSG \"%s\"\n", (unsigned long)eip, fop->op.func.string);
+         escaped = escape_binary(fop->op.func.string, fop->op.func.slen);
+         USER_MSG("%04lu: MSG \"%s\"\n", (unsigned long)eip, escaped);
+         SAFE_FREE(escaped);
          break;
-         
+
       case FFUNC_EXEC:
-         USER_MSG("%04lu: EXEC \"%s\"\n", (unsigned long)eip, fop->op.func.string);
+         escaped = escape_binary(fop->op.func.string, fop->op.func.slen);
+         USER_MSG("%04lu: EXEC \"%s\"\n", (unsigned long)eip, escaped);
+         SAFE_FREE(escaped);
          break;
-         
+
       default:
          USER_MSG("%04lu: UNDEFINED FUNCTION OPCODE (%d)!!\n", (unsigned long)eip, fop->op.func.op);
          break;


### PR DESCRIPTION
## Summary
- Fix #1201: `ec_globals_alloc()` allocated `ec_gbls->ui` and `ec_gbls->wifi`, but `ec_globals_free()` never freed them. Add the two missing `EC_GBL_FREE()` calls.
- Fix #709: `print_host_xml()` wrote user, password, banner, hostname, fingerprint and other foreign-controlled strings directly into XML, which could break the document or be used to inject elements. Add `print_xml_escaped()` and route all such strings through it.
- Fix #1087: `etterfilter -t` printed every filter string with `%s`, so strings containing `\x00` appeared truncated. Add `escape_binary()` to render non-printable bytes as `\xNN` and use the recorded `slen` when displaying strings.
- Fix #899: `v6_checksum()` used the stale `po->L3.payload_len` when a filter had already changed the payload. Use the real transport header + data length (`po->L4.len + po->DATA.len`) for both the checksum sum and the IPv6 pseudo-header, matching `v4_checksum()`.

## Test plan
- [x] `cmake -B build -S . && cmake --build build -j` succeeds
- [x] `cmake -B build-asan -S . -DCMAKE_C_FLAGS="-g -fsanitize=address" && cmake --build build-asan -j` succeeds
- [x] ASAN run of `ettercap -h` no longer reports leaks from `ec_globals_alloc`
- [x] `etterfilter -t` on a filter with `\x00` in `search`/`replace` strings shows the full escaped strings
- [x] `./build/src/ettercap -h` runs normally

Generated with [Devin](https://devin.ai)