### PR TITLE
Use link-local source addresses for IPv6 all-nodes scan (#460)

### DIFF
--- a/src/ec_scan.c
+++ b/src/ec_scan.c
@@ -446,6 +446,17 @@ static void scan_netmask(void)
 
 #ifdef WITH_IPV6
 /*
+ * helper to check if an IPv6 address is link-local
+ */
+static int ip6_addr_is_linklocal(struct ip_addr *ip)
+{
+   if (ntohs(ip->addr_type) != AF_INET6)
+      return 0;
+
+   return IN6_IS_ADDR_LINKLOCAL((struct in6_addr *)ip->addr);
+}
+
+/*
  * probe active IPv6 hosts
  */
 static void scan_ip6_onlink(void)
@@ -465,9 +476,14 @@ static void scan_ip6_onlink(void)
    /* go through the list of IPv6 addresses on the selected interface */
    LIST_FOREACH(e, &EC_GBL_IFACE->ip6_list, next) {
       /*
-       * ping to all-nodes from all ip addresses to get responses from all 
-       * IPv6 networks (global, link-local, ...)
+       * ff02::1 is a link-local multicast address.  Packets sent to it must
+       * use a link-local source address; otherwise the kernel/libnet may
+       * reject the write (especially when privacy/temporary addresses are
+       * enabled).  Skip non-link-local sources to avoid spurious failures.
        */
+      if (!ip6_addr_is_linklocal(&e->ip))
+         continue;
+
       send_L2_icmp6_echo(&e->ip, &an, LLA_IP6_ALLNODES_MULTICAST);
 
 #if EC_CHECK_LIBNET_VERSION(1,2)


### PR DESCRIPTION
## Summary
`scan_ip6_onlink()` sends ICMPv6 echo requests to `ff02::1` (the link-local all-nodes multicast address) from every IPv6 address on the selected interface. When IPv6 privacy extensions are enabled (`use_tempaddr`), the interface list can contain temporary/global addresses, and using those as the source of a link-local multicast packet can cause libnet/kernel write errors such as "Cannot assign requested address".

This change restricts the probes to link-local source addresses. Since the target `ff02::1` is link-local scope, a link-local source is the correct choice and avoids the temporary/privacy-address failures reported in #460.

## Test plan
- `cmake -B build -S . && cmake --build build -j` succeeds.
- `./build/src/ettercap -h` still runs without regression during init.

Closes #460.

Generated with [Devin](https://devin.ai)