### PR TITLE
Mark split packets as modified to fix 'Message too long' forwarding (#1271, #1179)

### DIFF
--- a/src/ec_inject.c
+++ b/src/ec_inject.c
@@ -176,6 +176,8 @@ void inject_split_data(struct packet_object *po)
       po->DATA.inject_len = po->DATA.len - max_len;
       po->DATA.delta -= po->DATA.len - max_len;
       po->DATA.len = max_len;
+      /* mark it modified so decode_ip/tcp update tot_len/seq/checksums */
+      po->flags |= PO_MODIFIED;
    } 
 }
 


### PR DESCRIPTION
## Summary
`inject_split_data()` truncates a packet that exceeds the MTU and queues the remainder in `po->DATA.inject` so `inject_buffer()` can send it.  However, it did not set `PO_MODIFIED`, so `decode_ip()` and `decode_tcp()` skipped the necessary updates to `ip->tot_len`, forwarded length, TCP sequence numbers, and checksums.  `send_to_L3()` then tried to forward the original oversized packet and libnet returned `EMSGSIZE` ("Message too long").

## Fix
Set `PO_MODIFIED` when a split occurs.  This lets the lower-layer decoders rebuild the first fragment with the correct length and checksums, and lets `inject_buffer()` send the remaining fragment with the right sequence number.

Closes #1271 and #1179 for unified sniffing.  The bridged-mode report in #1179 may involve a separate path because `forward_bridge_sniff()` does not call `inject_buffer()`.

## Test plan
- `cmake -B build -S . && cmake --build build -j` succeeds.
- `./build/src/ettercap -h` still runs without init regression.

Generated with [Devin](https://devin.ai)