### PR TITLE
URL-decode HTTP Basic Auth base64 token before decoding (#943)

### DIFF
--- a/src/dissectors/ec_http.c
+++ b/src/dissectors/ec_http.c
@@ -341,9 +341,12 @@ static int Parse_Basic_Auth(char *ptr, char *from_here, struct packet_object *po
        
    ec_strtok(to_decode, "\r", &tok);
 
+   /* Some clients URL-encode the base64 token (e.g. %3D for '=') */
+   Decode_Url(to_decode);
+
    char *decoded;
    base64decode(to_decode, &decoded);
-  
+
    DEBUG_MSG("Clear text AUTH: %s", decoded); 
 
    /* clear text should be username:password 


### PR DESCRIPTION
## Summary
Some clients send the `Authorization: Basic ...` base64 token URL-encoded (for example `%3D` for `=`).  The HTTP dissector passed the token directly to `base64decode()`, which then returned garbage and produced the wrong password in the UI.

## Fix
Call the existing `Decode_Url()` helper on the token before `base64decode()` to unescape any `%XX` sequences.  This does not affect normal base64 tokens.

Closes #943.

## Test plan
- `cmake -B build -S . && cmake --build build -j` succeeds.
- `./build/src/ettercap -h` still runs without init regression.

Generated with [Devin](https://devin.ai)