### PR TITLE
Filter language improvements: DATA.len/DECODED.len and manual checksum override (#1224, #649)

### DIFF
--- a/share/etterfilter.tbl
+++ b/share/etterfilter.tbl
@@ -171,6 +171,7 @@
 #
 [DATA][5] 
    data:1 = 0
+   len:4 = 65535
 
 #
 # some dissectors will decode/decrypt the data 
@@ -182,6 +183,7 @@
 #
 [DECODED][6]
    data:1 = 0
+   len:4 = 65535
 
 
 # EOF

--- a/src/ec_filter.c
+++ b/src/ec_filter.c
@@ -31,6 +31,9 @@
 
 #define JIT_FAULT(x, ...) do { USER_MSG("JIT FILTER FAULT: " x "\n", ## __VA_ARGS__); return -E_FATAL; } while(0)
 
+/* sentinel offset for DATA.len / DECODED.len in etterfilter.tbl */
+#define DATA_LEN_OFFSET   0xFFFF
+
 /* since we need a recursive mutex, we cannot initialize it here statically */
 static pthread_mutex_t filters_mutex;
 #define FILTERS_LOCK     do{ pthread_mutex_lock(&filters_mutex); }while(0)
@@ -357,11 +360,19 @@ static int execute_test(struct filter_op *fop, struct packet_object *po)
          if (cmp_func(htons(*(u_int16 *)(base + fop->op.test.offset)), (fop->op.test.value & 0xffff)) )
             return FLAG_TRUE;
          break;
-      case 4:
+      case 4: {
          /* int comparison */
-         if (cmp_func(htonl(*(u_int32 *)(base + fop->op.test.offset)), (fop->op.test.value & 0xffffffff)) )
+         u_int32 val;
+         if (fop->op.test.level == 5 && fop->op.test.offset == DATA_LEN_OFFSET)
+            val = (u_int32)po->DATA.len;
+         else if (fop->op.test.level == 6 && fop->op.test.offset == DATA_LEN_OFFSET)
+            val = (u_int32)po->DATA.disp_len;
+         else
+            val = htonl(*(u_int32 *)(base + fop->op.test.offset));
+         if (cmp_func(val, (fop->op.test.value & 0xffffffff)) )
             return FLAG_TRUE;
          break;
+      }
       case 16: /* well IPv6 addresses should be handled as 16-byte pointer */
          if (cmp_func(memcmp(base + fop->op.test.offset, fop->op.test.ipaddr, fop->op.test.size), 0) )
             return FLAG_TRUE;
@@ -387,8 +398,12 @@ static int execute_assign(struct filter_op *fop, struct packet_object *po)
       JIT_FAULT("Cannot modify packets in unoffensive mode");
    
    DEBUG_MSG("filter engine: execute_assign: L%d O%d S%d", fop->op.assign.level, fop->op.assign.offset, fop->op.assign.size);
-   
-   /* 
+
+   /* DATA.len / DECODED.len are derived, not direct packet bytes */
+   if (fop->op.assign.offset == DATA_LEN_OFFSET)
+      JIT_FAULT("Cannot assign to %s.len", fop->op.assign.level == 6 ? "DECODED" : "DATA");
+
+   /*
     * point to the right base.
     */
    switch (fop->op.assign.level) {
@@ -450,8 +465,12 @@ static int execute_incdec(struct filter_op *fop, struct packet_object *po)
       JIT_FAULT("Cannot modify packets in unoffensive mode");
    
    DEBUG_MSG("filter engine: execute_incdec: L%d O%d S%d", fop->op.assign.level, fop->op.assign.offset, fop->op.assign.size);
-   
-   /* 
+
+   /* DATA.len / DECODED.len are derived, not direct packet bytes */
+   if (fop->op.assign.offset == DATA_LEN_OFFSET)
+      JIT_FAULT("Cannot increment/decrement %s.len", fop->op.assign.level == 6 ? "DECODED" : "DATA");
+
+   /*
     * point to the right base.
     */
    switch (fop->op.assign.level) {

--- a/src/protocols/ec_tcp.c
+++ b/src/protocols/ec_tcp.c
@@ -111,6 +111,7 @@ FUNC_DECODER(decode_tcp)
    struct tcp_status *status = NULL;
    int direction = 0;
    u_int16 sum;
+   u_int16 orig_csum = 0;
 
    tcp = (struct tcp_header *)DECODE_DATA;
    
@@ -292,6 +293,13 @@ FUNC_DECODER(decode_tcp)
    
    /* get the next decoder */
    next_decoder = get_decoder(APP_LAYER, PL_DEFAULT);
+
+   /*
+    * remember the original checksum so we can detect filters
+    * that want to override the tcp checksum manually.
+    */
+   orig_csum = tcp->csum;
+
    EXECUTE_DECODER(next_decoder);
 
    /* don't save the sessions in unoffensive mode */
@@ -330,9 +338,11 @@ FUNC_DECODER(decode_tcp)
          /* and now save the new delta */
          status->way[direction].seq_adj += PACKET->DATA.delta;
 
-         /* Recalculate checksum */
-         tcp->csum = CSUM_INIT; 
-         tcp->csum = L4_checksum(PACKET);
+         /* Recalculate checksum unless the filter set it manually */
+         if (tcp->csum == orig_csum) {
+            tcp->csum = CSUM_INIT;
+            tcp->csum = L4_checksum(PACKET);
+         }
       }
    }
    return NULL;

--- a/src/protocols/ec_udp.c
+++ b/src/protocols/ec_udp.c
@@ -58,6 +58,7 @@ FUNC_DECODER(decode_udp)
    FUNC_DECODER_PTR(next_decoder);
    struct udp_header *udp;
    u_int16 sum;
+   u_int16 orig_csum = 0;
 
    udp = (struct udp_header *)DECODE_DATA;
 
@@ -129,6 +130,13 @@ FUNC_DECODER(decode_udp)
    
    /* get the next decoder */
    next_decoder =  get_decoder(APP_LAYER, PL_DEFAULT);
+
+   /*
+    * remember the original checksum so we can detect filters
+    * that want to override the udp checksum manually.
+    */
+   orig_csum = udp->csum;
+
    EXECUTE_DECODER(next_decoder);
    
    /* 
@@ -139,11 +147,13 @@ FUNC_DECODER(decode_udp)
 
    /* Adjustments after filters */
    if ((PACKET->flags & PO_MODIFIED) && (PACKET->flags & PO_FORWARDABLE)) {
-            
+
       ORDER_ADD_SHORT(udp->ulen, PACKET->DATA.delta);
-      /* Recalculate checksum */
-      udp->csum = CSUM_INIT; 
-      udp->csum = L4_checksum(PACKET);
+      /* Recalculate checksum unless the filter set it manually */
+      if (udp->csum == orig_csum) {
+         udp->csum = CSUM_INIT;
+         udp->csum = L4_checksum(PACKET);
+      }
    }
 
    return NULL;


### PR DESCRIPTION
## Summary
This PR addresses two long-standing filter limitations.

### DATA.len / DECODED.len (#1224)
Filters can now test the length of the current payload or decoded data:

```
if (DATA.len == 123) { ... }
if (DATA.len > 100) { ... }
```

Implementation:
- Add a virtual `len` field (sentinel offset `65535`) to `[DATA]` and `[DECODED]` in `share/etterfilter.tbl`.
- `execute_test()` resolves that sentinel to `po->DATA.len` / `po->DATA.disp_len` instead of dereferencing into the packet buffer.
- `execute_assign()` and `execute_incdec()` reject writes to these derived fields to avoid corrupting packet memory.

### Manual TCP/UDP checksum override (#649)
`decode_tcp()` and `decode_udp()` were unconditionally recalculating the checksum whenever `PO_MODIFIED` was set, so a filter doing `tcp.csum += 1` had no visible effect. Both decoders now remember the original checksum before filters run and only recalculate it if the filter did not change the checksum field.

## Test plan
- `cmake -B build -S . && cmake --build build -j` succeeds.
- `./build/src/ettercap -h` starts without regression.
- `etterfilter` compiles the following examples:
  - `if (DATA.len == 123) { msg("matched\n"); }`
  - `if (tcp.dst == 80) { tcp.csum += 1; }`

Generated with [Devin](https://devin.ai)