### PR TITLE
Filter language improvements: mod()/random() and --no-filters (#714, #1232)

### DIFF
--- a/include/ec_filter.h
+++ b/include/ec_filter.h
@@ -58,6 +58,8 @@ struct filter_op {
             #define FFUNC_EXECINJECT 10
             #define FFUNC_EXECREPLACE 11
             #define FFUNC_RANDOM    12
+            #define FFUNC_MOD       13
+            #define FFUNC_CHANCE    14
          u_int8 level; 
          u_int8 *string;
          size_t slen;

--- a/include/ec_globals.h
+++ b/include/ec_globals.h
@@ -90,6 +90,7 @@ struct ec_options {
    char gateway:1;
    char lifaces:1;
    char broadcast:1;
+   char no_filters:1;
    char reversed;
    char *hostsfile;
    LIST_HEAD(plugin_list_t, plugin_list) plugins;

--- a/src/ec_filter.c
+++ b/src/ec_filter.c
@@ -55,6 +55,8 @@ static int func_inject(struct filter_op *fop, struct packet_object *po);
 static int func_execinject(struct filter_op *fop, struct packet_object *po);
 static int func_execreplace(struct filter_op *fop, struct packet_object *po);
 static int func_random(struct filter_op *fop, struct packet_object *po);
+static int func_mod(struct filter_op *fop, struct packet_object *po);
+static int func_chance(struct filter_op *fop, struct packet_object *po);
 static int func_log(struct filter_op *fop, struct packet_object *po);
 static int func_drop(struct packet_object *po);
 static int func_kill(struct packet_object *po);
@@ -234,6 +236,16 @@ static int execute_func(struct filter_op *fop, struct packet_object *po)
       case FFUNC_RANDOM:
          /* replace the string through output of a executable */
          if (func_random(fop, po) == E_SUCCESS)
+            return FLAG_TRUE;
+         break;
+
+      case FFUNC_MOD:
+         if (func_mod(fop, po) == E_SUCCESS)
+            return FLAG_TRUE;
+         break;
+
+      case FFUNC_CHANCE:
+         if (func_chance(fop, po) == E_SUCCESS)
             return FLAG_TRUE;
          break;
 
@@ -1126,6 +1138,87 @@ static int func_random(struct filter_op *fop, struct packet_object *po)
 
    return E_SUCCESS;
 
+}
+
+/*
+ * modulo of a packet field (C-like: true if remainder != 0)
+ */
+static int func_mod(struct filter_op *fop, struct packet_object *po)
+{
+   u_int32 value = 0;
+   size_t divisor = fop->op.func.olen;
+
+   if (divisor == 0)
+      JIT_FAULT("mod(): divisor cannot be zero");
+
+   {
+      u_char *base;
+
+      switch (fop->op.test.level) {
+         case 2:
+            base = po->L2.header;
+            break;
+         case 3:
+            base = po->L3.header;
+            break;
+         case 4:
+            base = po->L4.header;
+            break;
+         case 5:
+            base = po->DATA.data;
+            break;
+         case 6:
+            base = po->DATA.disp_data;
+            break;
+         default:
+            JIT_FAULT("mod(): unsupported level [%d]", fop->op.test.level);
+            return -E_FATAL;
+      }
+
+      switch (fop->op.test.size) {
+         case 1:
+            value = *(u_int8 *)(base + fop->op.test.offset);
+            break;
+         case 2:
+            value = htons(*(u_int16 *)(base + fop->op.test.offset));
+            break;
+         case 4:
+            value = htonl(*(u_int32 *)(base + fop->op.test.offset));
+            break;
+         default:
+            JIT_FAULT("mod(): unsupported size [%d]", fop->op.test.size);
+            return -E_FATAL;
+      }
+   }
+
+   if (value % divisor)
+      return E_SUCCESS;
+   else
+      return -E_NOTFOUND;
+}
+
+/*
+ * probabilistic condition: true with the given percent chance
+ */
+static int func_chance(struct filter_op *fop, struct packet_object *po)
+{
+   size_t percent = fop->op.func.olen;
+   struct timeval seed;
+
+   (void)po;
+
+   if (percent == 0)
+      return -E_NOTFOUND;
+   if (percent >= 100)
+      return E_SUCCESS;
+
+   gettimeofday(&seed, NULL);
+   srandom(seed.tv_sec ^ seed.tv_usec);
+
+   if ((random() % 100) < (long)percent)
+      return E_SUCCESS;
+   else
+      return -E_NOTFOUND;
 }
 
 /*

--- a/src/ec_parser.c
+++ b/src/ec_parser.c
@@ -116,6 +116,7 @@ void ec_usage(void)
    fprintf(stdout, "  -P, --plugin <plugin>       launch this <plugin> - multiple occurance allowed\n");
    fprintf(stdout, "      --plugin-list <plugin1>,[<plugin2>,...]       comma-separated list of plugins\n");
    fprintf(stdout, "  -F, --filter <file>         load the filter <file> (content filter)\n");
+   fprintf(stdout, "      --no-filters            load -F filters, but keep them disabled\n");
    fprintf(stdout, "  -z, --silent                do not perform the initial ARP scan\n");
 #ifdef WITH_IPV6
    fprintf(stdout, "  -6, --ip6scan               send ICMPv6 probes to discover IPv6 nodes on the link\n");
@@ -159,6 +160,7 @@ void parse_options(int argc, char **argv)
       { "plugin-list", required_argument, NULL, 0 },
       
       { "filter", required_argument, NULL, 'F' },
+      { "no-filters", no_argument, NULL, 0 },
 #ifdef HAVE_EC_LUA
       { "lua-script", required_argument, NULL, 0 },
       { "lua-args", required_argument, NULL, 0 },
@@ -428,6 +430,9 @@ void parse_options(int argc, char **argv)
             }
             else if (!strcmp(long_options[option_index].name, "plugin-list")) {
                set_plugin_list(strdup(optarg));
+            }
+            else if (!strcmp(long_options[option_index].name, "no-filters")) {
+               EC_GBL_OPTIONS->no_filters = 1;
             }
             else {
                fprintf(stdout, "\nTry `%s --help' for more options.\n\n", EC_GBL_PROGRAM);

--- a/src/ec_set.c
+++ b/src/ec_set.c
@@ -164,7 +164,8 @@ void set_pcap_filter(char *filter)
 
 void set_filter(char *end, const char *filter)
 {
-	uint8_t f_enabled = 1;
+	/* default to enabled unless --no-filters was requested */
+	uint8_t f_enabled = !EC_GBL_OPTIONS->no_filters;
 	if ( (end-filter >=2) && *(end-2) == ':') {
 		*(end-2) = '\0';
 		f_enabled = !( *(end-1) == '0' );

--- a/utils/etterfilter/ef_encode.c
+++ b/utils/etterfilter/ef_encode.c
@@ -348,8 +348,29 @@ int encode_function(char *string, struct filter_op *fop)
          ret = E_SUCCESS;
       } else
          SCRIPT_ERROR("Wrong number of arguments for function \"%s\" ", name);
+   } else if (!strcmp(name, "mod")) {
+      if (nargs == 2) {
+         if (encode_offset(dec_args[0], fop) == E_SUCCESS) {
+            fop->opcode = FOP_FUNC;
+            fop->op.func.op = FFUNC_MOD;
+            fop->op.func.olen = atoi(dec_args[1]);
+            ret = E_SUCCESS;
+         } else
+            SCRIPT_ERROR("Unknown offset %s ", dec_args[0]);
+      } else
+         SCRIPT_ERROR("Wrong number of arguments for function \"%s\" ", name);
    } else if (!strcmp(name, "random")) {
-      if (nargs == 3) {
+      if (nargs == 0) {
+         fop->opcode = FOP_FUNC;
+         fop->op.func.op = FFUNC_CHANCE;
+         fop->op.func.olen = 50;
+         ret = E_SUCCESS;
+      } else if (nargs == 1) {
+         fop->opcode = FOP_FUNC;
+         fop->op.func.op = FFUNC_CHANCE;
+         fop->op.func.olen = atoi(dec_args[0]);
+         ret = E_SUCCESS;
+      } else if (nargs == 3) {
          if (encode_offset(dec_args[0], fop) == E_SUCCESS) {
             fop->opcode = FOP_FUNC;
             fop->op.func.op = FFUNC_RANDOM;

--- a/utils/etterfilter/ef_test.c
+++ b/utils/etterfilter/ef_test.c
@@ -244,6 +244,17 @@ void print_function(struct filter_op *fop, u_int32 eip)
                fop->op.func.level, fop->op.func.offset, fop->op.func.olen);
          break;
 
+      case FFUNC_MOD:
+         USER_MSG("%04lu: MOD level %d offset %d size %d divisor %zu\n", (unsigned long)eip,
+               fop->op.test.level, fop->op.test.offset, fop->op.test.size,
+               (size_t)fop->op.func.olen);
+         break;
+
+      case FFUNC_CHANCE:
+         USER_MSG("%04lu: CHANCE percent %zu\n", (unsigned long)eip,
+               (size_t)fop->op.func.olen);
+         break;
+
       case FFUNC_LOG:
          USER_MSG("%04lu: LOG to \"%s\"\n", (unsigned long)eip, fop->op.func.string);
          break;


### PR DESCRIPTION
## Summary
This PR bundles two small filter-related improvements.

### #714 — `mod()` and `random()` chance functions
- `mod(offset, divisor)` returns true when `(field_value % divisor) != 0`, e.g.:
  ```etterfilter
  if (mod(tcp.seq, 2)) { drop(); kill(); }
  ```
- `random()` returns true 50% of the time.
- `random(percent)` returns true `percent`% of the time (0-100).
- The existing `random(offset, start, length)` data randomizer is preserved.

### #1232 — `--no-filters` command-line flag
- New long option `--no-filters` loads filter files passed with `-F`/`--filter` but keeps them disabled at startup.
- Users can then enable them later through the interactive UI.
- The existing `:0` / `:1` filename suffix still overrides the per-file enabled state.

## Test plan
- `cmake --build build -j` passes.
- `etterfilter` compiles and `-t` disassembles `mod()`/`random()` examples.
- `ettercap -h` shows the new `--no-filters` option.

Generated with [Devin](https://devin.ai)