### PR TITLE
Fix daemon mode crash by setting all ui_ops callbacks (#719)

### DIFF
--- a/src/interfaces/daemon/ec_daemon.c
+++ b/src/interfaces/daemon/ec_daemon.c
@@ -40,6 +40,8 @@ static void daemon_init(void);
 static void daemon_cleanup(void);
 static void daemon_msg(const char *msg);
 static void daemon_error(const char *msg);
+static void daemon_input(const char *title, char *input, size_t n, void (*callback)(void));
+static void daemon_update(int target);
 static int daemon_progress(char *title, int value, int max);
 static void daemonize(void);
 
@@ -56,7 +58,9 @@ void set_daemon_interface(void)
    ops.msg = &daemon_msg;
    ops.error = &daemon_error;
    ops.fatal_error = &daemon_error;
+   ops.input = &daemon_input;
    ops.progress = &daemon_progress;
+   ops.update = &daemon_update;
    ops.type = UI_DAEMONIZE;
    
    ui_register(&ops);
@@ -130,6 +134,29 @@ static void daemon_error(const char *msg)
    
    fprintf(stdout, "%s\n", msg);
    
+   return;
+}
+
+/* no input possible in daemon mode */
+
+static void daemon_input(const char *title, char *input, size_t n, void (*callback)(void))
+{
+   (void) title;
+   (void) input;
+   (void) n;
+   (void) callback;
+
+   DEBUG_MSG("daemon_input");
+   return;
+}
+
+/* no UI updates in daemon mode */
+
+static void daemon_update(int target)
+{
+   (void) target;
+
+   DEBUG_MSG("daemon_update");
    return;
 }
 


### PR DESCRIPTION
## Summary
`set_daemon_interface()` in `src/interfaces/daemon/ec_daemon.c` left `ops.input` and `ops.update` uninitialized. When `ops.input` happened to be NULL, `ui_register()` hit `BUG_IF(ops->input == NULL)` and `ettercap -D` failed with:
```
BUG at src/ec_ui.c:ui_register:359
ops->input == NULL
```

## Fix
Add no-op `daemon_input()` and `daemon_update()` callbacks and register them, so the daemon `ui_ops` is fully populated.

## Test plan
- `cmake --build build -j` succeeds.
- `ettercap -h` still works.
- The `-D` / `--daemon` path no longer relies on uninitialized stack values.

Closes #719

Generated with [Devin](https://devin.ai)