### PR TITLE
Allow ARP poisoning in silent mode without a pre-built hosts list (#1239)

### DIFF
--- a/src/mitm/ec_arp_poisoning.c
+++ b/src/mitm/ec_arp_poisoning.c
@@ -106,8 +106,9 @@ static int arp_poisoning_start(char *args)
    if (EC_GBL_PCAP->dlt != IL_TYPE_ETH && EC_GBL_PCAP->dlt != IL_TYPE_TR && EC_GBL_PCAP->dlt != IL_TYPE_FDDI)
       SEMIFATAL_ERROR("ARP poisoning does not support this media.\n");
    
-   /* we need the host list */
-   if (LIST_EMPTY(&EC_GBL_HOSTLIST))
+   /* we need the host list unless we're in silent mode (targets carry MACs) */
+   if (LIST_EMPTY(&EC_GBL_HOSTLIST) &&
+       !(EC_GBL_OPTIONS->silent && !EC_GBL_OPTIONS->load_hosts))
       SEMIFATAL_ERROR("ARP poisoning needs a non empty hosts list.\n");
    
    /* wipe the previous lists */


### PR DESCRIPTION
## Summary
When running `ettercap -z -Tq -M arp:remote /10.0.0.1// /10.0.0.2//`, the ARP poisoning module failed before it could use `create_silent_list()` because the hosts list was empty (silent mode skips the scan).

The silent-mode path builds the victim groups directly from the user targets, but only if MAC addresses are supplied. This PR removes the premature empty-list check so `create_silent_list()` is reached and can emit its proper "MAC address must be specified in silent mode" error instead of the misleading "needs a non empty hosts list" message.

## Test plan
- `cmake --build build -j` succeeds.
- `ettercap -h` still works.
- The conditional now mirrors the check in `create_silent_list`.

Generated with [Devin](https://devin.ai)